### PR TITLE
fix(changelog): use knope's format so releases prepend correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,6 @@
 # Changelog
 
-All notable changes to Podspine are documented here. The format is based on
-[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and Podspine aims to
-follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
-
-_Nothing yet._
-
-## [1.0.0]
+## 1.0.0 (2026-07-05)
 
 First tagged release: a zero-config, self-hosted server that turns a folder of
 audiobooks into per-chapter podcast RSS feeds any podcast app can play.
@@ -46,6 +38,3 @@ audiobooks into per-chapter podcast RSS feeds any podcast app can play.
 - Error responses never leak filesystem paths or `ffmpeg` stderr.
 - **DRM-free input only.** DRM-protected files (`.aax`/`.aaxc`/`.aa`/`.odm`) are
   skipped with a logged notice; Podspine ships no DRM circumvention.
-
-[Unreleased]: https://github.com/schubydoo/podspine/compare/v1.0.0...HEAD
-[1.0.0]: https://github.com/schubydoo/podspine/releases/tag/v1.0.0


### PR DESCRIPTION
knope prepends new versions right after the `# Changelog` header, but the hand-written CHANGELOG had **Keep-a-Changelog boilerplate**, an `## [Unreleased]` section, and a link-reference-style `## [1.0.0]` in the way — so the v1.0.1 entry landed **below** v1.0.0 (Greptile flagged this on #25).

Restructure to knope's format (matching clauster): just `# Changelog` + `## X.Y.Z (date)` sections in descending order. Drops the `All notable changes…` boilerplate and the `Unreleased / Nothing yet` section; converts `## [1.0.0]` → `## 1.0.0 (2026-07-05)` and removes the orphaned link-ref defs. The rich v1.0.0 content is preserved.

**Verified locally** with knope 0.23.0: prepare-release now inserts

```
## 1.0.1 (2026-07-05)
### Fixes
- Set the audio Content-Type …

## 1.0.0 (2026-07-05)
…
```

i.e. 1.0.1 **above** 1.0.0, clean bullet, no boilerplate.

After merge, re-run/refresh prepare-release and #25's CHANGELOG will regenerate correctly.