### PR TITLE
fix: repair ClusterFuzzLite build and pin base image digests

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,7 +1,7 @@
 # ClusterFuzzLite build image. The OSS-Fuzz Rust base ships a nightly toolchain
 # + cargo-fuzz + the sanitizer runtimes; we only add the source and the build
 # script. https://google.github.io/clusterfuzzlite/build-integration/rust/
-FROM gcr.io/oss-fuzz-base/base-builder-rust
+FROM gcr.io/oss-fuzz-base/base-builder-rust@sha256:0ca3a7a12278d0feb565f7667b6b8056bb8c542570c7ccaa81daed889159913e
 
 # ffmpeg/ffprobe are NOT needed here: the harnesses fuzz pure parsers
 # (crates/chapters, crates/prober::parse_probe_json), no subprocess.

--- a/.clusterfuzzlite/Dockerfile.dockerignore
+++ b/.clusterfuzzlite/Dockerfile.dockerignore
@@ -1,0 +1,11 @@
+# Per-Dockerfile ignore for the ClusterFuzzLite build. It OVERRIDES the repo-root
+# .dockerignore (which keeps only dist/ for the lean runtime image) — without this,
+# the root ignore excludes the source, so `COPY .clusterfuzzlite/build.sh` fails
+# "not found" and no fuzzers build. Here we keep the whole Rust workspace and
+# exclude only what cargo-fuzz doesn't need. rust-toolchain.toml is excluded on
+# purpose: its `channel = "stable"` would override base-builder-rust's nightly and
+# break `cargo fuzz build`.
+.git
+target
+dist
+rust-toolchain.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # Base is Alpine: the binary is static musl, so no glibc is needed, and Alpine's
 # ffmpeg keeps the image ~1/3 the size of debian-slim (TAD sanctions this "if size
 # matters" — it does; the ≤180MB target rules out debian's full ffmpeg).
-FROM alpine:3.24
+FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 
 # ffmpeg is the one runtime dependency; ca-certificates for outbound TLS if needed.
 RUN apk add --no-cache ffmpeg ca-certificates


### PR DESCRIPTION
Fixes the three items reported:

### 1. Fuzzing was broken (`build.sh: not found`)
The repo-root `.dockerignore` (`*` + `!dist`, written for the lean runtime image) also applies to the ClusterFuzzLite build, so it excluded the source and `COPY .clusterfuzzlite/build.sh` failed. Add a **per-Dockerfile** `.clusterfuzzlite/Dockerfile.dockerignore` that overrides the root one for the fuzz build only — keeps the whole workspace, excludes `.git`/`target`/`dist` and `rust-toolchain.toml` (its `channel = "stable"` would override base-builder-rust's **nightly** and break `cargo fuzz build`). The runtime image keeps using the root `.dockerignore` unchanged.
*Proven with docker:* reproduced the `not found` failure, then confirmed the override makes source visible while excluding `rust-toolchain.toml`.

### 2. Pin `alpine` by digest (Scorecard #11)
`alpine:3.24` → `alpine:3.24@sha256:28bd…`. Verified it's the **multi-arch OCI index** (so amd64+arm64 buildx still resolves per-arch), and built the runtime image locally to confirm `apk add ffmpeg` still works (ffmpeg 8.1.2).

### 3. Pin `base-builder-rust` by digest (Scorecard #3)
`gcr.io/oss-fuzz-base/base-builder-rust` → `…@sha256:0ca3…`. Digests came from Scorecard's own remediation tips; Renovate's docker manager maintains both going forward.

Authoritative end-to-end validation is this PR's own **cflite** + **trivy** jobs.