### PR TITLE
docs(brand): OG-aware root redirect stub (bare root previewed as "Redirecting")

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -110,7 +110,7 @@ jobs:
             esac
             mike delete --push latest 2>/dev/null || true
             mike alias --push --update-aliases "$PROMOTE" latest
-            mike set-default --push latest
+            mike set-default --push --template mike/redirect.html latest
           elif [ "$REF_TYPE" = "tag" ]; then
             # Release vX.Y.Z -> immutable "X.Y" snapshot, and move `latest` (the
             # site default) onto it: the newest release is what visitors land on.
@@ -118,7 +118,7 @@ jobs:
             # claim `latest` — re-point manually via promote_to_latest if so).
             version="${REF_NAME#v}"
             mike deploy --push --update-aliases "${version%.*}" latest
-            mike set-default --push latest
+            mike set-default --push --template mike/redirect.html latest
           else
             # Push to main -> rolling `dev` snapshot. Deliberately never touches
             # `latest`/default, so unreleased changes aren't what users see by

--- a/mike/redirect.html
+++ b/mike/redirect.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <!--
+    Custom `mike set-default` redirect stub for the site root
+    (https://schubydoo.github.io/podspine/). The default mike template is a bare
+    "Redirecting" page with no metadata, so sharing the root URL previews as
+    "Redirecting" with no image — social scrapers read this stub and don't follow
+    the JS/meta redirect to /latest/. Mirror the latest page's title + social card
+    here so the bare root previews correctly. Wired in via docs.yml `set-default
+    --template mike/redirect.html`. URLs are absolute + point at the `latest`
+    alias, which always resolves to the newest release.
+  -->
+  <title>Podspine — turn audiobooks into per-chapter podcast feeds</title>
+  <link rel="canonical" href="https://schubydoo.github.io/podspine/latest/">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Podspine">
+  <meta property="og:title" content="Podspine — turn audiobooks into per-chapter podcast feeds">
+  <meta property="og:description" content="Turn your audiobook files into per-chapter podcast feeds any podcast app can play.">
+  <meta property="og:image" content="https://schubydoo.github.io/podspine/latest/assets/og-card.png">
+  <meta property="og:url" content="https://schubydoo.github.io/podspine/latest/">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Podspine — turn audiobooks into per-chapter podcast feeds">
+  <meta name="twitter:description" content="Turn your audiobook files into per-chapter podcast feeds any podcast app can play.">
+  <meta name="twitter:image" content="https://schubydoo.github.io/podspine/latest/assets/og-card.png">
+  <noscript>
+    <meta http-equiv="refresh" content="1; url={{href}}" />
+  </noscript>
+  <script>
+    window.location.replace(
+      "{{href}}" + window.location.search + window.location.hash
+    );
+  </script>
+</head>
+<body>
+  Redirecting to <a href="{{href}}">{{href}}</a>…
+</body>
+</html>


### PR DESCRIPTION
Sharing the bare site root **`https://schubydoo.github.io/podspine/`** previewed as **"Redirecting"** with no image — even though `/latest/` previews fine.

## Cause
Under mike, the site root is a `set-default` redirect stub. mike's default template is a metadata-less *"Redirecting…"* page, and social scrapers read that stub without following its JS/meta redirect to `/latest/`.

## Fix
- Add **`mike/redirect.html`** — same JS + `<noscript>` redirect, plus a real `<title>` and Open Graph/Twitter meta mirroring the latest page's social card (absolute URLs at the `latest` alias).
- Pass it via `mike set-default --template mike/redirect.html` in **both** the release-tag and promote paths (`docs.yml`), so the OG-aware root survives every future deploy.

## Already applied live
Regenerated the gh-pages root stub with this template. Verified the bare root now serves:
- `title` = `Podspine — turn audiobooks into per-chapter podcast feeds` (was "Redirecting")
- `og:image` = the 1.91:1 card (reachable, 200) · `twitter:card` = `summary_large_image`
- still redirects real users to `/latest/` (refresh + JS replace intact)

actionlint clean. This PR just makes it durable in the repo/workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)