### PR TITLE
ci(renovate): only auto-group stable (>=1.0) cargo minor/patch bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,9 +13,10 @@
       "groupName": "github-actions"
     },
     {
-      "description": "Batch non-major Cargo updates.",
+      "description": "Batch non-major Cargo updates for STABLE (>=1.0) crates only. A 0.x minor bump is a breaking change under Cargo semver, so 0.x updates are left ungrouped as individual PRs that get reviewed with any required code change.",
       "matchManagers": ["cargo"],
       "matchUpdateTypes": ["minor", "patch"],
+      "matchCurrentVersion": "!/^0\\./",
       "groupName": "cargo (minor & patch)"
     }
   ]


### PR DESCRIPTION
Stops Renovate from batching **breaking 0.x cargo bumps** into the 'safe' minor/patch auto-group.

**Why:** in Cargo semver a `0.x` minor bump is breaking. Renovate calls it 'minor' and grouped `getrandom 0.2->0.4`, `rusqlite 0.32->0.40`, `maud 0.26->0.27`, `toml 0.8->0.9` into one auto PR (#2) that failed CI because getrandom needed a code change (#9 fixes that).

**Change:** the `cargo (minor & patch)` group now matches only crates whose current version is `>=1.0` (`matchCurrentVersion: !/^0\\./`). Stable crates (tokio, serde, clap, …) still batch; `0.x` crates come as individual PRs you review alongside any code change.