### PR TITLE
docs: say "podcast app" instead of "podcatcher"; refresh stale CI comments

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -21,7 +21,7 @@ Other approaches, workarounds, or tools you've tried.
 ## Scope check
 
 Podspine is deliberately narrow: **files in, per-chapter feed out**, for
-podcatchers. Please confirm your idea fits — the following are out of scope by
+podcast apps. Please confirm your idea fits — the following are out of scope by
 design and won't be added: user accounts, a built-in player, ebooks, a full media
 library, and any form of DRM circumvention.
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,8 +10,8 @@ name: CodeQL
 # main. CodeQL uploads via the built-in GITHUB_TOKEN (App tokens are rejected by
 # upload-sarif, github/codeql-action#2719).
 #
-# NOTE: action refs are version tags for readability; a Renovate digest-pinning
-# rule (renovate.json) converts them to commit SHAs (Scorecard Pinned-Dependencies).
+# NOTE: action refs are pinned to full commit SHAs (the repo's Actions policy
+# requires it; also satisfies Scorecard Pinned-Dependencies); Renovate keeps them current.
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,8 @@ name: Release
 #
 # Cut a release: `git tag v1.0.0 && git push origin v1.0.0`.
 #
-# NOTE: action refs are version tags for readability; a Renovate digest-pinning
-# rule (renovate.json) converts them to commit SHAs (Scorecard Pinned-Dependencies).
+# NOTE: action refs are pinned to full commit SHAs (the repo's Actions policy
+# requires it; also satisfies Scorecard Pinned-Dependencies); Renovate keeps them current.
 
 on:
   push:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,9 +7,8 @@ name: Scorecard
 # signal lives in the Security tab (Code scanning → Scorecard) and at
 # scorecard.dev once publish_results is enabled.
 #
-# NOTE: action refs are version tags for readability; a Renovate digest-pinning
-# rule (renovate.json) converts them to commit SHAs to satisfy Scorecard's
-# Pinned-Dependencies check and keeps them updated.
+# NOTE: action refs are pinned to full commit SHAs (the repo's Actions policy
+# requires it; also satisfies Scorecard Pinned-Dependencies); Renovate keeps them current.
 
 on:
   branch_protection_rule:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,9 +6,8 @@ name: Security
 # code-scanning Security tab. Rust SAST lives in codeql.yml and Rust supply-chain
 # (cargo audit/deny) in ci.yml — this file deliberately does not duplicate them.
 #
-# NOTE: first-party/well-known action refs are version tags for readability (a
-# Renovate rule SHA-pins them for Scorecard Pinned-Dependencies). The App-token and
-# third-party scanner actions are SHA-pinned up front.
+# NOTE: all action refs are pinned to full commit SHAs (the repo's Actions policy
+# requires it; also satisfies Scorecard Pinned-Dependencies); Renovate keeps them current.
 
 on:
   push:
@@ -147,10 +146,9 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Install zizmor
         run: uv tool install zizmor
-      # Advisory: `|| true` keeps the SARIF flowing to the Security tab without
-      # gating merges. Pre-Renovate every action is TAG-pinned, so zizmor's
-      # `unpinned-uses` audit flags them all by design — that's expected noise until
-      # Renovate SHA-pins the refs. Once pinned, drop `|| true` to make it enforcing.
+      # Advisory: `|| true` keeps the SARIF flowing to the Security tab without gating
+      # merges while we confirm zizmor runs clean on these workflows. Drop `|| true` to
+      # make it enforcing once a run shows no findings we don't intend to accept.
       - name: Run zizmor
         run: zizmor --format sarif . > results.sarif || true
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ _Nothing yet._
 ## [1.0.0]
 
 First tagged release: a zero-config, self-hosted server that turns a folder of
-audiobooks into per-chapter podcast RSS feeds any podcatcher can play.
+audiobooks into per-chapter podcast RSS feeds any podcast app can play.
 
 ### Added
 - **Per-chapter podcast feeds** with correct ordering: sequential `pubDate`s

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Podspine
 
-**Turn your audiobook files into per-chapter podcast feeds any podcatcher can play.**
+**Turn your audiobook files into per-chapter podcast feeds any podcast app can play.**
 
 Podspine is a small self-hosted server. Point it at a folder of audiobooks and it
 gives each book its own podcast RSS feed — one episode per chapter, in the right
@@ -36,7 +36,7 @@ docker run \
 
 Then open <http://localhost:8080> to browse your books and copy feed URLs.
 
-> **Set `PODSPINE_BASE_URL`** to the address podcatchers will actually reach
+> **Set `PODSPINE_BASE_URL`** to the address podcast apps will actually reach
 > (your LAN IP or public hostname). It defaults to `http://localhost:8080`, which
 > only works from the same machine — feed and audio URLs are built from it.
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -26,7 +26,7 @@ that precedence. The library path is the only required input.
 | `--config` | `PODSPINE_CONFIG` | none | Path to a TOML config file. |
 
 > **`PODSPINE_BASE_URL` is the one that bites people.** Feed and enclosure (audio)
-> URLs are built from it. If it's left at `localhost`, a podcatcher on another device
+> URLs are built from it. If it's left at `localhost`, a podcast app on another device
 > can't fetch anything. Set it to the LAN IP / hostname (and scheme + port, or the
 > public URL if behind a proxy) that clients actually reach.
 


### PR DESCRIPTION
First real exercise of the PR flow.

**Wording:** aligns public docs with the repo description — `podcatcher` → `podcast app` across README, CHANGELOG, DEPLOYMENT, and the feature-request template.

**CI comments:** refreshes four workflow header notes + the zizmor comment that still called the actions tag-pinned — they're all SHA-pinned now (repo policy requires it; Renovate maintains).

No behavior change; comments and prose only. Actions stay SHA-pinned, `actionlint` clean.