### PR TITLE
ci: install ffmpeg via a cached self-hosted static build

### DIFF
--- a/.github/actions/setup-ffmpeg/action.yml
+++ b/.github/actions/setup-ffmpeg/action.yml
@@ -1,0 +1,74 @@
+name: Set up ffmpeg
+description: >-
+  Put real ffmpeg + ffprobe on PATH for the test/coverage jobs. On Linux a
+  pinned, sha256-verified John Van Sickle static build is cached across runs
+  (restore is seconds vs. apt pulling the whole libav* tree); macOS and the
+  informational Windows job fall back to their package managers. ffmpeg stays
+  real, so the split/probe/scan correctness tests are unaffected.
+
+# Why a local composite action rather than a published one (e.g.
+# AnimMouse/setup-ffmpeg): the repo ruleset requires every action — including
+# ones nested inside a composite action — to be pinned to a full commit SHA.
+# Published setup-ffmpeg actions call actions/cache and tool-cache by version
+# tag internally, which we can't pin, so they're rejected. Vendoring the logic
+# here keeps every ref under our control.
+#
+# Why ffmpeg 6.0.1 (not the newest 8.x): it's a deliberate *minimum-version
+# floor*. John Van Sickle's old-releases archive is the only source that is both
+# permanent AND immutable (BtbN's dated builds get pruned; its `latest` tag is
+# mutable, so a pinned hash would drift). Every ffmpeg flag Podspine uses is
+# stable across 4→8, and distro users (Debian/Ubuntu LTS) often run older
+# ffmpeg — proving it works on 6.0.1 covers them, and newer ffmpeg is
+# backward-compatible for this flag surface. Bump the version + FFMPEG_SHA256 +
+# cache key together to move the floor.
+
+runs:
+  using: composite
+  steps:
+    - name: Restore cached static ffmpeg (Linux)
+      if: runner.os == 'Linux'
+      id: cache
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.cache/podspine-ffmpeg/bin
+        key: ffmpeg-static-6.0.1-linux64-jvs
+
+    - name: Download static ffmpeg (Linux)
+      if: runner.os == 'Linux' && steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        FFMPEG_URL: https://johnvansickle.com/ffmpeg/old-releases/ffmpeg-6.0.1-amd64-static.tar.xz
+        FFMPEG_SHA256: 28268bf402f1083833ea269331587f60a242848880073be8016501d864bd07a5
+      run: |
+        set -euo pipefail
+        tmp="$(mktemp -d)"
+        curl -fsSL --retry 3 -o "$tmp/ffmpeg.tar.xz" "$FFMPEG_URL"
+        echo "${FFMPEG_SHA256}  ${tmp}/ffmpeg.tar.xz" | sha256sum -c -
+        dest="$HOME/.cache/podspine-ffmpeg/bin"
+        mkdir -p "$dest"
+        # Extract just the two binaries from the versioned top-level dir.
+        tar -xJf "$tmp/ffmpeg.tar.xz" --strip-components=1 -C "$dest" \
+          --wildcards '*/ffmpeg' '*/ffprobe'
+        rm -rf "$tmp"
+
+    - name: Add ffmpeg to PATH (Linux)
+      if: runner.os == 'Linux'
+      shell: bash
+      # $dest is a hardcoded constant (no untrusted input), so this GITHUB_PATH
+      # write can't be influenced by an attacker. Podspine runs `ffmpeg` via a
+      # PATH lookup, and GITHUB_PATH is the sanctioned way to extend PATH.
+      run: | # zizmor: ignore[github-env]
+        set -euo pipefail
+        dest="$HOME/.cache/podspine-ffmpeg/bin"
+        chmod +x "$dest/ffmpeg" "$dest/ffprobe"
+        echo "$dest" >> "$GITHUB_PATH"
+
+    - name: Install ffmpeg (macOS)
+      if: runner.os == 'macOS'
+      shell: bash
+      run: brew install ffmpeg
+
+    - name: Install ffmpeg (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: choco install ffmpeg -y

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,12 +54,10 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - name: Install ffmpeg (Linux)
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y ffmpeg
-      - name: Install ffmpeg (macOS)
-        if: runner.os == 'macOS'
-        run: brew install ffmpeg
+      # Real ffmpeg, cached static build on Linux (seconds vs. apt pulling the
+      # whole libav* tree); see .github/actions/setup-ffmpeg for the why.
+      - name: Set up ffmpeg
+        uses: ./.github/actions/setup-ffmpeg
       - name: Test
         run: cargo test --workspace --all-features
 
@@ -76,8 +74,8 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - name: Install ffmpeg
-        run: choco install ffmpeg -y
+      - name: Set up ffmpeg
+        uses: ./.github/actions/setup-ffmpeg
       - name: Test
         run: cargo test --workspace --all-features
 
@@ -95,8 +93,8 @@ jobs:
       - uses: taiki-e/install-action@50414676f9f5d50a65992c6dd2ed02641263226c # v2
         with:
           tool: cargo-llvm-cov
-      - name: Install ffmpeg
-        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+      - name: Set up ffmpeg
+        uses: ./.github/actions/setup-ffmpeg
       # Enforce the line floor (the real gate; baseline ~94%) and emit lcov.
       # cargo-llvm-cov writes lcov.info before the threshold check, so the upload
       # below still runs on a floor failure — surfacing a drop when it matters.


### PR DESCRIPTION
## Problem

Every CI run reinstalls ffmpeg through the OS package manager — `apt-get install ffmpeg` (test-Linux, coverage), `brew install ffmpeg` (test-macOS), `choco install ffmpeg` (test-Windows) — each dragging in the full `libav*` tree. On the coverage job that install dominates the wall-clock.

## Fix

A local composite action, **`.github/actions/setup-ffmpeg`**, used uniformly by all three jobs:

- **Linux** (coverage + test): downloads a **pinned, sha256-verified** John Van Sickle static `ffmpeg`+`ffprobe`, extracts just the two binaries, and **caches** them (`actions/cache`, SHA-pinned) — restore is **seconds** on a hit.
- **macOS / Windows**: keep `brew`/`choco` behind the same action, so the workflow calls one thing everywhere.

ffmpeg stays **real** — the split/probe/scan correctness tests are unchanged.

## Why self-hosted instead of a published `setup-ffmpeg` action

The repo ruleset requires **every** action — *including ones nested inside a composite action* — to be pinned to a full commit SHA. Published setup-ffmpeg actions call `actions/cache` and `tool-cache` by version tag internally, which we can't pin (that's the exact error the first revision hit). Vendoring the logic keeps every ref under our control. A direct CDN download also means **no GitHub API token is needed**.

## Why ffmpeg 6.0.1 (a deliberate minimum-version floor)

John Van Sickle's `old-releases/` is the only source that's both **permanent and immutable** — BtbN's dated builds get pruned (URL 404s) and its `latest` tag is mutable (a pinned hash would drift). Every ffmpeg flag Podspine uses (`-ss/-i/-t/-c copy/-map_chapters/-movflags`, ffprobe `-show_chapters/-format/-streams -print_format json`) is **stable across 4→8**, so testing on 6.0.1 both covers old-distro users (Debian/Ubuntu LTS run 4.x–6.x) and predicts 8.x behavior. Bump `version + FFMPEG_SHA256 + cache key` together to move the floor.

## Verification

Ran the action's download+extract locally against the real tarball: sha256 matches, extraction yields exactly `ffmpeg`+`ffprobe`, both execute, and **aac / flac / libmp3lame / libopus** encoders are all present (what the fixture-synthesis tests need).

No code change → `no-changelog`. Independent of #49/#50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)