### PR TITLE
docs(brand): fix docs og:image URL (latestlatest) + lengthen homepage title

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -14,10 +14,12 @@
 
 {# The bare site_name ("Podspine", 8 chars) is too short for SERP/social. Give
    the homepage a descriptive ~57-char title; subpages keep Material's default
-   "<page> - <site_name>". Kept in sync with the homepage social title below. #}
+   "<page> - <site_name>". Defined once here and reused by both <title> and the
+   homepage social title below. #}
+{%- set _homepage_title = "Podspine — turn audiobooks into per-chapter podcast feeds" -%}
 {% block htmltitle %}
   {% if page and page.is_homepage %}
-    <title>Podspine — turn audiobooks into per-chapter podcast feeds</title>
+    <title>{{ _homepage_title }}</title>
   {% else %}
     {{ super() }}
   {% endif %}
@@ -28,7 +30,7 @@
   {% set _base = config.site_url[:-1] if config.site_url.endswith('/') else config.site_url %}
   {% set social_image = _base ~ "/assets/social-card.png" %}
   {% if page and page.is_homepage %}
-    {% set social_title = "Podspine — turn audiobooks into per-chapter podcast feeds" %}
+    {% set social_title = _homepage_title %}
   {% elif page and page.title %}
     {% set social_title = page.title ~ " · " ~ config.site_name %}
   {% else %}

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -3,15 +3,32 @@
 <!--
   Adds Open Graph / Twitter card meta so links to the docs site preview with the
   Podspine social card. The image lives under docs/assets/ (bundled into every
-  built version) and is referenced at the `latest` mike alias — the versioned
-  paths are the only ones that actually exist on gh-pages; the site root is just
-  a redirect, so `config.site_url + assets/...` would 404.
+  built version).
+
+  mike rewrites config.site_url to the *versioned* base at deploy time
+  (e.g. https://schubydoo.github.io/podspine/latest), so the card just lives at
+  "<site_url>/assets/social-card.png". We must NOT hardcode "latest/" — that
+  would double-stack into ".../latestlatest/...". Normalise the trailing slash
+  (mike drops it; the configured root keeps it) before appending.
 -->
+
+{# The bare site_name ("Podspine", 8 chars) is too short for SERP/social. Give
+   the homepage a descriptive ~57-char title; subpages keep Material's default
+   "<page> - <site_name>". Kept in sync with the homepage social title below. #}
+{% block htmltitle %}
+  {% if page and page.is_homepage %}
+    <title>Podspine — turn audiobooks into per-chapter podcast feeds</title>
+  {% else %}
+    {{ super() }}
+  {% endif %}
+{% endblock %}
+
 {% block extrahead %}
   {{ super() }}
-  {% set social_image = config.site_url ~ "latest/assets/social-card.png" %}
+  {% set _base = config.site_url[:-1] if config.site_url.endswith('/') else config.site_url %}
+  {% set social_image = _base ~ "/assets/social-card.png" %}
   {% if page and page.is_homepage %}
-    {% set social_title = config.site_name %}
+    {% set social_title = "Podspine — turn audiobooks into per-chapter podcast feeds" %}
   {% elif page and page.title %}
     {% set social_title = page.title ~ " · " ~ config.site_name %}
   {% else %}


### PR DESCRIPTION
Two issues surfaced once the docs site deployed and I/you checked it on opengraph.xyz.

## 1. `og:image` 404 — doubled `latest`
The card link rendered as `…/podspine/**latestlatest**/assets/social-card.png`.

**Cause:** `mike` rewrites `config.site_url` to the *versioned* base (`…/podspine/latest`) at deploy time. My template appended another `latest/`, double-stacking. (Local plain builds hid it because there `site_url` is the configured root.)

**Fix:** reference the card at `<site_url>/assets/social-card.png` and normalise the trailing slash (mike drops it; the configured root keeps it). No hardcoded `latest/`.

## 2. Homepage title too short (8 chars)
opengraph flagged the bare `Podspine` `<title>`. Override the `htmltitle` block so the **homepage** gets a descriptive **57-char** title — `Podspine — turn audiobooks into per-chapter podcast feeds` — and matching `og:`/`twitter:title`. Subpages keep Material's `"<page> - Podspine"`.

## Verification
`mkdocs build --strict` under **both** a configured-root `site_url` and a **simulated mike** versioned `site_url`:
- og:image → `…/podspine/latest/assets/social-card.png` (single `latest`; asset confirmed HTTP 200 live)
- homepage `<title>` = 57 chars; subpage `<title>` unchanged (`Deploying - Podspine`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)