### PR TITLE
docs: render Material icons + make the Overview diagram legible

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -18,16 +18,13 @@ restart.
 
 ```mermaid
 flowchart LR
-  cfg[config<br/>CLI/env/TOML + ffmpeg preflight] --> scan[scanner<br/>walk library, classify books]
-  scan --> probe[prober<br/>ffprobe]
-  probe --> chap[chapters<br/>.cue / .ffmeta / embedded]
-  chap --> split[splitter<br/>ffmpeg stream-copy]
-  split --> idx[(index<br/>SQLite)]
-  idx --> feed[feed<br/>RSS 2.0 + itunes/podcast]
-  idx --> http[http<br/>Axum]
-  feed --> http
-  http --> ui[ui<br/>maud pages]
+  config --> scanner --> prober --> chapters --> splitter --> index[(index)]
+  index --> feed --> http --> ui
+  index --> http
 ```
+
+The crates are described below; the pipeline runs left to right, with the SQLite
+`index` feeding both the `feed` builder and the `http` server.
 
 ## Crates
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,10 @@ markdown_extensions:
   - pymdownx.snippets
   - pymdownx.highlight:
       anchor_linenums: true
+  # `:material-*:` / `:fontawesome-*:` icon shortcodes -> inline SVGs.
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.superfences:
       custom_fences:
         # Render ```mermaid fenced blocks client-side (Material bundles mermaid.js).


### PR DESCRIPTION
Follow-ups to the docs site (verified in a real browser via agent-browser).

## 1. Icons rendered literally
The home "Where to next" cards used `:material-rocket-launch:` etc., but `pymdownx.emoji` was never enabled, so the shortcodes showed as raw text. Added the extension (twemoji index + `to_svg` generator). Cards now render proper SVG icons.

## 2. Overview diagram unreadable
The Overview flowchart had **nine two-line nodes in one LR row**, so Mermaid scaled it down to tiny/cramped. Collapsed to short single-word crate labels (`config → scanner → prober → chapters → splitter → index → feed/http → ui`) — the crates table right below already carries the descriptions. Much more legible.

**Before/after** verified with agent-browser screenshots against a local `mkdocs serve`.

## Note on #3 (the version dropdown)
Not a code bug — `versions.json` currently has a single entry (`latest`), so the selector has nothing to switch to. I'm seeding a `1.1` snapshot so it's functional now; future release tags add their own snapshots automatically. (No workflow change needed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)