### PR TITLE
feat: faststart detection + opt-in remux for whole-file mp4

### DIFF
--- a/.changeset/faststart-remux.md
+++ b/.changeset/faststart-remux.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Detect non-faststart whole-file mp4 (`moov` after `mdat`) at ingest and log a one-line callout; add opt-in `PODSPINE_REMUX_NON_FASTSTART` to remux such books to faststart on demand — a cache-managed stream-copy (no re-encode) served from the `saver` cache and regenerated/evicted like a cached chapter, never a pinned duplicate — so podcast clients seek quickly. MP3/OGG/FLAC, already-faststart mp4, and chaptered books are unaffected.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,11 @@ disk (not ingest time) for a small first-play delay. So budget extra space for
 chaptered libraries; whole-file libraries cost only their index and covers. Full
 details: **[storage mode](docs/DEPLOYMENT.md#storage-mode-full-vs-saver)**.
 
+A whole-file `.m4a`/`.m4b` that isn't "faststart" plays fine but seeks slowly;
+Podspine flags it at ingest, and `PODSPINE_REMUX_NON_FASTSTART=true` will remux it
+to faststart on demand (cache-managed, no re-encode) — see
+**[faststart](docs/DEPLOYMENT.md#faststart-for-whole-file-mp4)**.
+
 Each book's feed lives at an unguessable **capability URL** — `/feed/{feed_id}.xml`,
 with `/audio/{feed_id}/{n}` (episode audio, HTTP Range) and `/cover/{feed_id}`. The
 browse UI (`/`, `/book/{slug}`) enumerates your library, so keep it on the LAN or

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -61,6 +61,12 @@ pub struct Cli {
     /// Force embedded chapters, ignoring any `.cue`/`.ffmeta` sidecar.
     #[arg(long, env = "PODSPINE_FORCE_EMBEDDED_CHAPTERS")]
     pub force_embedded_chapters: bool,
+    /// Remux a non-faststart whole-file mp4 (`moov` after `mdat`) to faststart on
+    /// demand so podcast clients seek quickly, instead of serving it in place. The
+    /// remux is stream-copied and cache-managed (counts against the `saver` cache
+    /// cap), never a pinned duplicate. Default off: serve in place + log a callout.
+    #[arg(long, env = "PODSPINE_REMUX_NON_FASTSTART")]
+    pub remux_non_faststart: bool,
     /// Chapter storage strategy for **chaptered** books: `full` pre-splits every
     /// chapter to disk (fast, ~2× storage); `saver` still splits at ingest but
     /// keeps chapters in a bounded on-demand cache (minimal steady-state disk, a
@@ -97,6 +103,8 @@ pub struct FileConfig {
     pub default_cover_url: Option<String>,
     /// Force embedded chapters, ignoring sidecars.
     pub force_embedded_chapters: Option<bool>,
+    /// Remux non-faststart whole-file mp4 to faststart on demand (cache-managed).
+    pub remux_non_faststart: Option<bool>,
     /// Chapter storage strategy (`full` | `saver`).
     pub storage_mode: Option<StorageMode>,
     /// On-demand cache size cap (e.g. `2GB`; `0`/`off` = unbounded).
@@ -121,6 +129,13 @@ pub struct Config {
     pub default_cover_url: Option<String>,
     /// Ignore `.cue`/`.ffmeta` sidecars and always use embedded chapters.
     pub force_embedded_chapters: bool,
+    /// Remux a non-faststart whole-file mp4 (`moov` after `mdat`) to faststart on
+    /// demand rather than serving it in place — so podcast clients seek quickly.
+    /// The remuxed copy is stream-copied and cache-managed (evicted under the
+    /// `saver` cap, regenerated on demand), never a pinned duplicate. Default off:
+    /// such books serve in place and a one-line callout is logged at ingest. No
+    /// effect on faststart mp4, MP3/OGG/FLAC, or chaptered books (Sprint 6.3).
+    pub remux_non_faststart: bool,
     /// How **chaptered** books are produced/stored: `full` (pre-split every
     /// chapter to disk) or `saver` (split at ingest, then cache regenerations on
     /// demand). Applies library-wide to chaptered books, which materialize under
@@ -252,6 +267,9 @@ impl Config {
         let force_embedded_chapters =
             cli.force_embedded_chapters || file.force_embedded_chapters.unwrap_or(false);
 
+        let remux_non_faststart =
+            cli.remux_non_faststart || file.remux_non_faststart.unwrap_or(false);
+
         let storage_mode = cli.storage_mode.or(file.storage_mode).unwrap_or_default();
 
         let cache_size_bytes = match cli.cache_size.clone().or_else(|| file.cache_size.clone()) {
@@ -274,6 +292,7 @@ impl Config {
             base_url,
             default_cover_url,
             force_embedded_chapters,
+            remux_non_faststart,
             storage_mode,
             cache_size_bytes,
             cache_ttl,
@@ -507,6 +526,7 @@ mod tests {
             base_url: "http://localhost:8080".to_string(),
             default_cover_url: None,
             force_embedded_chapters: false,
+            remux_non_faststart: false,
             storage_mode: StorageMode::Full,
             cache_size_bytes: Some(DEFAULT_CACHE_SIZE_BYTES),
             cache_ttl: None,
@@ -527,6 +547,7 @@ mod tests {
             base_url: "http://localhost:8080".to_string(),
             default_cover_url: None,
             force_embedded_chapters: false,
+            remux_non_faststart: false,
             storage_mode: StorageMode::Full,
             cache_size_bytes: Some(DEFAULT_CACHE_SIZE_BYTES),
             cache_ttl: None,
@@ -570,6 +591,32 @@ mod tests {
         assert_eq!(c.storage_mode, StorageMode::Full);
         assert_eq!(c.cache_size_bytes, Some(DEFAULT_CACHE_SIZE_BYTES));
         assert_eq!(c.cache_ttl, None);
+    }
+
+    #[test]
+    fn remux_non_faststart_defaults_off_and_resolves_from_either_layer() {
+        let c = Config::resolve(&cli(Some("/books")), &FileConfig::default()).unwrap();
+        assert!(!c.remux_non_faststart, "default off");
+
+        let file = FileConfig {
+            remux_non_faststart: Some(true),
+            ..Default::default()
+        };
+        assert!(
+            Config::resolve(&cli(Some("/books")), &file)
+                .unwrap()
+                .remux_non_faststart,
+            "enabled from the file layer"
+        );
+
+        let mut cl = cli(Some("/books"));
+        cl.remux_non_faststart = true;
+        assert!(
+            Config::resolve(&cl, &FileConfig::default())
+                .unwrap()
+                .remux_non_faststart,
+            "enabled from the CLI flag"
+        );
     }
 
     #[test]

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -48,7 +48,7 @@ use tower_http::trace::TraceLayer;
 
 use podspine_feed::{FeedBook, FeedEpisode, render_checked};
 use podspine_index::Index;
-use podspine_splitter::{ChapterCut, split_chapter};
+use podspine_splitter::{ChapterCut, remux_faststart, split_chapter};
 use podspine_ui::{BookCard, BookDetail, book_page, index_page, subscribe_page};
 
 /// Max concurrent in-flight requests before backpressure (DoS guard). Generous
@@ -391,11 +391,12 @@ async fn audio(
     range: Option<TypedHeader<Range>>,
 ) -> Result<impl IntoResponse, AppError> {
     let target = resolve_audio_target(&state, &feed_id, number)?;
-    // `saver` mode: the file isn't pre-split — regenerate (and cache) it on the
-    // first request. `full` mode: a missing file is a genuine 404.
+    // A missing file is regenerated on demand when the resolver supplied a `Regen`
+    // (a `saver` chapter split, or a faststart remux of a whole-file episode);
+    // otherwise (e.g. `full`-mode chapter, in-place whole file) it's a genuine 404.
     if !target.path.exists() {
         match &target.regen {
-            Some(regen) => ensure_chapter(&state, &target.path, regen).await?,
+            Some(regen) => ensure_cached(&state, &target.path, regen).await?,
             None => return Err(AppError::NotFound),
         }
     }
@@ -481,26 +482,41 @@ struct AudioTarget {
     regen: Option<Regen>,
 }
 
-/// Inputs to regenerate one chapter on demand (`saver` mode).
+/// Inputs to regenerate one cache file on demand — a `saver` chapter split, or a
+/// faststart remux of a whole-file episode (Sprint 6.3). The source is always a
+/// validated file under a trusted root; the op decides which ffmpeg call rebuilds
+/// the deterministic output.
 struct Regen {
     source: PathBuf,
     out_dir: PathBuf,
     out_ext: String,
-    cut: ChapterCut,
+    op: RegenOp,
 }
 
-/// Resolve `/audio/{feed_id}/{number}` to its on-disk target. Two path-safe
-/// shapes, depending on whether the episode is a whole file or a chapter:
+/// Which ffmpeg operation regenerates the cache file.
+#[derive(Clone)]
+enum RegenOp {
+    /// Re-split one chapter (`saver` mode) — a sub-range of the container.
+    Chapter(ChapterCut),
+    /// Remux a whole file to faststart (`PODSPINE_REMUX_NON_FASTSTART`).
+    Faststart { idx: usize, duration_sec: f64 },
+}
+
+/// Resolve `/audio/{feed_id}/{number}` to its on-disk target. Three path-safe
+/// shapes, by whether the episode is a whole file (and how it's stored):
 ///
-/// - **In place (whole-file episode):** when the episode carries a `source_path`,
-///   it's a whole file streamed from the library — canonicalized, asserted under
-///   the library root, and size-checked against the recorded length (Sprint 6.2).
+/// - **In place (whole-file episode, `file_path == source_path`):** a whole file
+///   streamed from the library — canonicalized, asserted under the library root,
+///   and size-checked against the recorded length (Sprint 6.2).
+/// - **Faststart remux (whole-file episode, `file_path != source_path`):** the
+///   served file is a cache copy under the data dir; it's regenerated on demand by
+///   remuxing the library source to faststart (Sprint 6.3), so the resolver returns
+///   a [`Regen`] carrying [`RegenOp::Faststart`].
 /// - **Extracted (chaptered episode):** the path is reconstructed from the
 ///   canonical `data_dir` plus **opaque DB keys** (`book.id`, chapter index) and a
 ///   validated audio extension — never built from request input — so it stays
-///   under the data dir by construction (no traversal). Existence is NOT required:
-///   in `saver` mode the file is regenerated on demand, so the resolver returns
-///   the target plus a [`Regen`].
+///   under the data dir by construction (no traversal). In `saver` mode it's
+///   regenerated on demand ([`RegenOp::Chapter`]); existence is not required.
 fn resolve_audio_target(
     state: &AppState,
     feed_id: &str,
@@ -526,10 +542,11 @@ fn resolve_audio_target(
         (book, ep)
     };
 
-    // Serve-in-place (Sprint 6.2): a whole-file episode (MP3-folder track, or a
-    // chapterless single file) is streamed directly from the read-only library —
-    // never copied under the data dir. `source_path` is the persisted library
-    // file. Three guards before it's served, all 404 on failure (no oracle):
+    // Serve-in-place (Sprint 6.2): a whole-file episode streamed directly from the
+    // read-only library — never copied under the data dir. Recognized by a
+    // non-empty `source_path` whose value equals `file_path` (a whole-file episode
+    // whose `file_path != source_path` was remuxed to a faststart cache copy and
+    // is handled by the data-dir path below). Three guards, all 404 on failure:
     //   1. canonicalize + assert under the library root (reject `..`/symlink
     //      escape) — the A01 "assert under the library root" rule (TAD §7);
     //   2. the recorded enclosure length must equal the on-disk source size —
@@ -540,7 +557,7 @@ fn resolve_audio_target(
     //      under the chapter's enclosure length.
     // Returns before the data-dir/regeneration logic below, so a poisoned row can
     // never fall through into it.
-    if !ep.source_path.is_empty() {
+    if !ep.source_path.is_empty() && ep.file_path == ep.source_path {
         let src = FsPath::new(&ep.source_path)
             .canonicalize()
             .map_err(|_| AppError::NotFound)?;
@@ -591,35 +608,61 @@ fn resolve_audio_target(
     }
     let path = out_dir.join(format!("{:03}.{out_ext}", idx + 1));
 
-    // Only chaptered single-file books reach here: whole-file episodes (MP3-folder
-    // tracks, chapterless singles) carry a `source_path` and were served in place
-    // and returned above, so they never regenerate. Regen is possible only in
-    // saver mode when the book's source is a single file to re-split; the
-    // `is_file` guard stays as belt-and-suspenders (a directory source would make
-    // `ffmpeg <directory>` fail), so a missing file is a clean 404, not a 500.
-    let regen = (state.saver && FsPath::new(&book.source_path).is_file()).then(|| Regen {
-        source: PathBuf::from(&book.source_path),
-        out_dir,
-        out_ext,
-        // `end_sec` is reconstructed as start + duration. This is EXACT, not an
-        // approximation: the scanner stores `duration_sec = cut.end - cut.start`
-        // (the requested cut length, not a measured output duration), so this
-        // yields the same `[start, end)` the ingest split used — and ffmpeg's
-        // 6-decimal arg formatting absorbs any float round-trip. The stream copy
-        // is therefore byte-identical (asserted in the serve test).
-        cut: ChapterCut {
-            idx: idx as usize,
-            start_sec: ep.start_sec,
-            end_sec: ep.start_sec + ep.duration_sec,
-        },
-    });
+    // Two kinds of episode materialize under the data dir here:
+    let regen = if !ep.source_path.is_empty() && ep.needs_faststart {
+        // A non-faststart whole-file episode remuxed to a faststart cache copy
+        // (Sprint 6.3, `file_path != source_path`). Regenerate it on demand from
+        // the library source — always, independent of storage_mode. The
+        // `needs_faststart` gate means a chaptered row that merely carries a stray
+        // `source_path` is NOT remuxed into its container here; it drops to the
+        // chaptered arm and serves its actual split (or 404s). Validate the source
+        // stays under the library root first (the A01 rule), 404 on escape.
+        let src = FsPath::new(&ep.source_path)
+            .canonicalize()
+            .map_err(|_| AppError::NotFound)?;
+        if !src.starts_with(&state.library_dir) {
+            tracing::warn!(feed_id, number, "remux source escaped the library root");
+            return Err(AppError::NotFound);
+        }
+        Some(Regen {
+            source: src,
+            out_dir,
+            out_ext,
+            op: RegenOp::Faststart {
+                idx: idx as usize,
+                duration_sec: ep.duration_sec,
+            },
+        })
+    } else {
+        // A chaptered episode. Regen is possible only in `saver` mode when the
+        // book's source is a single file to re-split; the `is_file` guard is
+        // belt-and-suspenders (a directory source would make `ffmpeg <directory>`
+        // fail), so a missing file is a clean 404, not a 500.
+        (state.saver && FsPath::new(&book.source_path).is_file()).then(|| Regen {
+            source: PathBuf::from(&book.source_path),
+            out_dir,
+            out_ext,
+            // `end_sec` is reconstructed as start + duration. This is EXACT, not an
+            // approximation: the scanner stores `duration_sec = cut.end - cut.start`
+            // (the requested cut length, not a measured output duration), so this
+            // yields the same `[start, end)` the ingest split used — and ffmpeg's
+            // 6-decimal arg formatting absorbs any float round-trip. The stream
+            // copy is therefore byte-identical (asserted in the serve test).
+            op: RegenOp::Chapter(ChapterCut {
+                idx: idx as usize,
+                start_sec: ep.start_sec,
+                end_sec: ep.start_sec + ep.duration_sec,
+            }),
+        })
+    };
     Ok(AudioTarget { path, regen })
 }
 
-/// Ensure `target` exists, regenerating it on demand (`saver` mode). A per-path
-/// single-flight lock means concurrent requests for the same uncached chapter
-/// run ffmpeg once; the blocking split runs off the async runtime.
-async fn ensure_chapter(state: &AppState, target: &FsPath, regen: &Regen) -> Result<(), AppError> {
+/// Ensure `target` exists, regenerating it on demand: a `saver` chapter split, or
+/// a whole-file faststart remux (Sprint 6.3). A per-path single-flight lock means
+/// concurrent requests for the same uncached file run ffmpeg once; the blocking
+/// ffmpeg work runs off the async runtime.
+async fn ensure_cached(state: &AppState, target: &FsPath, regen: &Regen) -> Result<(), AppError> {
     let lock = {
         let mut map = state.inflight.lock().map_err(AppError::internal)?;
         map.entry(target.to_path_buf())
@@ -636,10 +679,19 @@ async fn ensure_chapter(state: &AppState, target: &FsPath, regen: &Regen) -> Res
         let source = regen.source.clone();
         let out_dir = regen.out_dir.clone();
         let out_ext = regen.out_ext.clone();
-        let cut = regen.cut.clone();
+        let op = regen.op.clone();
         tokio::task::spawn_blocking(move || -> std::io::Result<()> {
             std::fs::create_dir_all(&out_dir)?;
-            split_chapter(&source, &out_dir, &cut, &out_ext).map_err(std::io::Error::other)?;
+            match op {
+                RegenOp::Chapter(cut) => {
+                    split_chapter(&source, &out_dir, &cut, &out_ext)
+                        .map_err(std::io::Error::other)?;
+                }
+                RegenOp::Faststart { idx, duration_sec } => {
+                    remux_faststart(&source, &out_dir, idx, &out_ext, duration_sec)
+                        .map_err(std::io::Error::other)?;
+                }
+            }
             Ok(())
         })
         .await

--- a/crates/http/tests/server.rs
+++ b/crates/http/tests/server.rs
@@ -162,7 +162,7 @@ async fn saver_mode_regenerates_a_chapter_on_demand() {
     let index = Index::open_in_memory().unwrap();
     let input = synth_three_chapters(&dir);
     // Ingest in `saver` mode: sizes recorded, split files deleted.
-    let book = scan_book_as(&input, "saverbook", &data, &index, false, true).unwrap();
+    let book = scan_book_as(&input, "saverbook", &data, &index, false, true, false).unwrap();
     let feed_id = book.feed_id.clone();
 
     let eps = index.episodes_for_book(&book.id).unwrap();
@@ -237,7 +237,7 @@ async fn saver_cache_evicts_over_the_size_cap() {
 
     let index = Index::open_in_memory().unwrap();
     let input = synth_three_chapters(&dir);
-    let book = scan_book_as(&input, "evictbook", &data, &index, false, true).unwrap();
+    let book = scan_book_as(&input, "evictbook", &data, &index, false, true, false).unwrap();
     let feed_id = book.feed_id.clone();
     let book_out = data.join("books").join(&book.id);
 
@@ -513,11 +513,14 @@ async fn in_place_source_on_a_chaptered_episode_is_rejected() {
         "a chaptered episode has no source_path"
     );
 
-    // Corrupt the row: mark chapter 1 as in-place pointing at the WHOLE container
-    // (under the library, so the library-root check passes). Its recorded
-    // byte_length is the chapter's size, not the container's — so the whole-file
-    // size invariant must reject it rather than serve the full container's bytes.
-    ep.source_path = input.canonicalize().unwrap().to_string_lossy().into_owned();
+    // Corrupt the row: mark chapter 1 as an in-place whole-file episode pointing at
+    // the WHOLE container (`file_path == source_path`, under the library so the
+    // library-root check passes). Its recorded byte_length is the chapter's size,
+    // not the container's — so the whole-file size invariant must reject it rather
+    // than serve the full container's bytes.
+    let container = input.canonicalize().unwrap().to_string_lossy().into_owned();
+    ep.source_path = container.clone();
+    ep.file_path = container;
     assert_ne!(
         ep.byte_length as u64,
         std::fs::metadata(&input).unwrap().len(),
@@ -549,6 +552,96 @@ async fn in_place_source_on_a_chaptered_episode_is_rejected() {
         StatusCode::NOT_FOUND,
         "a chaptered episode with a stray source_path must not serve the container"
     );
+
+    let _ = std::fs::remove_dir_all(&base);
+}
+
+#[tokio::test]
+async fn serves_a_remuxed_faststart_copy_on_demand() {
+    if !ffmpeg_available() {
+        eprintln!("skipping: ffmpeg not available");
+        return;
+    }
+    let base = std::env::temp_dir().join("podspine-http-remux");
+    let _ = std::fs::remove_dir_all(&base);
+    let library = base.join("library");
+    let data = base.join("data");
+    std::fs::create_dir_all(&library).unwrap();
+
+    let index = Index::open_in_memory().unwrap();
+    // A non-faststart m4a (moov at end) under the library. Ingest with remux ON.
+    let input = synth_flat(&library);
+    let book = scan_book_as(&input, "remuxbook", &data, &index, false, false, true).unwrap();
+    let feed_id = book.feed_id.clone();
+
+    // Recorded as a faststart cache episode: file_path (cache) != source_path, and
+    // the cache file was measured then deleted at ingest (regenerated on demand).
+    let eps = index.episodes_for_book(&book.id).unwrap();
+    assert_eq!(eps.len(), 1);
+    assert!(eps[0].needs_faststart);
+    assert_ne!(
+        eps[0].source_path, eps[0].file_path,
+        "remuxed: a cache copy, not in place"
+    );
+    assert!(std::path::Path::new(&eps[0].file_path).starts_with(&data));
+    assert!(
+        !std::path::Path::new(&eps[0].file_path).exists(),
+        "cache file deleted at ingest"
+    );
+    let recorded_len = eps[0].byte_length;
+
+    let state = AppState::new(
+        index,
+        "http://test".to_string(),
+        &data,
+        &library,
+        None,
+        false,
+        None,
+        None,
+    );
+    let app = router(state);
+
+    // First request regenerates the remux and serves it; the body matches the
+    // recorded enclosure length and is faststart (moov before mdat).
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::get(format!("/audio/{feed_id}/1"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_bytes(resp).await;
+    assert_eq!(
+        body.len() as i64,
+        recorded_len,
+        "served body matches the recorded enclosure length"
+    );
+    let find = |h: &[u8], n: &[u8]| h.windows(n.len()).position(|w| w == n);
+    assert!(
+        find(&body, b"moov") < find(&body, b"mdat"),
+        "the served copy is faststart (moov before mdat)"
+    );
+    assert!(
+        std::path::Path::new(&eps[0].file_path).exists(),
+        "the remux is now cached on disk"
+    );
+
+    // A Range request against the cached remux yields a 206 partial.
+    let resp = app
+        .oneshot(
+            Request::get(format!("/audio/{feed_id}/1"))
+                .header(header::RANGE, "bytes=0-9")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::PARTIAL_CONTENT);
+    assert_eq!(body_bytes(resp).await.len(), 10, "range served 10 bytes");
 
     let _ = std::fs::remove_dir_all(&base);
 }

--- a/crates/index/src/lib.rs
+++ b/crates/index/src/lib.rs
@@ -61,7 +61,8 @@ CREATE TABLE IF NOT EXISTS episode (
     duration_sec  REAL NOT NULL,
     start_sec     REAL NOT NULL,
     pubdate_epoch INTEGER NOT NULL,
-    source_path   TEXT NOT NULL DEFAULT ''
+    source_path   TEXT NOT NULL DEFAULT '',
+    needs_faststart INTEGER NOT NULL DEFAULT 0
 );
 CREATE INDEX IF NOT EXISTS episode_book_idx ON episode(book_id, idx);
 ";
@@ -101,15 +102,21 @@ pub struct EpisodeRow {
     pub idx: i64,
     /// Episode title.
     pub title: String,
-    /// Path to the served audio file. For an extracted (chaptered) episode this
-    /// is the split under `<data_dir>`; for a whole-file episode served in place
-    /// it is the original file in the read-only library (same as `source_path`).
+    /// Path to the served audio file. Extracted (chaptered) episode → the split
+    /// under `<data_dir>`. Whole-file episode served in place → the original
+    /// library file (`== source_path`). Whole-file episode remuxed to faststart
+    /// (Sprint 6.3) → the cache file under `<data_dir>` (`!= source_path`).
     pub file_path: String,
-    /// When non-empty, the episode IS a whole source file streamed in place from
-    /// the library (MP3-folder track, or a chapterless single file) — nothing is
-    /// copied under `<data_dir>`. Empty = an extracted sub-range served from
-    /// `<data_dir>` (`full`/`saver`). See TAD §5.3.
+    /// When non-empty, the episode IS a whole source file (MP3-folder track, or a
+    /// chapterless single file). `file_path == source_path` ⇒ streamed in place
+    /// from the library; `file_path != source_path` ⇒ remuxed to faststart and
+    /// cached under `<data_dir>`. Empty ⇒ an extracted sub-range (`full`/`saver`).
+    /// See TAD §5.3.
     pub source_path: String,
+    /// `true` when the source is a non-faststart MP4 (`moov` after `mdat`), so a
+    /// whole-file serve seeks slowly. Recorded at ingest; drives the callout and,
+    /// with `PODSPINE_REMUX_NON_FASTSTART` on, the remux-vs-in-place decision.
+    pub needs_faststart: bool,
     /// Real output size in bytes.
     pub byte_length: i64,
     /// Duration in seconds.
@@ -191,6 +198,19 @@ impl Index {
                 [],
             )?;
         }
+        // `needs_faststart` (faststart detection, Sprint 6.3). Existing rows
+        // default to `0`; a re-scan re-detects and records it per whole-file mp4.
+        let has_needs_faststart: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM pragma_table_info('episode') WHERE name = 'needs_faststart'",
+            [],
+            |r| r.get(0),
+        )?;
+        if has_needs_faststart == 0 {
+            conn.execute(
+                "ALTER TABLE episode ADD COLUMN needs_faststart INTEGER NOT NULL DEFAULT 0",
+                [],
+            )?;
+        }
         Ok(())
     }
 
@@ -228,13 +248,14 @@ impl Index {
     pub fn upsert_episode(&self, e: &EpisodeRow) -> Result<(), IndexError> {
         self.conn.execute(
             "INSERT INTO episode
-               (guid, book_id, idx, title, file_path, byte_length, duration_sec, start_sec, pubdate_epoch, source_path)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+               (guid, book_id, idx, title, file_path, byte_length, duration_sec, start_sec, pubdate_epoch, source_path, needs_faststart)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
              ON CONFLICT(guid) DO UPDATE SET
                book_id=excluded.book_id, idx=excluded.idx, title=excluded.title,
                file_path=excluded.file_path, byte_length=excluded.byte_length,
                duration_sec=excluded.duration_sec, start_sec=excluded.start_sec,
-               pubdate_epoch=excluded.pubdate_epoch, source_path=excluded.source_path",
+               pubdate_epoch=excluded.pubdate_epoch, source_path=excluded.source_path,
+               needs_faststart=excluded.needs_faststart",
             params![
                 e.guid,
                 e.book_id,
@@ -246,6 +267,7 @@ impl Index {
                 e.start_sec,
                 e.pubdate_epoch,
                 e.source_path,
+                e.needs_faststart,
             ],
         )?;
         Ok(())
@@ -290,7 +312,7 @@ impl Index {
     /// Episodes for a book, ordered by chapter index (chapter 1 first).
     pub fn episodes_for_book(&self, book_id: &str) -> Result<Vec<EpisodeRow>, IndexError> {
         let mut stmt = self.conn.prepare(
-            "SELECT guid, book_id, idx, title, file_path, byte_length, duration_sec, start_sec, pubdate_epoch, source_path
+            "SELECT guid, book_id, idx, title, file_path, byte_length, duration_sec, start_sec, pubdate_epoch, source_path, needs_faststart
              FROM episode WHERE book_id = ?1 ORDER BY idx",
         )?;
         let rows = stmt.query_map([book_id], episode_from_row)?;
@@ -337,7 +359,7 @@ impl Index {
         Ok(self
             .conn
             .query_row(
-                "SELECT guid, book_id, idx, title, file_path, byte_length, duration_sec, start_sec, pubdate_epoch, source_path
+                "SELECT guid, book_id, idx, title, file_path, byte_length, duration_sec, start_sec, pubdate_epoch, source_path, needs_faststart
                  FROM episode WHERE guid = ?1",
                 [guid],
                 episode_from_row,
@@ -372,6 +394,7 @@ fn episode_from_row(row: &Row) -> rusqlite::Result<EpisodeRow> {
         start_sec: row.get(7)?,
         pubdate_epoch: row.get(8)?,
         source_path: row.get(9)?,
+        needs_faststart: row.get(10)?,
     })
 }
 
@@ -401,6 +424,7 @@ mod tests {
             title: format!("Chapter {}", idx + 1),
             file_path: format!("/data/books/{book_id}/{:03}.m4a", idx + 1),
             source_path: String::new(),
+            needs_faststart: false,
             byte_length: 1000 + idx,
             duration_sec: 60.0 * (idx as f64 + 1.0),
             start_sec: 60.0 * (idx as f64),
@@ -547,6 +571,10 @@ mod tests {
         assert_eq!(
             eps[0].source_path, "",
             "migrated rows default to empty source_path (extracted, not in-place)"
+        );
+        assert!(
+            !eps[0].needs_faststart,
+            "migrated rows default to needs_faststart = false"
         );
         assert_eq!(
             idx.get_book_by_feed_id("cap-b1").unwrap().unwrap().id,

--- a/crates/prober/src/faststart.rs
+++ b/crates/prober/src/faststart.rs
@@ -1,0 +1,191 @@
+//! Faststart detection for whole-file MP4 (`.m4a`/`.m4b`) — pure byte parsing,
+//! **no ffprobe**.
+//!
+//! An MP4 seeks quickly only when its `moov` atom (the index) sits BEFORE the
+//! `mdat` payload ("faststart"); if `mdat` comes first, a player must read to the
+//! end of the file before it can seek. Podspine serves whole-file episodes in
+//! place (Sprint 6.2), so it detects this at ingest and can optionally remux to
+//! faststart (Sprint 6.3, `PODSPINE_REMUX_NON_FASTSTART`).
+//!
+//! Detection reads only the top-level box headers (seeking past each payload), so
+//! it touches a few dozen bytes regardless of file size, and never shells out.
+
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::Path;
+
+/// Upper bound on top-level boxes scanned, so a malformed or hostile file can't
+/// spin the loop. A real MP4 reaches `moov`/`mdat` within a handful of boxes.
+const MAX_BOXES: usize = 256;
+
+/// Whether `path` is a **non-faststart MP4** — i.e. it IS an MP4 (a `ftyp` box is
+/// present) and its `mdat` box precedes `moov`.
+///
+/// Returns `false` for a faststart MP4 (`moov` first), a non-MP4 (MP3/OGG/FLAC —
+/// no `ftyp`/`moov`/`mdat` boxes), or any read/parse error. Failing to `false` is
+/// deliberate: a file we can't classify is served in place unchanged, never
+/// remuxed on a guess.
+pub fn needs_faststart(path: &Path) -> bool {
+    scan(path).unwrap_or(false)
+}
+
+fn scan(path: &Path) -> std::io::Result<bool> {
+    let mut f = File::open(path)?;
+    let len = f.metadata()?.len();
+    let mut pos: u64 = 0;
+    let mut saw_ftyp = false;
+
+    for _ in 0..MAX_BOXES {
+        // Saturating, not `pos + 8`: a crafted 64-bit `largesize` can push `pos`
+        // near u64::MAX, and a plain add would overflow (panic under
+        // overflow-checks). Saturating breaks cleanly instead.
+        if pos.saturating_add(8) > len {
+            break;
+        }
+        f.seek(SeekFrom::Start(pos))?;
+        let mut hdr = [0u8; 8];
+        f.read_exact(&mut hdr)?;
+        let size32 = u32::from_be_bytes([hdr[0], hdr[1], hdr[2], hdr[3]]);
+        let kind = [hdr[4], hdr[5], hdr[6], hdr[7]];
+
+        // Box size field: 1 => a 64-bit largesize follows the type; 0 => the box
+        // runs to EOF (only ever the last box).
+        let box_size = match size32 {
+            1 => {
+                let mut ext = [0u8; 8];
+                f.read_exact(&mut ext)?;
+                u64::from_be_bytes(ext)
+            }
+            0 => len - pos,
+            n => u64::from(n),
+        };
+        if box_size < 8 {
+            break; // malformed header — give up (serve in place)
+        }
+
+        match &kind {
+            b"ftyp" => saw_ftyp = true,
+            // `moov` seen before any `mdat` => already faststart.
+            b"moov" => return Ok(false),
+            // `mdat` seen before `moov` => needs faststart, but only for a real
+            // MP4 (a stray `mdat`-like tag in a non-MP4 shouldn't trigger a remux).
+            b"mdat" => return Ok(saw_ftyp),
+            _ => {}
+        }
+
+        // Advance to the next top-level box; stop on overflow or a non-advancing
+        // size so a crafted file can't loop.
+        match pos.checked_add(box_size) {
+            Some(next) if next > pos => pos = next,
+            _ => break,
+        }
+    }
+    Ok(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a minimal MP4 box: `[u32 size][4-byte type][payload]`.
+    fn mp4_box(kind: &[u8; 4], payload: &[u8]) -> Vec<u8> {
+        let size = (8 + payload.len()) as u32;
+        let mut v = size.to_be_bytes().to_vec();
+        v.extend_from_slice(kind);
+        v.extend_from_slice(payload);
+        v
+    }
+
+    fn write(name: &str, chunks: &[Vec<u8>]) -> std::path::PathBuf {
+        let p = std::env::temp_dir().join(format!("podspine-faststart-{name}"));
+        let bytes: Vec<u8> = chunks.iter().flatten().copied().collect();
+        std::fs::write(&p, bytes).unwrap();
+        p
+    }
+
+    #[test]
+    fn moov_before_mdat_is_faststart() {
+        let p = write(
+            "fast",
+            &[
+                mp4_box(b"ftyp", b"M4A isom"),
+                mp4_box(b"moov", &[0u8; 16]),
+                mp4_box(b"mdat", &[0u8; 64]),
+            ],
+        );
+        assert!(!needs_faststart(&p), "moov-first mp4 is already faststart");
+        let _ = std::fs::remove_file(&p);
+    }
+
+    #[test]
+    fn mdat_before_moov_needs_faststart() {
+        let p = write(
+            "slow",
+            &[
+                mp4_box(b"ftyp", b"M4A isom"),
+                mp4_box(b"mdat", &[0u8; 64]),
+                mp4_box(b"moov", &[0u8; 16]),
+            ],
+        );
+        assert!(needs_faststart(&p), "mdat-first mp4 needs faststart");
+        let _ = std::fs::remove_file(&p);
+    }
+
+    #[test]
+    fn mdat_first_without_ftyp_is_not_treated_as_mp4() {
+        // No `ftyp` => not an MP4 we should touch, even if an `mdat`-like tag leads.
+        let p = write(
+            "nottyp",
+            &[mp4_box(b"mdat", &[0u8; 32]), mp4_box(b"moov", &[0u8; 8])],
+        );
+        assert!(!needs_faststart(&p));
+        let _ = std::fs::remove_file(&p);
+    }
+
+    #[test]
+    fn non_mp4_bytes_are_false() {
+        // MP3-ish / arbitrary leading bytes have no valid box structure.
+        let p = write(
+            "mp3ish",
+            &[b"ID3\x04\x00\x00\x00\x00\x00\x21rest-of-file".to_vec()],
+        );
+        assert!(!needs_faststart(&p));
+        let _ = std::fs::remove_file(&p);
+    }
+
+    #[test]
+    fn short_or_missing_file_is_false() {
+        let p = write("tiny", &[vec![0u8, 1, 2]]);
+        assert!(!needs_faststart(&p));
+        let _ = std::fs::remove_file(&p);
+        assert!(!needs_faststart(std::path::Path::new(
+            "/nonexistent/podspine/faststart"
+        )));
+    }
+
+    #[test]
+    fn a_crafted_64bit_largesize_box_does_not_overflow() {
+        // First box: size32 == 1 (a 64-bit largesize follows the type), type
+        // "free", largesize near u64::MAX. Advancing `pos` by it must not overflow
+        // the `pos + 8` guard (would panic under overflow-checks); returns false.
+        let mut bytes = 1u32.to_be_bytes().to_vec(); // size32 = 1
+        bytes.extend_from_slice(b"free");
+        bytes.extend_from_slice(&(u64::MAX - 4).to_be_bytes()); // largesize
+        let p = write("largesize", &[bytes]);
+        assert!(!needs_faststart(&p));
+        let _ = std::fs::remove_file(&p);
+    }
+
+    #[test]
+    fn a_zero_size_box_does_not_loop() {
+        // size32 == 0 means "to EOF"; must terminate, not spin.
+        let mut bytes = mp4_box(b"ftyp", b"isom");
+        bytes.extend_from_slice(&0u32.to_be_bytes()); // size 0
+        bytes.extend_from_slice(b"free");
+        bytes.extend_from_slice(&[0u8; 16]);
+        let p = write("zerobox", &[bytes]);
+        // free-to-EOF with no moov/mdat => false, and returns promptly.
+        assert!(!needs_faststart(&p));
+        let _ = std::fs::remove_file(&p);
+    }
+}

--- a/crates/prober/src/lib.rs
+++ b/crates/prober/src/lib.rs
@@ -21,6 +21,9 @@
 use std::path::Path;
 use std::process::Command;
 
+mod faststart;
+pub use faststart::needs_faststart;
+
 /// One embedded chapter, with times already resolved to seconds.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Chapter {

--- a/crates/scanner/src/lib.rs
+++ b/crates/scanner/src/lib.rs
@@ -33,9 +33,9 @@ use std::time::UNIX_EPOCH;
 
 use podspine_feed::{episode_guid, pubdate_epoch};
 use podspine_index::{BookRow, EpisodeRow, Index, IndexError};
-use podspine_prober::{ProbeError, probe};
+use podspine_prober::{ProbeError, needs_faststart, probe};
 use podspine_splitter::{
-    ChapterCut, SplitEpisode, SplitError, extract_cover, split_book, split_chapter,
+    ChapterCut, SplitEpisode, SplitError, extract_cover, remux_faststart, split_book, split_chapter,
 };
 
 /// Extensions we refuse to ingest (DRM). Matched case-insensitively.
@@ -84,7 +84,7 @@ pub enum ScanError {
 /// name. Convenience wrapper over [`scan_book_as`] for single-book callers.
 pub fn scan_book(input: &Path, data_dir: &Path, index: &Index) -> Result<BookRow, ScanError> {
     let id = slugify(&file_stem(input));
-    scan_book_as(input, &id, data_dir, index, false, false)
+    scan_book_as(input, &id, data_dir, index, false, false, false)
 }
 
 /// Scan one audiobook `input` into `index` under the explicit `id` (also used as
@@ -107,6 +107,7 @@ pub fn scan_book_as(
     index: &Index,
     force_embedded: bool,
     saver: bool,
+    remux_non_faststart: bool,
 ) -> Result<BookRow, ScanError> {
     if !input.is_file() {
         return Err(ScanError::NotAFile(input.to_path_buf()));
@@ -144,10 +145,25 @@ pub fn scan_book_as(
         // starts at 0, so only non-first chapters are checked.
         let start_secs_recorded =
             !saver || eps.iter().filter(|e| e.idx > 0).all(|e| e.start_sec > 0.0);
-        if !eps.is_empty()
-            && start_secs_recorded
-            && (saver || eps.iter().all(|e| Path::new(&e.file_path).exists()))
-        {
+        // Faststart re-ingest guard (Sprint 6.3): if PODSPINE_REMUX_NON_FASTSTART
+        // was toggled since the last scan, a `needs_faststart` whole-file episode's
+        // recorded serve mode (in place ⇒ `file_path == source_path`; remuxed ⇒
+        // `file_path != source_path`) no longer matches the flag — re-ingest so
+        // `byte_length`/`file_path` are re-recorded for the current mode.
+        let faststart_consistent = eps.iter().all(|e| {
+            !e.needs_faststart
+                || e.source_path.is_empty()
+                || (e.file_path != e.source_path) == remux_non_faststart
+        });
+        // An episode's file may legitimately be absent when it's regenerated on
+        // demand: a saver chapter, or a remuxed whole-file cache copy. Everything
+        // else (full chapters, in-place whole files) must be present on disk.
+        let files_present = eps.iter().all(|e| {
+            let regenerable = (saver && e.source_path.is_empty())
+                || (!e.source_path.is_empty() && e.file_path != e.source_path);
+            regenerable || Path::new(&e.file_path).exists()
+        });
+        if !eps.is_empty() && start_secs_recorded && faststart_consistent && files_present {
             return Ok(existing);
         }
     }
@@ -202,23 +218,53 @@ pub fn scan_book_as(
     let cuts: Vec<ChapterCut> = specs.iter().map(|(cut, _)| cut.clone()).collect();
     // Stream-copy into a container matching the source codec (Task 3.9).
     let out_ext = output_ext(probed.audio_codec.as_deref());
+    // Set for the single whole-file episode below; chaptered episodes never need
+    // faststart (`split_chapter` already writes `moov`-first).
+    let mut needs_ft = false;
     let episodes = if serve_in_place {
-        // Whole source file: stream it in place from the read-only library. No
-        // ffmpeg, no copy under <data_dir>; the enclosure length is the real
-        // source size. Reclaim any per-episode copy a pre-6.2 ingest left behind.
+        // Whole source file. Reclaim any per-episode copy a pre-6.2 ingest left.
         remove_stale_episode_copies(&book_out);
-        let byte_length = std::fs::metadata(input)
-            .map_err(|source| ScanError::Io {
-                path: input.to_path_buf(),
+        // Faststart (Sprint 6.3): a non-faststart whole-file mp4 (`moov` after
+        // `mdat`) seeks slowly when streamed in place. Detect it ffmpeg-free.
+        needs_ft = needs_faststart(input);
+        if needs_ft && remux_non_faststart {
+            // Opt-in remux: write a faststart cache copy (byte-deterministic
+            // `-c copy`), measure it, then delete — the http layer regenerates it
+            // on demand and evicts it under the cache cap. The source is untouched.
+            std::fs::create_dir_all(&book_out).map_err(|source| ScanError::Io {
+                path: book_out.clone(),
                 source,
-            })?
-            .len();
-        vec![SplitEpisode {
-            idx: 0,
-            path: input.to_path_buf(),
-            byte_length,
-            duration_sec: probed.duration_sec,
-        }]
+            })?;
+            let ep = remux_faststart(input, &book_out, 0, out_ext, probed.duration_sec)?;
+            std::fs::remove_file(&ep.path).map_err(|source| ScanError::Io {
+                path: ep.path.clone(),
+                source,
+            })?;
+            vec![ep]
+        } else {
+            // Serve in place from the read-only library — no ffmpeg, no copy; the
+            // enclosure length is the real source size. A non-faststart mp4 still
+            // plays, so just log a one-line callout naming the (opt-in) fix.
+            if needs_ft {
+                tracing::warn!(
+                    id = %id,
+                    book = %file_stem(input),
+                    "non-faststart MP4 (moov after mdat): plays but seeks slowly. Set PODSPINE_REMUX_NON_FASTSTART=true to remux it to faststart."
+                );
+            }
+            let byte_length = std::fs::metadata(input)
+                .map_err(|source| ScanError::Io {
+                    path: input.to_path_buf(),
+                    source,
+                })?
+                .len();
+            vec![SplitEpisode {
+                idx: 0,
+                path: input.to_path_buf(),
+                byte_length,
+                duration_sec: probed.duration_sec,
+            }]
+        }
     } else if saver {
         // Split each chapter to record its real byte size, then delete it — the
         // http layer regenerates on demand (deterministic stream-copy, so the
@@ -276,13 +322,17 @@ pub fn scan_book_as(
             idx: ep.idx as i64,
             title: title.clone(),
             file_path: ep.path.to_string_lossy().into_owned(),
-            // Non-empty only for a whole-file episode served in place; empty for
-            // an extracted chapter served from <data_dir>.
+            // Non-empty for a whole-file episode (source path); empty for an
+            // extracted chapter under <data_dir>. `file_path == source_path` ⇒
+            // in place, `file_path != source_path` ⇒ remuxed to the faststart cache.
             source_path: if serve_in_place {
                 input.to_string_lossy().into_owned()
             } else {
                 String::new()
             },
+            // Only ever true for the single whole-file episode; drives the http
+            // remux-vs-in-place decision + the toggle guard above.
+            needs_faststart: needs_ft,
             byte_length: ep.byte_length as i64,
             duration_sec: ep.duration_sec,
             start_sec: cut.start_sec,
@@ -430,6 +480,8 @@ fn scan_mp3_folder(
             file_path: t.path.to_string_lossy().into_owned(),
             // A folder track IS a whole source file — stream it in place.
             source_path: t.path.to_string_lossy().into_owned(),
+            // MP3 has no `moov` atom, so faststart never applies.
+            needs_faststart: false,
             byte_length: byte_length as i64,
             duration_sec: t.duration_sec,
             // Whole files (not sub-ranges of a container), so each starts at 0.
@@ -534,6 +586,7 @@ pub fn scan_library(
     index: &Index,
     force_embedded: bool,
     saver: bool,
+    remux_non_faststart: bool,
 ) -> ScanSummary {
     let sources = discover(library);
 
@@ -545,7 +598,15 @@ pub fn scan_library(
         let slug = unique_slug(&slugify(&source.base_name()), &mut seen);
         match source {
             BookSource::File(path) => {
-                match scan_book_as(&path, &slug, data_dir, index, force_embedded, saver) {
+                match scan_book_as(
+                    &path,
+                    &slug,
+                    data_dir,
+                    index,
+                    force_embedded,
+                    saver,
+                    remux_non_faststart,
+                ) {
                     Ok(book) => {
                         summary.indexed += 1;
                         tracing::info!(slug = %book.slug, title = %book.title, "indexed book");
@@ -625,8 +686,16 @@ pub fn reconcile(
     index: &Index,
     force_embedded: bool,
     saver: bool,
+    remux_non_faststart: bool,
 ) -> ScanSummary {
-    let mut summary = scan_library(library, data_dir, index, force_embedded, saver);
+    let mut summary = scan_library(
+        library,
+        data_dir,
+        index,
+        force_embedded,
+        saver,
+        remux_non_faststart,
+    );
     summary.pruned = prune_orphans(library, data_dir, index).unwrap_or_else(|err| {
         tracing::warn!(error = %err, "orphan prune failed");
         0
@@ -652,9 +721,17 @@ pub fn spawn_library_watcher(
     db_path: PathBuf,
     force_embedded: bool,
     saver: bool,
+    remux_non_faststart: bool,
 ) {
     std::thread::spawn(move || {
-        if let Err(err) = watch_loop(&library, &data_dir, &db_path, force_embedded, saver) {
+        if let Err(err) = watch_loop(
+            &library,
+            &data_dir,
+            &db_path,
+            force_embedded,
+            saver,
+            remux_non_faststart,
+        ) {
             tracing::error!(error = %err, "library watcher stopped — auto-refresh disabled");
         }
     });
@@ -666,6 +743,7 @@ fn watch_loop(
     db_path: &Path,
     force_embedded: bool,
     saver: bool,
+    remux_non_faststart: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use notify::{RecursiveMode, Watcher};
 
@@ -683,7 +761,14 @@ fn watch_loop(
     while rx.recv().is_ok() {
         while rx.recv_timeout(WATCH_DEBOUNCE).is_ok() {}
         tracing::info!("library changed — reconciling");
-        let s = reconcile(library, data_dir, &index, force_embedded, saver);
+        let s = reconcile(
+            library,
+            data_dir,
+            &index,
+            force_embedded,
+            saver,
+            remux_non_faststart,
+        );
         tracing::info!(
             indexed = s.indexed,
             skipped = s.skipped,
@@ -992,7 +1077,7 @@ mod tests {
 
         let data = root.join("data");
         let index = Index::open_in_memory().unwrap();
-        let summary = scan_library(&root, &data, &index, false, false);
+        let summary = scan_library(&root, &data, &index, false, false, false);
         assert_eq!(summary.indexed, 1);
         assert_eq!(summary.skipped, 0);
 
@@ -1057,7 +1142,10 @@ mod tests {
 
         let data = root.join("data");
         let index = Index::open_in_memory().unwrap();
-        assert_eq!(scan_library(&root, &data, &index, false, false).indexed, 1);
+        assert_eq!(
+            scan_library(&root, &data, &index, false, false, false).indexed,
+            1
+        );
         let books = index.list_books().unwrap();
         let eps = index.episodes_for_book(&books[0].id).unwrap();
         assert_eq!(eps.len(), 2);
@@ -1096,7 +1184,7 @@ mod tests {
         // force_embedded ignores the sidecar -> back to 3 embedded chapters.
         let data2 = dir.join("data2");
         let index2 = Index::open_in_memory().unwrap();
-        let book2 = scan_book_as(&input, "forced", &data2, &index2, true, false).unwrap();
+        let book2 = scan_book_as(&input, "forced", &data2, &index2, true, false, false).unwrap();
         assert_eq!(
             index2.episodes_for_book(&book2.id).unwrap().len(),
             3,
@@ -1119,7 +1207,7 @@ mod tests {
         let data = dir.join("data");
         let index = Index::open_in_memory().unwrap();
 
-        let book = scan_book_as(&input, "saver-book", &data, &index, false, true).unwrap();
+        let book = scan_book_as(&input, "saver-book", &data, &index, false, true, false).unwrap();
         let eps = index.episodes_for_book(&book.id).unwrap();
         assert_eq!(eps.len(), 3);
         for (i, e) in eps.iter().enumerate() {
@@ -1142,7 +1230,7 @@ mod tests {
 
         // Idempotent: re-scanning at the same mtime is a no-op despite the files
         // being absent (the index entry alone satisfies the check in saver mode).
-        let again = scan_book_as(&input, "saver-book", &data, &index, false, true).unwrap();
+        let again = scan_book_as(&input, "saver-book", &data, &index, false, true, false).unwrap();
         assert_eq!(again.id, book.id);
 
         let _ = std::fs::remove_dir_all(&dir);
@@ -1162,7 +1250,7 @@ mod tests {
         let index = Index::open_in_memory().unwrap();
 
         // A normal full-mode ingest first: files on disk, real offsets recorded.
-        let book = scan_book_as(&input, "mig", &data, &index, false, false).unwrap();
+        let book = scan_book_as(&input, "mig", &data, &index, false, false, false).unwrap();
         let eps = index.episodes_for_book(&book.id).unwrap();
         assert!(
             eps.iter().any(|e| e.start_sec > 0.0),
@@ -1178,7 +1266,7 @@ mod tests {
 
         // Re-scan at the SAME mtime in saver mode. The zeroed non-first chapters
         // must force a one-time re-split, not an idempotent skip.
-        let book2 = scan_book_as(&input, "mig", &data, &index, false, true).unwrap();
+        let book2 = scan_book_as(&input, "mig", &data, &index, false, true, false).unwrap();
         assert_eq!(book2.id, book.id);
         let eps2 = index.episodes_for_book(&book.id).unwrap();
         assert!(
@@ -1419,7 +1507,7 @@ mod tests {
 
         let data = root.join("data");
         let index = Index::open_in_memory().unwrap();
-        let summary = scan_library(&root, &data, &index, false, false);
+        let summary = scan_library(&root, &data, &index, false, false, false);
 
         assert_eq!(summary.indexed, 2, "both books indexed");
         assert_eq!(summary.skipped, 0);
@@ -1448,7 +1536,7 @@ mod tests {
 
         let data = root.join("data");
         let index = Index::open_in_memory().unwrap();
-        let summary = scan_library(&root, &data, &index, false, false);
+        let summary = scan_library(&root, &data, &index, false, false, false);
 
         assert_eq!(summary.indexed, 1, "only the good book");
         assert_eq!(summary.skipped, 2, "unprobeable file + MP3 folder skipped");
@@ -1523,6 +1611,148 @@ mod tests {
     }
 
     #[test]
+    fn non_faststart_single_file_is_flagged_and_optionally_remuxed() {
+        if !ffmpeg_available() {
+            eprintln!("skipping: ffmpeg not available");
+            return;
+        }
+        let dir = scratch("faststart");
+        // ffmpeg's mp4 muxer writes `moov` at the END by default → non-faststart.
+        let input = synth(&dir, false);
+        assert!(
+            needs_faststart(&input),
+            "precondition: synthesized m4a is non-faststart"
+        );
+        let input_c = input.canonicalize().unwrap();
+
+        // remux OFF (default): flagged, but still streamed in place.
+        {
+            let data = dir.join("data-off");
+            let index = Index::open_in_memory().unwrap();
+            let book = scan_book_as(&input, "ft", &data, &index, false, false, false).unwrap();
+            let eps = index.episodes_for_book(&book.id).unwrap();
+            assert!(eps[0].needs_faststart, "non-faststart mp4 flagged");
+            assert_eq!(
+                eps[0].source_path, eps[0].file_path,
+                "served in place when remux is off"
+            );
+            assert_eq!(
+                eps[0].byte_length as u64,
+                std::fs::metadata(&input).unwrap().len()
+            );
+        }
+
+        // remux ON: remuxed to a faststart cache file under the data dir; measured
+        // then deleted at ingest (regenerated on demand, like a saver chapter).
+        {
+            let data = dir.join("data-on");
+            let index = Index::open_in_memory().unwrap();
+            let book = scan_book_as(&input, "ft", &data, &index, false, false, true).unwrap();
+            let eps = index.episodes_for_book(&book.id).unwrap();
+            assert!(eps[0].needs_faststart);
+            assert_ne!(
+                eps[0].source_path, eps[0].file_path,
+                "remuxed: file_path is the cache copy, not the source"
+            );
+            assert_eq!(eps[0].source_path, input_c.to_string_lossy());
+            assert!(
+                Path::new(&eps[0].file_path).starts_with(&data),
+                "cache under data dir"
+            );
+            assert!(eps[0].byte_length > 0);
+            assert!(
+                !Path::new(&eps[0].file_path).exists(),
+                "measured then deleted for on-demand regen"
+            );
+        }
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn faststart_single_file_is_never_remuxed() {
+        if !ffmpeg_available() {
+            eprintln!("skipping: ffmpeg not available");
+            return;
+        }
+        let dir = scratch("faststart-ok");
+        std::fs::create_dir_all(&dir).unwrap();
+        let input = dir.join("fast.m4a");
+        let ok = Command::new("ffmpeg")
+            .args([
+                "-y",
+                "-loglevel",
+                "error",
+                "-f",
+                "lavfi",
+                "-i",
+                "sine=frequency=300:duration=3",
+                "-c:a",
+                "aac",
+                "-movflags",
+                "+faststart",
+            ])
+            .arg(&input)
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if !ok {
+            eprintln!("skipping: no aac encoder");
+            return;
+        }
+        assert!(!needs_faststart(&input), "precondition: file is faststart");
+
+        // Even with remux ON, a faststart mp4 is served in place (nothing to fix).
+        let data = dir.join("data");
+        let index = Index::open_in_memory().unwrap();
+        let book = scan_book_as(&input, "ok", &data, &index, false, false, true).unwrap();
+        let eps = index.episodes_for_book(&book.id).unwrap();
+        assert!(!eps[0].needs_faststart);
+        assert_eq!(
+            eps[0].source_path, eps[0].file_path,
+            "faststart mp4 is not remuxed"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn toggling_remux_flag_reingests_the_episode() {
+        if !ffmpeg_available() {
+            eprintln!("skipping: ffmpeg not available");
+            return;
+        }
+        let dir = scratch("faststart-toggle");
+        let input = synth(&dir, false); // non-faststart m4a
+        let data = dir.join("data");
+        let index = Index::open_in_memory().unwrap();
+
+        // remux OFF → in place.
+        scan_book_as(&input, "t", &data, &index, false, false, false).unwrap();
+        let e1 = index.episodes_for_book("t").unwrap();
+        assert_eq!(e1[0].source_path, e1[0].file_path, "remux off → in place");
+
+        // Same mtime, flag flipped ON: the faststart toggle guard forces a
+        // re-ingest instead of the idempotent early return.
+        scan_book_as(&input, "t", &data, &index, false, false, true).unwrap();
+        let e2 = index.episodes_for_book("t").unwrap();
+        assert_ne!(
+            e2[0].source_path, e2[0].file_path,
+            "remux on → served from the cache copy"
+        );
+
+        // Flip back OFF: re-ingest again, back to in place.
+        scan_book_as(&input, "t", &data, &index, false, false, false).unwrap();
+        let e3 = index.episodes_for_book("t").unwrap();
+        assert_eq!(
+            e3[0].source_path, e3[0].file_path,
+            "remux off again → in place"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
     fn chapterless_file_becomes_a_single_episode() {
         if !ffmpeg_available() {
             eprintln!("skipping: ffmpeg not available");
@@ -1571,14 +1801,14 @@ mod tests {
         let data = root.join("data");
         let index = Index::open_in_memory().unwrap();
 
-        scan_library(&root, &data, &index, false, false);
+        scan_library(&root, &data, &index, false, false, false);
         let id = index.list_books().unwrap()[0].id.clone();
         let first = index.episodes_for_book(&id).unwrap();
         assert!(first.iter().all(|e| !e.source_path.is_empty()));
 
         // Re-scan the unchanged folder: the `source_path` idempotency guard takes
         // the early return — episodes are unchanged and still served in place.
-        scan_library(&root, &data, &index, false, false);
+        scan_library(&root, &data, &index, false, false, false);
         let second = index.episodes_for_book(&id).unwrap();
         assert_eq!(first.len(), second.len());
         for (x, y) in first.iter().zip(&second) {
@@ -1644,7 +1874,7 @@ mod tests {
         std::fs::rename(&b, root.join("beta.m4a")).unwrap();
         let index = Index::open_in_memory().unwrap();
 
-        scan_library(&root, &data, &index, false, false);
+        scan_library(&root, &data, &index, false, false, false);
         assert_eq!(index.list_books().unwrap().len(), 2);
         let beta_out = data.join("books").join("beta");
         assert!(beta_out.exists(), "beta was split");
@@ -1670,7 +1900,7 @@ mod tests {
             return;
         }
         let (root, data, index) = two_book_library("prune-guard");
-        scan_library(&root, &data, &index, false, false);
+        scan_library(&root, &data, &index, false, false, false);
         assert_eq!(index.list_books().unwrap().len(), 2);
 
         // Simulate an unmount: every source vanishes and the root goes empty.
@@ -1698,13 +1928,13 @@ mod tests {
         let (root, data, index) = two_book_library("reconcile");
 
         // First pass indexes both, prunes none.
-        let s = reconcile(&root, &data, &index, false, false);
+        let s = reconcile(&root, &data, &index, false, false, false);
         assert_eq!(index.list_books().unwrap().len(), 2);
         assert_eq!(s.pruned, 0);
 
         // Remove one source, reconcile again -> it is pruned.
         std::fs::remove_file(root.join("beta.m4a")).unwrap();
-        let s = reconcile(&root, &data, &index, false, false);
+        let s = reconcile(&root, &data, &index, false, false, false);
         assert_eq!(s.pruned, 1);
         let books = index.list_books().unwrap();
         assert_eq!(books.len(), 1);

--- a/crates/splitter/src/lib.rs
+++ b/crates/splitter/src/lib.rs
@@ -393,6 +393,77 @@ pub fn split_chapter(
     })
 }
 
+/// Remux a whole (chapterless) MP4 to **faststart** — stream-copied, `moov`
+/// relocated to the front — so podcast clients seek immediately. Serves a
+/// non-faststart whole-file episode from the cache when `PODSPINE_REMUX_NON_FASTSTART`
+/// is on (Sprint 6.3); the source is never touched. Like [`split_chapter`] it is a
+/// deterministic `-c copy`, so the output size is a stable `enclosure length`.
+/// `idx`/`out_ext` name the cache file (`NNN.<ext>`); `duration_sec` is the whole
+/// file's duration (the enclosure duration, carried through unchanged).
+pub fn remux_faststart(
+    input: &Path,
+    out_dir: &Path,
+    idx: usize,
+    out_ext: &str,
+    duration_sec: f64,
+) -> Result<SplitEpisode, SplitError> {
+    let out_path = out_dir.join(format!("{:03}.{out_ext}", idx + 1));
+    let args = build_remux_args(input, &out_path);
+
+    match run_ffmpeg(&args) {
+        Ok(()) => {}
+        Err(RunError::Spawn(e)) => return Err(SplitError::Spawn(e)),
+        Err(RunError::Failed { code, stderr }) => {
+            return Err(SplitError::Ffmpeg { idx, code, stderr });
+        }
+        Err(RunError::TimedOut) => return Err(SplitError::TimedOut { idx }),
+    }
+
+    // enclosure length MUST come from the real file, never prorated.
+    let byte_length = fs::metadata(&out_path)
+        .map_err(|source| SplitError::Metadata {
+            path: out_path.clone(),
+            source,
+        })?
+        .len();
+    if byte_length == 0 {
+        return Err(SplitError::OutputMissing {
+            idx,
+            path: out_path,
+        });
+    }
+
+    Ok(SplitEpisode {
+        idx,
+        path: out_path,
+        byte_length,
+        duration_sec,
+    })
+}
+
+/// argv for a whole-file faststart remux: keep audio only, drop chapters, copy
+/// codecs (no re-encode), relocate `moov`. No `-ss`/`-t` — the whole file. An
+/// argument vector, never a shell string (untrusted paths).
+fn build_remux_args(input: &Path, output: &Path) -> Vec<OsString> {
+    vec![
+        "-nostdin".into(),
+        "-y".into(),
+        "-loglevel".into(),
+        "error".into(),
+        "-i".into(),
+        input.as_os_str().to_os_string(),
+        "-map".into(),
+        "0:a:0".into(),
+        "-map_chapters".into(),
+        "-1".into(),
+        "-c".into(),
+        "copy".into(),
+        "-movflags".into(),
+        "+faststart".into(),
+        output.as_os_str().to_os_string(),
+    ]
+}
+
 /// Build the exact ffmpeg argv for a stream-copy chapter cut.
 ///
 /// Factored out so the ordering invariants (`-ss` before `-i`, `-t` not `-to`,
@@ -526,6 +597,27 @@ mod tests {
     }
 
     #[test]
+    fn remux_args_are_whole_file_copy_faststart() {
+        let args: Vec<String> = build_remux_args(Path::new("in.m4b"), Path::new("out/001.m4b"))
+            .iter()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        let pair = |a: &str, b: &str| args.windows(2).any(|w| w[0] == a && w[1] == b);
+        assert!(pair("-c", "copy"), "stream copy, no re-encode");
+        assert!(
+            pair("-movflags", "+faststart"),
+            "relocates moov to the front"
+        );
+        assert!(pair("-map", "0:a:0"), "audio only");
+        assert!(pair("-map_chapters", "-1"), "drops chapters");
+        assert!(
+            !args.iter().any(|a| a == "-ss" || a == "-t"),
+            "whole file — no seek/duration cut"
+        );
+        assert_eq!(args.last().unwrap(), "out/001.m4b", "output path is last");
+    }
+
+    #[test]
     fn cover_args_copy_first_video_stream_to_named_output() {
         let args: Vec<String> = build_cover_args(Path::new("in.m4b"), Path::new("out/cover.jpg"))
             .iter()
@@ -649,6 +741,71 @@ mod tests {
         let err = split_book(&bad, &dir.join("out"), std::slice::from_ref(&ch), "m4a")
             .expect_err("bad input must fail");
         assert!(matches!(err, SplitError::Ffmpeg { idx: 0, .. }), "{err:?}");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn remux_faststart_produces_a_deterministic_faststart_file() {
+        if !have_ffmpeg() {
+            eprintln!("skipping: ffmpeg not available");
+            return;
+        }
+        let dir = std::env::temp_dir().join("podspine-remux-ft");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        // ffmpeg's mp4 muxer writes `moov` at the END unless +faststart is asked,
+        // so a plain encode gives us a non-faststart source.
+        let src = dir.join("src.m4a");
+        let ok = Command::new("ffmpeg")
+            .args([
+                "-y",
+                "-loglevel",
+                "error",
+                "-f",
+                "lavfi",
+                "-i",
+                "sine=frequency=300:duration=3",
+                "-c:a",
+                "aac",
+            ])
+            .arg(&src)
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if !ok {
+            eprintln!("skipping: no aac encoder");
+            return;
+        }
+
+        let out = dir.join("out");
+        std::fs::create_dir_all(&out).unwrap();
+        let ep = remux_faststart(&src, &out, 0, "m4a", 3.0).unwrap();
+        assert_eq!(ep.idx, 0);
+        assert_eq!(ep.duration_sec, 3.0);
+        assert!(ep.byte_length > 0);
+        assert_eq!(ep.path, out.join("001.m4a"));
+
+        // The output is faststart: `moov` now precedes `mdat` in the byte stream.
+        let find = |hay: &[u8], n: &[u8]| hay.windows(n.len()).position(|w| w == n);
+        let bytes = std::fs::read(&ep.path).unwrap();
+        let (moov, mdat) = (find(&bytes, b"moov"), find(&bytes, b"mdat"));
+        assert!(
+            moov.is_some() && mdat.is_some() && moov < mdat,
+            "moov must precede mdat (faststart)"
+        );
+
+        // Byte-deterministic: a second remux is identical, so the recorded
+        // enclosure length stays valid across cache eviction + regeneration.
+        let out2 = dir.join("out2");
+        std::fs::create_dir_all(&out2).unwrap();
+        let ep2 = remux_faststart(&src, &out2, 0, "m4a", 3.0).unwrap();
+        assert_eq!(ep.byte_length, ep2.byte_length);
+        assert_eq!(
+            std::fs::read(&ep.path).unwrap(),
+            std::fs::read(&ep2.path).unwrap(),
+            "remux is byte-identical run-to-run"
+        );
+
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -82,7 +82,11 @@ depends on whether it is a whole source file or a sub-range of a container:
   is **served in place** from the read-only library (Sprint 6.2). Its
   `episode.source_path` records the library file; nothing is copied under
   `<data_dir>`, and the audio handler streams it (with Range) after asserting the
-  path stays under the canonical library root.
+  path stays under the canonical library root. If it's a non-faststart mp4
+  (`moov` after `mdat`, flagged `episode.needs_faststart` at ingest) and
+  `PODSPINE_REMUX_NON_FASTSTART` is on, the handler instead serves a faststart
+  **remux** regenerated on demand into the cache (`file_path != source_path`) —
+  Sprint 6.3; otherwise it logs a callout and serves in place.
 - **Chaptered episode** — a sub-range of a container — must be **extracted** under
   `<data_dir>` (a raw byte range of an `.m4b` isn't a standalone file). In `full`
   mode (default) every chapter is pre-split at ingest and kept; in `saver` mode

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -26,6 +26,7 @@ that precedence. The library path is the only required input.
 | `--storage-mode` | `PODSPINE_STORAGE_MODE` | `full` | `full` keeps every chapter split on disk; `saver` still splits once at ingest but caches on demand. See below. |
 | `--cache-size` | `PODSPINE_CACHE_SIZE` | `2GB` | `saver` only: cache cap (`2GB`, `500MB`; `0`/`off` = unbounded). |
 | `--cache-ttl` | `PODSPINE_CACHE_TTL` | off | `saver` only: evict chapters unplayed this long (`30d`, `12h`; `off` = size-only). |
+| `--remux-non-faststart` | `PODSPINE_REMUX_NON_FASTSTART` | off | Remux a non-faststart whole-file mp4 to faststart on demand (cache-managed). See below. |
 | `--config` | `PODSPINE_CONFIG` | none | Path to a TOML config file. |
 
 > **`PODSPINE_BASE_URL` is the one that bites people.** Feed and enclosure (audio)
@@ -79,6 +80,21 @@ cache cap (`PODSPINE_CACHE_SIZE`) rather than a second copy of every book.
 is cheap and you want every play to start instantly. Either way you only need to
 size `--data-dir` for your chaptered books — whole-file books add essentially
 nothing beyond their index rows and covers.
+
+### Faststart for whole-file mp4
+
+A whole-file `.m4a`/`.m4b` served in place plays fine but can **seek slowly** if
+its `moov` atom (the index) sits after the audio ("non-faststart"). Podspine
+detects this at ingest (a quick header read, no ffmpeg) and logs a one-line
+callout naming the book. MP3/OGG/FLAC and chaptered books are never affected (a
+chaptered episode is already written moov-first).
+
+Set `PODSPINE_REMUX_NON_FASTSTART=true` to fix it automatically: such a book is
+**remuxed to faststart on demand** — a stream-copy (no re-encode) served from the
+`saver` cache, evicted and regenerated under `PODSPINE_CACHE_SIZE` like any cached
+chapter, **not** a pinned second copy. The default is **off** because in-place
+serving costs no disk; enable it if slow seeking on those books bothers you and
+you can spare the cache. (A faststart mp4, or any non-mp4, is left untouched.)
 
 ## Exposing Podspine safely
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ async fn main() -> Result<()> {
         &index,
         config.force_embedded_chapters,
         saver,
+        config.remux_non_faststart,
     );
 
     // Auto-refresh: a background thread (its own WAL index connection) re-runs the
@@ -43,6 +44,7 @@ async fn main() -> Result<()> {
         db_path,
         config.force_embedded_chapters,
         saver,
+        config.remux_non_faststart,
     );
 
     let state = AppState::new(


### PR DESCRIPTION
Sprint 6, Task 6.3 — the last piece of the storage/serving trilogy (after #59 serve-in-place).

A whole-file `.m4a`/`.m4b` served in place (6.2) plays fine but **seeks slowly** if its `moov` atom sits after `mdat` (non-faststart). This detects that at ingest and, optionally, remuxes to faststart on demand.

## How it works
- **prober** `needs_faststart` — ffmpeg-free parse of the top-level MP4 boxes (is `mdat` before `moov`?). Bounded loop, saturating pointer math, any read/parse error → `false`. MP3/OGG/FLAC (no `ftyp`) and already-faststart mp4 → `false`.
- **index** — `episode.needs_faststart` column (additive migration).
- **splitter** `remux_faststart` — whole-file `-map 0:a:0 -c copy -movflags +faststart` (argv vector, no re-encode); byte-deterministic, so its size is a stable enclosure length.
- **config** — `PODSPINE_REMUX_NON_FASTSTART` (default **off**).
- **scanner** — detects at ingest. **Off** → serve in place + a one-line callout naming the book + the fix. **On** → remux→measure→delete, regenerated on demand. A re-ingest guard flips a book when the flag is toggled.
- **http** — `Regen` now carries `RegenOp::{Chapter,Faststart}`; `ensure_cached` dispatches. The resolver routes **in-place** (`file_path == source_path`), **remux-cache** (`file_path != source_path` **and** `needs_faststart`), or **chaptered**. The remux copy is regenerated on demand and evicted under the `saver` cap like a cached chapter — never a pinned duplicate.

## Acceptance criteria (all met)
- [x] Non-faststart whole-file mp4 detected **without** invoking ffmpeg.
- [x] Default (off): served in place; a one-line callout logged per detected book at ingest.
- [x] `PODSPINE_REMUX_NON_FASTSTART=true`: remuxed to faststart and served from the cache, subject to the LRU cap.
- [x] MP3/OGG/FLAC whole files unaffected (no `moov`).

## Security
Re-audited (path resolution + command injection on the new remux path) — **no Critical/High/Medium findings**. Source is canonicalized + asserted under the library root; the cache path is reconstructed only from canonical `data_dir` + opaque `book.id` + a validated ext; ffmpeg is an argv vector (`-c copy`, out-of-process). The `needs_faststart` gate + the in-place size invariant (#59) keep a corrupt/stray `source_path` from serving a container. Fixed the one **Low** it flagged: a crafted 64-bit `largesize` box could overflow the parser's pointer add in overflow-checked builds — now saturating, with a regression test.

## Corruption-safety note
The remux branch is gated on `needs_faststart` (set true only on genuine whole-file mp4 at ingest), so a chaptered episode carrying a stray `source_path` drops to the chaptered arm and serves its real split (or 404s) rather than being remuxed into its container.

## Tests / coverage
prober (6 box-parse cases + the largesize regression); splitter (argv assertions + a deterministic-faststart round-trip); scanner (flag on/off, faststart-noop, toggle re-ingest); http (remux served-on-demand, faststart body, Range/206). Local gate green (fmt, clippy `-D warnings`, full suite); `cargo llvm-cov --workspace` at **92.7%** (floor 90%).

> Note: this adds a third unreleased changeset; the held knope release PR (#54) will want an "Update branch" before you eventually release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)