### PR TITLE
chore(release): bump to 1.0.0 + harden pre-release handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,10 +134,14 @@ jobs:
             release/checksums.txt.sigstore.json
             release/podspine.intoto.jsonl
           )
+          # A tag with a hyphen (v1.0.0-rc.1, -beta …) is a pre-release: mark it so it
+          # doesn't become the repo's "Latest release". SemVer build/pre-release marker.
+          prerelease=""
+          case "$TAG" in *-*) prerelease="--prerelease" ;; esac
           if gh release view "$TAG" >/dev/null 2>&1; then
             gh release upload "$TAG" "${assets[@]}" --clobber
           else
-            gh release create "$TAG" "${assets[@]}" --title "$TAG" --generate-notes
+            gh release create "$TAG" "${assets[@]}" --title "$TAG" --generate-notes $prerelease
           fi
 
   image:
@@ -181,7 +185,10 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest
+            # Only move :latest for a stable release; a pre-release tag (v1.0.0-rc.1)
+            # must not claim :latest. type=semver already skips {{major}}.{{minor}} for
+            # pre-releases, but type=raw is unconditional, so guard it explicitly.
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
       - name: Build and push
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,7 +1072,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "podspine"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "podspine-config",
@@ -1085,14 +1085,14 @@ dependencies = [
 
 [[package]]
 name = "podspine-chapters"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "podspine-prober",
 ]
 
 [[package]]
 name = "podspine-cli"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1103,7 +1103,7 @@ dependencies = [
 
 [[package]]
 name = "podspine-config"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "clap",
  "serde",
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "podspine-feed"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "blake3",
  "rss",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "podspine-http"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "axum",
  "axum-extra 0.12.6",
@@ -1141,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "podspine-index"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "base64",
  "getrandom",
@@ -1151,7 +1151,7 @@ dependencies = [
 
 [[package]]
 name = "podspine-prober"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1160,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "podspine-scanner"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "notify",
  "podspine-chapters",
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "podspine-splitter"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "podspine-prober",
  "thiserror",
@@ -1183,7 +1183,7 @@ dependencies = [
 
 [[package]]
 name = "podspine-ui"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "maud",
  "qrcode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.1.0"
+version = "1.0.0"
 edition = "2024"
 rust-version = "1.88"  # raised from 1.85: time >=0.3.47 (RUSTSEC-2026-0009 fix) needs 1.88
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Prep for the first tagged release. Two things:

### 1. Version bump `0.1.0` → `1.0.0`
Workspace version (all crates inherit via `version.workspace`); `Cargo.lock` resynced (workspace members only, no dependency churn).

### 2. Harden `release.yml` for pre-release tags
The tag-triggered release pipeline has **never run** (no tag exists yet), so its pre-release behavior was untested. Before cutting the real `v1.0.0`, I want to smoke-test the signed path (cosign / SLSA / SBOM / GHCR / publish) with a throwaway `v1.0.0-rc.1`. Two gaps that would make an RC misrepresent itself as stable:

- **`:latest`** was moved unconditionally (`type=raw,value=latest`). Now gated on `!contains(ref_name, '-')`, so only a stable tag claims `:latest`. (`type=semver` already skips `{{major}}.{{minor}}` for pre-releases.)
- **GitHub Release** was created without `--prerelease`. Now a hyphenated tag (`-rc`, `-beta`) is published as a pre-release, so it never becomes the repo's "Latest release".

### Plan after merge
`v1.0.0-rc.1` → verify all artifacts + signatures land correctly → tag real `v1.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)