### PR TITLE
ci: replace unmaintained goto-bus-stop/setup-zig with mlugg/setup-zig

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,10 @@ jobs:
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
           version: 0.13.0
+          # No Actions cache in this signed-release build: it's tag-triggered (rare),
+          # and caching in an artifact-publishing workflow is a cache-poisoning vector
+          # (zizmor cache-poisoning). Matches the old goto-bus-stop/setup-zig behavior.
+          use-cache: false
       - name: Install cargo-zigbuild
         run: cargo install cargo-zigbuild --locked
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,8 +46,9 @@ jobs:
         with:
           targets: ${{ matrix.target }}
       # cargo-zigbuild uses zig as the cross linker, so both musl targets build
-      # from an x86_64 runner (incl. rusqlite's bundled SQLite C).
-      - uses: goto-bus-stop/setup-zig@abea47f85e598557f500fa1fd2ab7464fcb39406 # v2
+      # from an x86_64 runner (incl. rusqlite's bundled SQLite C). mlugg/setup-zig
+      # is the maintained successor to the abandoned goto-bus-stop/setup-zig.
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
           version: 0.13.0
       - name: Install cargo-zigbuild


### PR DESCRIPTION
Replaces `goto-bus-stop/setup-zig` (abandoned — last push 2024-09) with the maintained successor `mlugg/setup-zig` in `release.yml`.

**Why:** it's the sole Renovate lookup failure on the Dependency Dashboard ("Could not determine new digest"), because the old action is stale. `mlugg/setup-zig` is a drop-in (same `version` input, adds built-in Zig caching), actively released, and Renovate-resolvable.

Pinned to the v2 SHA per the repo's `sha_pinning_required` policy. Only `release.yml` changes; that job runs on `v*` tags.

**Audit:** checked all workflow actions for maintenance status — this was the only stale one (everything else pushed within ~5 months; none archived).