### PR TITLE
docs: v1.1.0 accuracy + cross-linking pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ built-in player. Just a feed URL.
 - **Your files stay yours.** DRM-free input only — Podspine ships no DRM
   circumvention.
 
-> Status: MVP + v1 feature-complete (library scan, web UI, cover art, MP3 folders,
-> Tier-2 formats, chapter sidecars, security hardening). See [CHANGELOG](CHANGELOG.md).
+> Status: released and feature-complete — library scan with live auto-refresh, web
+> UI, cover art, MP3 folders, Tier-2 formats, chapter sidecars, private
+> capability-URL feeds (with one-click regenerate), a one-tap **subscribe page**
+> with per-app deep links + QR, and security hardening. See [CHANGELOG](CHANGELOG.md).
 
 ## Quick start
 
@@ -95,8 +97,10 @@ tools first, then drop the result in your library.
 
 ## Adding a feed to your podcast app
 
-Open the Podspine UI, click a book, and copy its feed URL (or scan the QR code).
-Then see the per-app steps and troubleshooting in **[docs/importing.md](docs/importing.md)**.
+Open the Podspine UI and click a book. Copy its feed URL, or scan the QR code with
+your phone to open its **subscribe page** — a set of one-tap "Open in…" deep links
+for Apple Podcasts, Overcast, Pocket Casts, Castro, AntennaPod, and Podcast Addict.
+For per-app steps and troubleshooting, see **[docs/importing.md](docs/importing.md)**.
 
 ## Documentation
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,9 +10,11 @@ pipeline stage. It shells out to `ffmpeg`/`ffprobe` as separate processes (a GPL
 boundary; always invoked with an argument vector, never a shell string) and keeps
 its own state in a SQLite index plus a flat directory of split episode files.
 
-At startup it resolves configuration, scans the library once (splitting each book
-into per-chapter files and recording them in the index), then serves feeds, audio,
-and a small browse UI over HTTP.
+At startup it resolves configuration, scans the library (splitting each book into
+per-chapter files and recording them in the index), then serves feeds, audio, and a
+small browse UI over HTTP. A background watcher keeps the index reconciled with the
+library while it runs, so added, replaced, or removed books are picked up without a
+restart.
 
 ```mermaid
 flowchart LR
@@ -32,17 +34,17 @@ flowchart LR
 | Crate | Responsibility |
 |---|---|
 | `config` | Resolve settings from CLI flags → env → TOML (in that precedence); preflight `ffmpeg`/`ffprobe` so a missing toolchain fails at startup, not mid-request. |
-| `scanner` | Walk the library, classify each book (single audio file, per-book subfolder, or multi-track MP3 folder), and orchestrate probe → chapters → split → cover → index. Assigns collision-free slugs; one bad book never aborts the scan. |
+| `scanner` | Walk the library, classify each book (single audio file, per-book subfolder, or multi-track MP3 folder), and orchestrate probe → chapters → split → cover → index. Assigns collision-free slugs; one bad book never aborts the scan. Also hosts the background watcher that debounces filesystem changes and re-reconciles the index while the server runs. |
 | `prober` | Thin `ffprobe` wrapper → `ProbedBook` (duration, audio codec, cover presence/codec, track/title tags, embedded chapters). Parsing is separated from the subprocess call so it's unit-testable. |
 | `chapters` | Resolve the chapter source: a sibling `.cue` (75 fps `INDEX 01`) or `.ffmeta` sidecar wins over embedded markers (priority `.cue` > `.ffmeta` > embedded). `.opf`/`.nfo`/`.odm` are never chapter sources. |
 | `splitter` | `ffmpeg` wrapper: stream-copy each chapter into a codec-matching container (no re-encode). Bounds concurrency with a semaphore and enforces a per-child timeout/kill. Also extracts cover art. |
 | `index` | `rusqlite` (bundled SQLite) store for `book`, `episode`, and `feed_token` rows, with idempotent upserts keyed on stable ids. |
 | `feed` | Build one RSS 2.0 channel (itunes + podcast namespaces) per book, and a self-check that refuses to serve a malformed feed. |
 | `http` | Axum router: UI, feed, cover, and Range audio routes, plus the security/DoS middleware. |
-| `ui` | `maud` server-rendered pages (book grid, per-book copy-URL + QR, how-to panel). Pure presentation — no DB or HTTP dependency. |
+| `ui` | `maud` server-rendered pages: book grid, per-book copy-URL + QR + regenerate, and the per-book **subscribe page** (one-tap "Open in…" deep links + per-app QRs). Pure presentation — no DB or HTTP dependency. |
 
-Plus the `podspine` server binary (`src/main.rs`, wiring config → scan → serve) and
-a `podspine-cli` proof-of-concept for the single-file split pipeline.
+Plus the `podspine` server binary (`src/main.rs`, wiring config → scan → watch →
+serve) and a `podspine-cli` proof-of-concept for the single-file split pipeline.
 
 ## Ingest data flow
 
@@ -101,8 +103,9 @@ safe to expose externally (a guessed id 404s); see
 | Route | Surface | Purpose |
 |---|---|---|
 | `GET /` | UI (slug) | Browsable book grid. |
-| `GET /book/{slug}` | UI (slug) | Per-book page: copy capability-feed-URL, QR code, per-app how-to, **Regenerate link**. |
+| `GET /book/{slug}` | UI (slug) | Per-book page: copy capability-feed-URL, QR code (to the subscribe page), per-app how-to, **Regenerate link**. |
 | `POST /book/{slug}/regenerate` | UI (slug) | Rotate the book's `feed_id` (leak recovery); same-origin/CSRF-guarded. |
+| `GET /subscribe/{feed_id}` | capability | "Add to a podcast app" helper page: one-tap "Open in…" deep links + per-app QRs. |
 | `GET /feed/{feed_id}.xml` | capability | The podcast feed (built from the index, passed through the self-check); always `itunes:block` + `X-Robots-Tag: noindex`. |
 | `GET /audio/{feed_id}/{n}` | capability | Episode audio with HTTP Range (206 / `Content-Range` / 416) via `axum-range`. |
 | `GET /cover/{feed_id}` | capability | Book cover image. |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -19,7 +19,7 @@ for what each does):
 
 ```
 Cargo.toml            # workspace + the `podspine` server binary
