### PR TITLE
ci: install cargo-audit/deny as prebuilt binaries (faster audit·deny job)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,9 +118,13 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
-      - name: Install cargo-audit and cargo-deny
-        run: cargo install cargo-audit cargo-deny --locked
+      # Prebuilt binaries (seconds) instead of `cargo install`, which compiled both
+      # tools from source — by far the slowest step in CI. cargo-audit/deny only read
+      # Cargo.toml/lock, so no project toolchain is needed (the runner's cargo
+      # dispatches the subcommands).
+      - uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2
+        with:
+          tool: cargo-audit,cargo-deny
       - name: Audit
         run: cargo audit
       - name: Deny


### PR DESCRIPTION
Speeds up the `audit · deny` job — currently the longest job in CI.

**Why it's slow:** it runs `cargo install cargo-audit cargo-deny --locked`, compiling both tools from source every run (~4-5 min). The `cargo audit` / `cargo deny check` calls themselves take seconds.

**Change:** install prebuilt binaries via `taiki-e/install-action` (~15-30s) — the same pattern the `coverage` job already uses for `cargo-llvm-cov`. Also drops the `dtolnay/rust-toolchain` step from this job: cargo-audit/deny only parse `Cargo.toml`/`Cargo.lock`, and the runner's preinstalled cargo dispatches the subcommands.

Net: **~4-5 min → under a minute**, no behavior change. actionlint clean. Independent of the rest of the PR queue.