### PR TITLE
docs: default the site to releases (not main) + version-warning banner; reconcile to 1.2.0

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -99,12 +99,17 @@ jobs:
             # it removes the legacy version literally named `latest` (the old main
             # snapshot) so `latest` can become an alias on the release. `|| true`
             # because on a healthy tree there's no such version to delete.
+            #
+            # Use `mike alias` (NOT `mike deploy`): we're only re-pointing the
+            # alias at an already-published snapshot. `mike deploy $PROMOTE` would
+            # rebuild the docs from the current checkout (main) into the $PROMOTE
+            # dir, clobbering the immutable release snapshot with main's content.
             case "$PROMOTE" in
               [0-9]*.[0-9]*) ;;
               *) echo "::error::promote_to_latest must be an X.Y version (e.g. 1.2)"; exit 1 ;;
             esac
             mike delete --push latest 2>/dev/null || true
-            mike deploy --push --update-aliases "$PROMOTE" latest
+            mike alias --push --update-aliases "$PROMOTE" latest
             mike set-default --push latest
           elif [ "$REF_TYPE" = "tag" ]; then
             # Release vX.Y.Z -> immutable "X.Y" snapshot, and move `latest` (the

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,8 +2,11 @@ name: Docs
 
 # Build the MkDocs (Material) site and publish it to GitHub Pages via `mike`,
 # which keeps a version selector on the gh-pages branch:
-#   - every push to main updates the `latest` version (docs track main)
-#   - every stable release tag (vX.Y.Z) publishes an immutable `X.Y` snapshot
+#   - every push to main updates the rolling `dev` snapshot (unreleased docs)
+#   - every release tag (vX.Y.Z) publishes an immutable `X.Y` snapshot AND moves
+#     the `latest` alias (the site default) to it, so visitors land on the newest
+#     release — the version they can actually install. `dev` is opt-in via the
+#     selector and carries a version-warning banner.
 # Pull requests only build with --strict (link/config validation), never deploy.
 #
 # NOTE: action refs are pinned to full commit SHAs (repo Actions policy + Scorecard);
@@ -22,6 +25,11 @@ on:
       - CHANGELOG.md
       - .github/workflows/docs.yml
   workflow_dispatch:
+    inputs:
+      promote_to_latest:
+        description: "One-time: point `latest`/default at an already-deployed release (X.Y, e.g. 1.2). Leave empty for a normal deploy."
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -81,20 +89,35 @@ jobs:
         env:
           REF_NAME: ${{ github.ref_name }}
           REF_TYPE: ${{ github.ref_type }}
+          PROMOTE: ${{ github.event.inputs.promote_to_latest }}
         run: |
-          if [ "$REF_TYPE" = "tag" ]; then
-            # vX.Y.Z -> immutable "X.Y" snapshot; leaves `latest`/default untouched.
+          set -euo pipefail
+          if [ -n "${PROMOTE:-}" ]; then
+            # One-time migration / manual re-point: make an already-deployed
+            # release the site default under the `latest` alias. Used once when
+            # switching from "latest tracks main" to the release-default model —
+            # it removes the legacy version literally named `latest` (the old main
+            # snapshot) so `latest` can become an alias on the release. `|| true`
+            # because on a healthy tree there's no such version to delete.
+            case "$PROMOTE" in
+              [0-9]*.[0-9]*) ;;
+              *) echo "::error::promote_to_latest must be an X.Y version (e.g. 1.2)"; exit 1 ;;
+            esac
+            mike delete --push latest 2>/dev/null || true
+            mike deploy --push --update-aliases "$PROMOTE" latest
+            mike set-default --push latest
+          elif [ "$REF_TYPE" = "tag" ]; then
+            # Release vX.Y.Z -> immutable "X.Y" snapshot, and move `latest` (the
+            # site default) onto it: the newest release is what visitors land on.
+            # Assumes linear releases (a backport to an old line would wrongly
+            # claim `latest` — re-point manually via promote_to_latest if so).
             version="${REF_NAME#v}"
-            mike deploy --push "${version%.*}"
+            mike deploy --push --update-aliases "${version%.*}" latest
+            mike set-default --push latest
           else
