### PR TITLE
ci(renovate): batch dependency updates to a weekly schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
     "helpers:pinGitHubActionDigests"
   ],
   "labels": ["dependencies"],
+  "schedule": ["before 6am on monday"],
   "lockFileMaintenance": {
     "description": "Keep flake.lock (nixpkgs/flake-utils) fresh weekly.",
     "enabled": true,


### PR DESCRIPTION
## Why

Renovate was opening actions/docker digest-pin PRs throughout the week, unlike our other repos (which batch to ~once a week, security excepted).

Root cause: `renovate.json` had **no top-level `schedule`** — only `lockFileMaintenance` was scheduled, and that setting doesn't cascade. So GitHub Actions digest pins (32 SHA-pinned actions), the pinned `alpine` base-image digest, and cargo bumps all ran on Renovate's default *anytime* cadence and opened PRs as soon as any upstream digest moved.

## Change

Add a root-level schedule:

```json
"schedule": ["before 6am on monday"]
```

- Batches **all** update types to Monday mornings (actions group, docker digest, cargo).
- `vulnerabilityAlerts` ignore `schedule`, so **security updates still fire immediately** → "weekly, unless urgent", matching the other repos.
- Existing `lockFileMaintenance` Monday schedule is unchanged and consistent.

Validated with `renovate-config-validator` (passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)