### PR TITLE
feat(brand): add Podspine logo asset set

### DIFF
--- a/assets/logo/favicon.svg
+++ b/assets/logo/favicon.svg
@@ -1,0 +1,9 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Podspine">
+  <title>Podspine</title>
+  <rect width="16" height="16" rx="3.5" fill="#0A0A0A"/>
+  <g fill="#FF9E3D">
+    <rect x="3" y="6" width="2.4" height="7" rx="1.2"/>
+    <rect x="6.8" y="2.5" width="2.4" height="10.5" rx="1.2"/>
+    <rect x="10.6" y="5" width="2.4" height="8" rx="1.2"/>
+  </g>
+</svg>

--- a/assets/logo/logo-black.svg
+++ b/assets/logo/logo-black.svg
@@ -1,0 +1,11 @@
+<svg width="320" height="72" viewBox="0 0 320 72" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Podspine">
+  <title>Podspine</title>
+  <g transform="translate(8,4) scale(0.9375)" fill="#0A0A0A">
+    <rect x="8" y="32" width="6" height="24" rx="3"/>
+    <rect x="18.5" y="18" width="6" height="38" rx="3"/>
+    <rect x="29" y="8" width="6" height="48" rx="3"/>
+    <rect x="39.5" y="22" width="6" height="34" rx="3"/>
+    <rect x="50" y="38" width="6" height="18" rx="3"/>
+  </g>
+  <text x="86" y="47" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="34" font-weight="700" letter-spacing="-0.5" fill="#0A0A0A">Podspine</text>
+</svg>

--- a/assets/logo/logo-full.svg
+++ b/assets/logo/logo-full.svg
@@ -1,0 +1,11 @@
+<svg width="320" height="72" viewBox="0 0 320 72" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Podspine">
+  <title>Podspine</title>
+  <g transform="translate(8,4) scale(0.9375)" fill="#FF9E3D">
+    <rect x="8" y="32" width="6" height="24" rx="3"/>
+    <rect x="18.5" y="18" width="6" height="38" rx="3"/>
+    <rect x="29" y="8" width="6" height="48" rx="3"/>
+    <rect x="39.5" y="22" width="6" height="34" rx="3"/>
+    <rect x="50" y="38" width="6" height="18" rx="3"/>
+  </g>
+  <text x="86" y="47" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="34" font-weight="700" letter-spacing="-0.5" fill="#141414">Podspine</text>
+</svg>

--- a/assets/logo/logo-icon.svg
+++ b/assets/logo/logo-icon.svg
@@ -1,0 +1,11 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Podspine">
+  <title>Podspine</title>
+  <rect width="512" height="512" rx="112" fill="#0A0A0A"/>
+  <g transform="translate(80,80) scale(5.5)" fill="#FF9E3D">
+    <rect x="8" y="32" width="6" height="24" rx="3"/>
+    <rect x="18.5" y="18" width="6" height="38" rx="3"/>
+    <rect x="29" y="8" width="6" height="48" rx="3"/>
+    <rect x="39.5" y="22" width="6" height="34" rx="3"/>
+    <rect x="50" y="38" width="6" height="18" rx="3"/>
+  </g>
+</svg>

--- a/assets/logo/logo-mark.svg
+++ b/assets/logo/logo-mark.svg
@@ -1,0 +1,10 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Podspine">
+  <title>Podspine</title>
+  <g fill="#FF9E3D">
+    <rect x="8" y="32" width="6" height="24" rx="3"/>
+    <rect x="18.5" y="18" width="6" height="38" rx="3"/>
+    <rect x="29" y="8" width="6" height="48" rx="3"/>
+    <rect x="39.5" y="22" width="6" height="34" rx="3"/>
+    <rect x="50" y="38" width="6" height="18" rx="3"/>
+  </g>
+</svg>

--- a/assets/logo/logo-white.svg
+++ b/assets/logo/logo-white.svg
@@ -1,0 +1,11 @@
+<svg width="320" height="72" viewBox="0 0 320 72" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Podspine">
+  <title>Podspine</title>
+  <g transform="translate(8,4) scale(0.9375)" fill="#FFFFFF">
+    <rect x="8" y="32" width="6" height="24" rx="3"/>
+    <rect x="18.5" y="18" width="6" height="38" rx="3"/>
+    <rect x="29" y="8" width="6" height="48" rx="3"/>
+    <rect x="39.5" y="22" width="6" height="34" rx="3"/>
+    <rect x="50" y="38" width="6" height="18" rx="3"/>
+  </g>
+  <text x="86" y="47" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="34" font-weight="700" letter-spacing="-0.5" fill="#FFFFFF">Podspine</text>
+</svg>

--- a/assets/logo/logo-wordmark.svg
+++ b/assets/logo/logo-wordmark.svg
@@ -1,0 +1,4 @@
+<svg width="180" height="40" viewBox="0 0 180 40" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Podspine">
+  <title>Podspine</title>
+  <text x="0" y="30" font-family="Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="30" font-weight="700" letter-spacing="-0.5" fill="#141414">Podspine</text>
+</svg>


### PR DESCRIPTION
Adds the first official Podspine brand assets under `assets/logo/` — seven SVG variants generated from one canonical mark.

## The mark
Five rounded vertical bars that read simultaneously as **book spines on a shelf** and an **audio equalizer** — the "pod + spine" pun made geometric. Amber `#FF9E3D` accent on a `#0A0A0A` base (warm/audiobook-leaning, ownable in a category dominated by blues). Wordmark: **Podspine**, Inter Bold.

## Files
| File | Spec | Use |
|---|---|---|
| `logo-mark.svg` | 64×64 | Canonical geometry (source of truth) |
| `logo-full.svg` | 320×72, amber mark + dark wordmark | Light backgrounds |
| `logo-white.svg` | 320×72 all-white | Dark backgrounds |
| `logo-black.svg` | 320×72 all-black | Monochrome on light |
| `logo-wordmark.svg` | 180×40 | Text-only |
| `logo-icon.svg` | 512×512 | App/store icon |
| `favicon.svg` | 16×16 | Browser tab |

## Notes
- Bar geometry is **byte-identical** across all five lockups (verified same md5); `favicon.svg` is the intentional 2-layer simplification for 16px legibility.
- **Assets only — no source or release impact**, so no changeset is included (nothing to version-bump). The brand-showcase page and palette-comparison preview live in the gitignored `scratch/` working space, not this PR.
- Follow-up (separate PR, if wanted): wire `favicon.svg` into `mkdocs.yml` and the README header so it actually ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)