-            # main -> rolling `latest`. Note whether gh-pages exists BEFORE the
-            # deploy creates it, so we can set the root redirect exactly once.
-            first_deploy=true
-            git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1 && first_deploy=false
-            mike deploy --push --update-aliases latest
-            # Point the site root at `latest` — only needed on the first deploy;
-            # skipping it afterwards avoids a redundant redirect commit each push.
-            if [ "$first_deploy" = true ]; then
-              mike set-default --push latest
-            fi
+            # Push to main -> rolling `dev` snapshot. Deliberately never touches
+            # `latest`/default, so unreleased changes aren't what users see by
+            # default; Material's version-warning banner flags `dev` as ahead of
+            # the release.
+            mike deploy --push --update-aliases dev
           fi

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -41,13 +41,13 @@ Overrides (environment variables):
 
 | Var | Default | Purpose |
 |---|---|---|
-| `PODSPINE_VERSION` | latest release | Pin a version, e.g. `1.1.0` |
+| `PODSPINE_VERSION` | latest release | Pin a version, e.g. `1.2.0` |
 | `PODSPINE_INSTALL_DIR` | `~/.local/bin` | Install location (uses `sudo` only if it isn't writable) |
 
 ```bash
 # Pin a version and install system-wide:
 curl -fsSL https://raw.githubusercontent.com/schubydoo/podspine/main/install.sh \
-  | PODSPINE_VERSION=1.1.0 PODSPINE_INSTALL_DIR=/usr/local/bin bash
+  | PODSPINE_VERSION=1.2.0 PODSPINE_INSTALL_DIR=/usr/local/bin bash
 ```
 
 **Uninstall** (removes the binary only — never your library or data dir):

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -25,6 +25,15 @@
   {% endif %}
 {% endblock %}
 
+{# Version-warning banner. Material renders it (via extra.version.provider: mike)
+   on any version that is NOT the `latest` alias — i.e. the rolling `dev`/main
+   build or a superseded release — so readers who land on unreleased docs know
+   they're ahead of what they can install. #}
+{% block outdated %}
+  You're reading docs for an unreleased or older version of Podspine.
+  <a href="{{ '../' ~ base_url }}"><strong>Go to the latest release →</strong></a>
+{% endblock %}
+
 {% block extrahead %}
   {{ super() }}
   {% set _base = config.site_url[:-1] if config.site_url.endswith('/') else config.site_url %}


### PR DESCRIPTION
Implements the release-default docs model we discussed, plus the 1.2.0 drift reconcile.

## Why
Every package-manager install pins to a **release** (brew/scoop/nix/binstall). But today the docs `latest` alias tracks **main**, so a reader on a pinned binary can land on docs describing unreleased behavior. This flips the default so *"the docs you land on = the Podspine you can install."*

## Versioning model (`.github/workflows/docs.yml`)
| Trigger | Before | After |
|---|---|---|
| push to `main` | updates `latest` (= main) | updates rolling **`dev`** snapshot; never touches `latest`/default |
| release `vX.Y.Z` | `X.Y` snapshot, `latest` untouched | `X.Y` snapshot **and moves `latest`** (site default) onto it |

`dev` stays available via the version selector for people who want unreleased docs.

## Version-warning banner
`extra.version.provider: mike` + `default: latest` were already set. Added the `outdated` block override in `overrides/main.html`, so Material shows a banner on any non-`latest` version (`dev` or a superseded release): *"You're reading docs for an unreleased or older version… Go to the latest release →"*. Config verified against current Material docs (Context7).

## Drift reconcile vs 1.2.0
- `installation.md`: pinned-version examples `1.1.0` → `1.2.0`.
- **Full audit found nothing else:** `git log v1.2.0..main` = 6 commits, all docs/brand/CI/packaging (no features); DEPLOYMENT.md's config reference matches `crates/config` exactly (all 7 flags/env vars, no phantoms); no unreleased/TBD markers.

## Verification
- `actionlint` clean on `docs.yml`
- `mkdocs build --strict` clean; banner text renders under `data-md-component="outdated"`
- deploy logic exercised by reasoning (mike push can't run locally) — see the one-time migration below

## ⚠️ One-time migration after merge (I'll run it, or you can)
Currently `latest` is a mike *version* holding main's content. To make it an *alias* on the 1.2 release:
```
gh workflow run docs.yml -f promote_to_latest=1.2
```
That deletes the legacy `latest` version, aliases `1.2` as `latest`, and sets it default. The `1.2` snapshot already exists, and `/podspine/latest/` URLs keep working (alias → 1.2). Serialized via the workflow concurrency group, so it won't race the merge's `dev` deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)