### PR TITLE
fix(http): set audio Content-Type so iOS/Apple Podcasts can play

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -35,5 +35,6 @@ An optional second paragraph becomes the entry's details in the changelog.
 
 Internal-only PRs (CI, refactors, tests, docs that aren't user-facing) don't need
 a fragment — add the **`no-changelog`** label to silence the advisory
-`changeset-check`. The release automation is currently gated off (`KNOPE_ENABLED`);
-fragments still accumulate here and are consumed on the first enabled release.
+`changeset-check`. The release automation is **enabled** (`KNOPE_ENABLED=true`):
+merging a PR with a fragment opens a "prepare release" PR (version bump +
+generated `CHANGELOG.md`), and merging *that* tags the release.

--- a/.changeset/audio-content-type.md
+++ b/.changeset/audio-content-type.md
@@ -1,0 +1,13 @@
+---
+default: patch
+---
+
+Set the audio Content-Type so Apple Podcasts and other iOS players can play episodes
+
+The `/audio/{feed_id}/{n}` endpoint streamed episodes with no `Content-Type`
+header — `axum-range` emits Content-Range/Accept-Ranges/Content-Length but not a
+type. Strict clients (Apple Podcasts / iOS AVPlayer) then refuse to play with
+"This episode can't be played on this device", even though the RSS enclosure
+already carried `type=`. The response now sets the codec-appropriate type (e.g.
+`audio/mp4` for m4a/m4b, `audio/mpeg` for mp3) on both the full `200` and the
+`206` Range responses.

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -310,16 +310,24 @@ async fn cover(
 }
 
 /// `GET /audio/{feed_id}/{number}` — stream an episode with Range support.
+///
+/// The `Content-Type` is set explicitly: `axum-range`'s `Ranged` emits
+/// Content-Range/Accept-Ranges/Content-Length but NO Content-Type, and a missing
+/// type makes strict clients (Apple Podcasts / iOS AVPlayer) refuse to play with
+/// "can't be played on this device" — even though the enclosure carries `type=`.
 async fn audio(
     State(state): State<AppState>,
     Path((feed_id, number)): Path<(String, u32)>,
     range: Option<TypedHeader<Range>>,
-) -> Result<Ranged<KnownSize<File>>, AppError> {
+) -> Result<impl IntoResponse, AppError> {
     let path = resolve_audio_path(&state, &feed_id, number)?;
+    let mime = mime_for(&path.to_string_lossy());
     let file = File::open(&path).await.map_err(|_| AppError::NotFound)?;
     let body = KnownSize::file(file).await.map_err(AppError::internal)?;
     let range = range.map(|TypedHeader(range)| range);
-    Ok(Ranged::new(range, body))
+    // Header parts apply on top of Ranged's response, so the 206/Content-Range
+    // and the 200 full-body case both keep their status and gain Content-Type.
+    Ok(([(header::CONTENT_TYPE, mime)], Ranged::new(range, body)))
 }
 
 /// Build and self-check the feed XML for a capability `feed_id`. All public URLs

--- a/crates/http/tests/server.rs
+++ b/crates/http/tests/server.rs
@@ -319,6 +319,13 @@ async fn serves_feed_and_range_audio() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
     assert_eq!(resp.headers().get(header::ACCEPT_RANGES).unwrap(), "bytes");
+    // Regression: audio responses MUST carry a Content-Type. axum-range's Ranged
+    // sets none, and a missing type makes Apple Podcasts / iOS refuse playback
+    // ("can't be played on this device"). The synthetic .m4a AAC -> audio/mp4.
+    assert_eq!(
+        resp.headers().get(header::CONTENT_TYPE).unwrap(),
+        "audio/mp4"
+    );
 
     // Range request -> 206 + Content-Range, exactly 100 bytes
     let resp = app
@@ -333,6 +340,11 @@ async fn serves_feed_and_range_audio() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::PARTIAL_CONTENT);
     assert!(resp.headers().get(header::CONTENT_RANGE).is_some());
+    // ...and the 206 keeps Content-Type too (applied on top of Ranged).
+    assert_eq!(
+        resp.headers().get(header::CONTENT_TYPE).unwrap(),
+        "audio/mp4"
+    );
     assert_eq!(body_bytes(resp).await.len(), 100);
 
     // unknown episode number -> 404


### PR DESCRIPTION
## The bug
Episodes loaded in Apple Podcasts but wouldn't play — **"This episode can't be played on this device."** Root cause: the `/audio/{feed_id}/{n}` endpoint served the audio bytes with an **empty `Content-Type`**. `axum-range`'s `Ranged` emits `Content-Range`/`Accept-Ranges`/`Content-Length` but no type, and strict clients (Apple Podcasts / iOS AVPlayer) decide playability from that header — even though the RSS enclosure already carried `type="audio/mp4"`.

Present in the shipped **v1.0.0**; caught by real-app testing (Task 2.7).

## The fix
Attach the codec-appropriate `Content-Type` (via the existing `mime_for`) on top of the `Ranged` response, so both the `200` full-body and `206` Range cases keep their status/headers and gain the type. Same `[(header::CONTENT_TYPE, …)]` pattern the cover handler already uses.

## Verification
- Extended the http integration test to assert `audio/mp4` on **both** the 200 and 206 responses — the exact gap that let this ship (the test checked status + `Accept-Ranges`/`Content-Range` but never the type). All 3 tests pass.
- Rebuilt the image and confirmed live: 206 → `audio/mp4` + `Content-Range` intact, 200/HEAD → `audio/mp4`.
- **Confirmed playing in Apple Podcasts on a real device.**

## Release
Includes a `patch` changeset → this is the first **knope-driven release** (v1.0.1). On merge, knope opens the "prepare release 1.0.1" PR (version bump + generated CHANGELOG); merging that tags `v1.0.1` and fires the signed build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)