-src/main.rs           # server entrypoint: config → scan → serve
+src/main.rs           # server entrypoint: config → scan → watch → serve
 crates/
 ├── config            # CLI/env/TOML resolution + ffmpeg preflight
 ├── scanner           # library walk + per-book orchestration

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -3,7 +3,8 @@
 How Podspine measures itself against the v2 performance targets, and how to
 reproduce the numbers on your own hardware.
 
-This is the measurement half of [Task 5.3](../tasks.md#task-53-performance-validation--tuning-against-nfr-targets).
+This is the measurement half of the Sprint 5 performance-validation work (against
+NFR-P1..P4 in the PRD).
 The point is not to publish a leaderboard — it is to answer one question before
 any v2 efficiency work (on-the-fly splitting, transcoding) is built: **are the
 NFR targets already met, or is there a real bottleneck to fix?** Run the harness
@@ -84,8 +85,9 @@ under budget, and idle memory is ~6× under. The only figure worth watching is
 storage or a many-chapter book it will rise. Because the extrapolation folds in
 fixed startup cost it is pessimistic, but if a real 10h book on your disk lands
 near the 2-minute ceiling, that is the signal that on-the-fly byte-range
-splitting ([Task 5.1](../tasks.md)) is worth building — otherwise it is premature.
+splitting (serving chapters from computed offsets, no duplicate split files) is
+worth building — otherwise it is premature.
 
-The `/metrics` half of Task 5.3 (Prometheus counters/histograms) is intentionally
+The optional `/metrics` endpoint (Prometheus counters/histograms) is intentionally
 not part of this harness; it adds a runtime dependency and an opt-in config flag,
 which is a separate change.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -3,14 +3,15 @@
 How Podspine measures itself against the v2 performance targets, and how to
 reproduce the numbers on your own hardware.
 
-This is the measurement half of the Sprint 5 performance-validation work (against
-NFR-P1..P4 in the PRD).
+This is the measurement half of the Sprint 5 performance-validation work — it
+checks Podspine against the four performance targets in the [table below](#targets)
+(ingest time, feed render p95, audio time-to-first-byte, and idle memory).
 The point is not to publish a leaderboard — it is to answer one question before
 any v2 efficiency work (on-the-fly splitting, transcoding) is built: **are the
 NFR targets already met, or is there a real bottleneck to fix?** Run the harness
 on the box you actually deploy to and let the numbers decide.
 
-## Targets (PRD §5.1, NFR-P1..P4)
+## Targets
 
 | NFR    | Metric                          | Target                  |
 |--------|---------------------------------|-------------------------|

--- a/docs/importing.md
+++ b/docs/importing.md
@@ -1,8 +1,21 @@
 # Adding a Podspine feed to your podcast app
 
-Every book has its own feed URL — a private, unguessable **capability link**. In the
-Podspine web UI (`http://<host>:8080/`), open a book and use **Copy feed URL** (or
-scan the QR code with your phone). The URL looks like:
+Every book has its own feed URL — a private, unguessable **capability link**.
+
+## The easy way: the subscribe page
+
+In the Podspine web UI (`http://<host>:8080/`), open a book and **scan its QR code**
+with your phone (or open the book page directly). The QR opens that book's
+**subscribe page** (`/subscribe/<feed_id>`) — a set of one-tap **"Open in…"** deep
+links for Apple Podcasts, Overcast, Pocket Casts, Castro, AntennaPod, and Podcast
+Addict, with a per-app QR behind an expander. Tap the app you use and it opens with
+the feed ready to add. This is the phone-friendly path — especially on iOS, where
+Apple Podcasts has no "add by URL" of its own.
+
+## The manual way: add by URL
+
+Prefer to paste the URL yourself? On the book page use **Copy feed URL**. It looks
+like:
 
 ```
 http://<your-host>:8080/feed/<feed_id>.xml
@@ -14,13 +27,16 @@ to replace it (the old URL stops working). Then add it as a podcast **by URL** i
 app. Most apps hide this behind an "add by URL / RSS" option because these feeds are
 deliberately kept out of the public podcast directories.
 
-## Per-app steps
+## Per-app steps (adding by URL)
+
+These are the manual steps if you copied the feed URL. On a phone, the
+[subscribe page](#the-easy-way-the-subscribe-page) is usually quicker.
 
 ### Apple Podcasts
 - **macOS:** File → *Add a Show by URL…* → paste the feed URL.
-- **iOS:** there's no "add by URL" in the app itself. Subscribe once on a Mac
-  signed into the same Apple ID, or use a third-party app (below) for phone-only
-  setups.
+- **iOS:** Apple Podcasts has no "add by URL" of its own. Use the **subscribe
+  page's "Open in Apple Podcasts"** deep link (scan the book's QR), subscribe once
+  on a Mac signed into the same Apple ID, or use a third-party app (below).
 
 ### Pocket Casts
 - Profile → *Add Podcast* → *Add URL* → paste the feed URL.
@@ -78,3 +94,9 @@ playback order is correct.
 ### The cover art is missing
 - Books with no embedded cover show a lettered placeholder in the UI and no
   `itunes:image` unless you set `--default-cover-url`.
+
+## See also
+
+- [README](../README.md) — what Podspine is and the quick start.
+- [DEPLOYMENT.md](DEPLOYMENT.md) — running it, reverse proxy, and the full config reference.
+- [SECURITY.md](../SECURITY.md) — why feed URLs are capability links, and how to expose them safely.


### PR DESCRIPTION
Full documentation pass to remove information that went stale by v1.1.0 and make the doc set link together cleanly.

## Staleness fixed
- **README status line** listed only v1 features. Now reflects **live auto-refresh**, **private capability feeds + regenerate**, and the v1.1.0 **subscribe page** (per-app deep links + QR).
- **`docs/importing.md`** led with copy-the-URL and told iOS users "there's no add-by-URL." It now leads with the **subscribe page's one-tap "Open in…" deep links** (the phone-friendly path, and the whole point of #22), with the manual by-URL steps kept below.
- **`docs/ARCHITECTURE.md`** Overview + entrypoint said "scan → serve," omitting the **live library watcher**; the HTTP-surface table was missing **`GET /subscribe/{feed_id}`**; the `ui` crate row didn't mention the subscribe page. All added. `docs/DEVELOPMENT.md` entrypoint comment updated to `config → scan → watch → serve` to match `src/main.rs`.
- **`docs/benchmarks.md`** linked `../tasks.md`, which is **gitignored** → those links 404 on GitHub. Reworded to reference the PRD/NFRs instead.

## Cross-linking
- `docs/importing.md` was a nav leaf (linked to nothing); added a **See also** footer back to README / DEPLOYMENT / SECURITY. (It was already linked *from* the README in two places, contrary to first impression.)
- Verified **every internal doc link resolves** and **none point at a gitignored file** (`git check-ignore` sweep).

Docs-only — no changeset needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)