### PR TITLE
docs: publish docs site (MkDocs Material + mike) to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,90 @@
+name: Docs
+
+# Build the MkDocs (Material) site and publish it to GitHub Pages via `mike`,
+# which keeps a version selector on the gh-pages branch:
+#   - every push to main updates the `latest` version (docs track main)
+#   - every stable release tag (vX.Y.Z) publishes an immutable `X.Y` snapshot
+# Pull requests only build with --strict (link/config validation), never deploy.
+#
+# NOTE: action refs are pinned to full commit SHAs (repo Actions policy + Scorecard);
+# pip caching is deliberately NOT used (cache-poisoning vector in a publishing
+# workflow — zizmor), and the deploy job pushes via an explicit tokened remote
+# rather than persisted checkout credentials (zizmor artipacked).
+
+on:
+  push:
+    branches: [main]
+    tags: ["v[0-9]+.[0-9]+.[0-9]+"]
+  pull_request:
+    paths:
+      - docs/**
+      - mkdocs.yml
+      - CHANGELOG.md
+      - .github/workflows/docs.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  # Serialize deploys (they push to gh-pages); don't cancel a push mid-deploy.
+  group: docs-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: build (strict)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.x"
+      - run: pip install -r docs/requirements.txt
+      - run: mkdocs build --strict
+
+  deploy:
+    name: deploy (mike)
+    needs: build
+    # Never on PRs (fork tokens are read-only anyway); same-repo only.
+    if: >-
+      github.event_name != 'pull_request'
+      && github.repository == 'schubydoo/podspine'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write # mike commits/pushes the built site to gh-pages
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0 # mike needs the gh-pages history to update it
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.x"
+      - run: pip install -r docs/requirements.txt
+      - name: Configure git + push auth
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git fetch origin gh-pages --depth=1 || true
+      - name: Deploy
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
+        run: |
+          if [ "$REF_TYPE" = "tag" ]; then
+            # vX.Y.Z -> immutable "X.Y" snapshot; leaves `latest`/default untouched.
+            version="${REF_NAME#v}"
+            mike deploy --push "${version%.*}"
+          else
+            # main -> rolling `latest`, and make the site root redirect to it.
+            mike deploy --push --update-aliases latest
+            mike set-default --push latest
+          fi

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,10 +49,13 @@ jobs:
   deploy:
     name: deploy (mike)
     needs: build
-    # Never on PRs (fork tokens are read-only anyway); same-repo only.
+    # Never on PRs (fork tokens are read-only anyway); same-repo only; and only
+    # for main or a release tag — otherwise a manual workflow_dispatch from a
+    # feature branch would fall through and overwrite `latest` with branch docs.
     if: >-
       github.event_name != 'pull_request'
       && github.repository == 'schubydoo/podspine'
+      && (github.ref == 'refs/heads/main' || github.ref_type == 'tag')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -84,7 +87,14 @@ jobs:
             version="${REF_NAME#v}"
             mike deploy --push "${version%.*}"
           else
-            # main -> rolling `latest`, and make the site root redirect to it.
+            # main -> rolling `latest`. Note whether gh-pages exists BEFORE the
+            # deploy creates it, so we can set the root redirect exactly once.
+            first_deploy=true
+            git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1 && first_deploy=false
             mike deploy --push --update-aliases latest
-            mike set-default --push latest
+            # Point the site root at `latest` — only needed on the first deploy;
+            # skipping it afterwards avoids a redundant redirect commit each push.
+            if [ "$first_deploy" = true ]; then
+              mike set-default --push latest
+            fi
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 
 # Release build output (per-arch binaries for the Docker image)
 /dist/
+
+# MkDocs build output
+/site/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,9 @@ repos:
       - id: end-of-file-fixer
         exclude: '^LICENSE$'
       - id: check-yaml
+        # mkdocs.yml uses the `!!python/name:` tag (Material Mermaid fence); the
+        # safe loader can't resolve it. Everything else stays safe-loaded.
+        exclude: '^mkdocs\.yml$'
       - id: check-toml
       - id: check-merge-conflict
       - id: detect-private-key

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ For per-app steps and troubleshooting, see **[docs/importing.md](docs/importing.
 
 ## Documentation
 
+📖 **Full docs: <https://schubydoo.github.io/podspine/>** (searchable, versioned). The sources also render on GitHub:
+
 - **[Deploying](docs/DEPLOYMENT.md)** — Docker/compose, reverse proxy, systemd, backups, and the full config reference.
 - **[Adding to your podcast app](docs/importing.md)** — per-app import steps and troubleshooting.
 - **[Architecture](docs/ARCHITECTURE.md)** — how the pipeline and feeds work, and the invariants behind them.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -131,7 +131,7 @@ split the way they are.
 - Copy-first: chapters are split by stream copy, no re-encode, so there's no quality
   loss.
 
-**Security (see [SECURITY.md](../SECURITY.md) for the threat model):**
+**Security (see [SECURITY.md](https://github.com/schubydoo/podspine/blob/main/SECURITY.md) for the threat model):**
 - Book/episode ids are **opaque index keys**. Slugs are validated against an
   allow-list charset and rejected with 404; the resolved audio path is canonicalized
   and asserted to stay under `<data_dir>`. A path is never built from user input.
@@ -146,4 +146,4 @@ split the way they are.
 
 - [DEVELOPMENT.md](DEVELOPMENT.md) — building, testing, and the crate layout in practice.
 - [DEPLOYMENT.md](DEPLOYMENT.md) — running it in production (Docker, reverse proxy, systemd).
-- [../CONTRIBUTING.md](../CONTRIBUTING.md) — contribution workflow.
+- [CONTRIBUTING.md](https://github.com/schubydoo/podspine/blob/main/CONTRIBUTING.md) — contribution workflow.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,6 +1,6 @@
 # Deployment
 
-Running Podspine in a homelab. For a first run, the [README quick start](../README.md#quick-start)
+Running Podspine in a homelab. For a first run, the [quick start](index.md#quick-start)
 is enough; this page covers the production details: persistence, exposing it safely,
 and running it as a service.
 
@@ -8,7 +8,7 @@ and running it as a service.
 > [Exposing Podspine safely](#exposing-podspine-safely) below): the **feed/audio/cover**
 > routes are protected by an unguessable per-book **capability URL** and are safe to
 > expose to the internet, while the **browse UI** enumerates your whole library and
-> must stay on your LAN or behind proxy-auth. See [SECURITY.md](../SECURITY.md).
+> must stay on your LAN or behind proxy-auth. See [SECURITY.md](https://github.com/schubydoo/podspine/blob/main/SECURITY.md).
 
 ## Configuration
 
@@ -94,7 +94,7 @@ Download the static musl binary for your architecture from the
 [releases](https://github.com/schubydoo/podspine/releases) and make sure
 `ffmpeg`/`ffprobe` are installed. Releases are signed — verify before running:
 `cosign verify-blob --bundle checksums.txt.sigstore.json checksums.txt` then
-`sha256sum -c checksums.txt` (see [SECURITY.md](../SECURITY.md#release-artifacts)).
+`sha256sum -c checksums.txt` (see [SECURITY.md](https://github.com/schubydoo/podspine/blob/main/SECURITY.md#release-artifacts)).
 Example unit:
 
 ```ini
@@ -133,7 +133,7 @@ Linux binary above, behind a reverse proxy.
 They are **not code-signed or notarized** (that needs paid Apple/Microsoft
 certificates), so the OS warns on first launch. Verify the download the same way
 as Linux — cosign-signed `checksums.txt` + SLSA provenance (see
-[SECURITY.md](../SECURITY.md#release-artifacts)) — rather than relying on OS
+[SECURITY.md](https://github.com/schubydoo/podspine/blob/main/SECURITY.md#release-artifacts)) — rather than relying on OS
 signing, then clear the warning:
 
 - **macOS (Gatekeeper):** a browser download is quarantined. Remove it with
@@ -225,4 +225,4 @@ compose example above) or an uptime monitor.
 
 - [ARCHITECTURE.md](ARCHITECTURE.md) — how it works internally.
 - [importing.md](importing.md) — adding a feed to podcast apps + troubleshooting.
-- [../SECURITY.md](../SECURITY.md) — threat model and vulnerability reporting.
+- [SECURITY.md](https://github.com/schubydoo/podspine/blob/main/SECURITY.md) — threat model and vulnerability reporting.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,7 +1,7 @@
 # Development
 
 Setting up, building, and testing Podspine locally. For the contribution workflow
-(branching, commits, PRs), see [CONTRIBUTING.md](../CONTRIBUTING.md); for how the
+(branching, commits, PRs), see [CONTRIBUTING.md](https://github.com/schubydoo/podspine/blob/main/CONTRIBUTING.md); for how the
 system fits together, see [ARCHITECTURE.md](ARCHITECTURE.md).
 
 ## Prerequisites

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,2 @@
+<!-- Rendered from the canonical CHANGELOG.md at the repo root (knope-managed). -->
+{% include-markdown "../CHANGELOG.md" %}

--- a/docs/importing.md
+++ b/docs/importing.md
@@ -97,6 +97,6 @@ playback order is correct.
 
 ## See also
 
-- [README](../README.md) — what Podspine is and the quick start.
+- [Home](index.md) — what Podspine is and the quick start.
 - [DEPLOYMENT.md](DEPLOYMENT.md) — running it, reverse proxy, and the full config reference.
-- [SECURITY.md](../SECURITY.md) — why feed URLs are capability links, and how to expose them safely.
+- [SECURITY.md](https://github.com/schubydoo/podspine/blob/main/SECURITY.md) — why feed URLs are capability links, and how to expose them safely.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,67 @@
+# Podspine
+
+**Turn your audiobook files into per-chapter podcast feeds any podcast app can play.**
+
+Podspine is a small self-hosted server. Point it at a folder of audiobooks and it
+gives each book its own podcast RSS feed — one episode per chapter, in the right
+order — that you subscribe to in Apple Podcasts, Pocket Casts, Overcast, AntennaPod,
+or anything else that reads RSS. No accounts, no separate app, no built-in player.
+Just a feed URL.
+
+- **Chapters as episodes, in order.** The #1 bug in naive attempts is episodes
+  playing out of order; Podspine emits sequential `pubDate`s (oldest = chapter 1)
+  and `itunes:episode` numbers, and refuses to serve a feed that fails its own
+  self-check.
+- **Zero-config.** `docker run` with your library mounted just works.
+- **Copy-first, no quality loss.** Chapters are split by stream copy (no re-encode)
+  at ingest.
+- **Private by default.** Each feed lives at an unguessable capability URL; the
+  library is watched and feeds auto-refresh as you add books.
+- **Your files stay yours.** DRM-free input only — Podspine ships no DRM
+  circumvention.
+
+## Quick start
+
+Run the container with your library mounted:
+
+```bash
+docker run \
+  -v /path/to/audiobooks:/library:ro \
+  -v podspine-data:/data \
+  -p 8080:8080 \
+  -e PODSPINE_BASE_URL=http://<your-lan-ip>:8080 \
+  ghcr.io/schubydoo/podspine:latest
+```
+
+Then open <http://localhost:8080> to browse your books, copy feed URLs, or scan a
+book's QR code to open its one-tap [subscribe page](importing.md).
+
+!!! tip "Set `PODSPINE_BASE_URL`"
+    Point it at the address podcast apps will actually reach (your LAN IP or public
+    hostname). It defaults to `http://localhost:8080`, which only works from the same
+    machine — feed and audio URLs are built from it.
+
+`ffmpeg`/`ffprobe` are bundled in the image. `/data` holds the SQLite index and the
+split episode files, so keep it on a persistent volume. Prebuilt static binaries and
+`cargo run` are covered in [Deploying](DEPLOYMENT.md).
+
+## Where to next
+
+<div class="grid cards" markdown>
+
+- :material-rocket-launch: **[Deploying](DEPLOYMENT.md)** — Docker/compose, reverse
+  proxy, systemd, backups, and the full config reference.
+- :material-cellphone: **[Adding to your podcast app](importing.md)** — the subscribe
+  page, per-app steps, and troubleshooting.
+- :material-sitemap: **[Architecture](ARCHITECTURE.md)** — how the pipeline and feeds
+  work, and the invariants behind them.
+- :material-wrench: **[Development](DEVELOPMENT.md)** — local setup, crate layout,
+  testing, and release builds.
+
+</div>
+
+## License
+
+[AGPL-3.0-only](https://github.com/schubydoo/podspine/blob/main/LICENSE). Podspine
+shells out to `ffmpeg`/`ffprobe` as separate processes (no linking) and ships no DRM
+circumvention.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,5 @@
+# Documentation site toolchain (Material for MkDocs + versioning).
+# Pinned for reproducible builds; Renovate keeps them current.
+mkdocs-material==9.7.6
+mkdocs-include-markdown-plugin==7.3.0
+mike==2.2.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,83 @@
+site_name: Podspine
+site_description: Turn your audiobook files into per-chapter podcast feeds any podcast app can play.
+site_url: https://schubydoo.github.io/podspine/
+site_author: schubydoo
+copyright: AGPL-3.0-only
+
+repo_url: https://github.com/schubydoo/podspine
+repo_name: schubydoo/podspine
+edit_uri: edit/main/docs/
+
+docs_dir: docs
+
+theme:
+  name: material
+  icon:
+    repo: fontawesome/brands/github
+  features:
+    - navigation.top
+    - navigation.sections
+    - navigation.instant
+    - navigation.tracking
+    - toc.follow
+    - content.code.copy
+    - search.suggest
+    - search.highlight
+  palette:
+    # Light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    # Dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+
+plugins:
+  - search
+  - include-markdown
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences:
+      custom_fences:
+        # Render ```mermaid fenced blocks client-side (Material bundles mermaid.js).
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+
+extra:
+  version:
+    # Version selector is driven by `mike` (see .github/workflows/docs.yml).
+    provider: mike
+    default: latest
+
+nav:
+  - Home: index.md
+  - Deploying: DEPLOYMENT.md
+  - Adding to your app: importing.md
+  - Architecture: ARCHITECTURE.md
+  - Development: DEVELOPMENT.md
+  - Benchmarks: benchmarks.md
+  - Changelog: changelog.md
+  # Governance docs stay canonical on GitHub:
+  - Contributing: https://github.com/schubydoo/podspine/blob/main/CONTRIBUTING.md
+  - Security: https://github.com/schubydoo/podspine/blob/main/SECURITY.md


### PR DESCRIPTION
Publishes a **searchable, versioned documentation site** built from the existing `docs/`, using **Material for MkDocs** deployed to GitHub Pages via **mike** (per our discussion).

## What's here
- **`mkdocs.yml`** — Material theme (light/dark toggle), client-side search, **Mermaid** rendering (the `ARCHITECTURE.md` diagrams), admonitions, and a **mike version selector**.
- **`docs/index.md`** — purpose-built home with a quick start (keeps `README.md` as the GitHub landing).
- **`docs/changelog.md`** — renders the canonical root `CHANGELOG.md` via `include-markdown` (single source of truth; knope still owns it).
- **`docs/requirements.txt`** — pinned toolchain (`mkdocs-material`, `include-markdown`, `mike`); Renovate-maintained.
- **`.github/workflows/docs.yml`** — the deploy pipeline (below).
- Cross-doc links to **SECURITY/CONTRIBUTING** now use absolute GitHub URLs so they resolve identically on GitHub *and* the site; product-doc links stay relative.
- `check-yaml` skips `mkdocs.yml` (the `!!python/name:` Mermaid tag isn't safe-loadable); `/site/` gitignored.

## Versioning model
- **PRs** → `mkdocs build --strict` only (link/config validation, no deploy).
- **push to main** → updates the rolling **`latest`** (docs track main; doc fixes publish immediately) and is the site default.
- **release tag `vX.Y.Z`** → publishes an **immutable `X.Y` snapshot** (leaves `latest` alone).

Version dropdown ends up: `latest · 1.1 · 1.0 · …`.

## Conventions honored
- All actions **SHA-pinned** (reused the repo's `checkout@…v7` pin; resolved `setup-python@…v6.3.0`).
- **actionlint-clean**; **zizmor: no findings** — no pip cache (cache-poisoning vector in a publishing workflow, same lesson as setup-zig), and the deploy pushes via a **tokened remote** rather than persisted checkout credentials (artipacked).
- Least-privilege perms (`contents: read` top-level; `contents: write` only on the deploy job); fork-safe (deploy gated off PRs + to this repo).
- Verified locally: `mkdocs build --strict` passes, Mermaid + changelog include render, all internal links resolve.

## ⚠️ One-time step after merge (needs you)
mike creates the `gh-pages` branch on the first `main` deploy. Pages then has to be pointed at it:
**Settings → Pages → Source: “Deploy from a branch” → `gh-pages` / `/ (root)`.**
I can also run this for you via `gh api` once `gh-pages` exists after merge — say the word. The site will be at **https://schubydoo.github.io/podspine/**.

Also worth a glance: confirm no repo/org ruleset protects `gh-pages` (it would block the bot's deploy push — our `main` ruleset targets `main` only, so this should be fine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)