### PR TITLE
fix(ci): packaging-bump waits for checksums.txt (fixes the release-publish race)

### DIFF
--- a/.github/workflows/packaging-bump.yml
+++ b/.github/workflows/packaging-bump.yml
@@ -103,6 +103,17 @@ jobs:
         run: |
           set -euo pipefail
           tmp="$(mktemp -d)"
+          # release.yml publishes the release before its 5-platform matrix finishes
+          # uploading assets, so `release: published` can fire before checksums.txt
+          # exists. Wait for it (up to ~5 min) instead of racing to a hard failure.
+          for i in $(seq 1 20); do
+            if [ "$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
+                    --json assets --jq '[.assets[].name]|index("checksums.txt")')" != "null" ]; then
+              break
+            fi
+            echo "checksums.txt not on $TAG yet (attempt $i/20) — waiting 15s..."
+            sleep 15
+          done
           gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern checksums.txt --dir "$tmp"
           python3 scripts/bump_packaging.py "$VERSION" "$GITHUB_REPOSITORY" "$tmp/checksums.txt"
           if git diff --quiet; then

--- a/.github/workflows/packaging-bump.yml
+++ b/.github/workflows/packaging-bump.yml
@@ -107,8 +107,13 @@ jobs:
           # uploading assets, so `release: published` can fire before checksums.txt
           # exists. Wait for it (up to ~5 min) instead of racing to a hard failure.
           for i in $(seq 1 20); do
-            if [ "$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
-                    --json assets --jq '[.assets[].name]|index("checksums.txt")')" != "null" ]; then
+            # `|| asset_index=null` so a transient gh/API failure keeps waiting
+            # rather than yielding "" (which would pass the != "null" test and
+            # break early, right back into the race this loop exists to avoid).
+            asset_index="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
+                    --json assets --jq '[.assets[].name]|index("checksums.txt")')" \
+                    || asset_index="null"
+            if [ "$asset_index" != "null" ]; then
               break
             fi
             echo "checksums.txt not on $TAG yet (attempt $i/20) — waiting 15s..."


### PR DESCRIPTION
## The race (hit on v1.2.0)
`release.yml` publishes the GitHub Release **before** its 5-platform matrix finishes uploading assets, so the `release: published` event fires while the release still has **0 assets**. The automatic `packaging-bump` run then tried to `gh release download checksums.txt` → failed. On v1.2.0 I recovered it with a manual `workflow_dispatch` (the workflow's built-in recovery path), and the 1.2.0 bump PR opened fine — but every release would need that manual nudge.

## The fix
Before downloading, poll the release for `checksums.txt` (up to ~5 min: 20 × 15s) so the automatic run rides out the upload window instead of racing to a hard failure. Same trust model — still gated on the release's signed `checksums.txt`; if it never appears, `gh release download` fails closed exactly as before.

Isolated to `packaging-bump.yml` (no change to the delicate signed/SLSA `release.yml` flow). actionlint + zizmor clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)