### PR TITLE
feat: per-book .podspine.toml overrides

### DIFF
--- a/.changeset/per-book-overrides.md
+++ b/.changeset/per-book-overrides.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add per-book `.podspine.toml` overrides: a sidecar beside a single-file book (`Author - Title.podspine.toml`) or inside a folder book overrides settings for just that book — `storage_mode`, `force_embedded_chapters`, `remux_non_faststart`, `default_cover_url`, plus troubleshooting knobs `disabled`, `title`, `author`, and `force_reingest` — with precedence sidecar → CLI/env → global config → default. Server-wide keys placed in a per-book file are ignored with a warning.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1165,6 +1165,7 @@ version = "1.2.0"
 dependencies = [
  "notify",
  "podspine-chapters",
+ "podspine-config",
  "podspine-feed",
  "podspine-index",
  "podspine-prober",

--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ Podspine flags it at ingest, and `PODSPINE_REMUX_NON_FASTSTART=true` will remux 
 to faststart on demand (cache-managed, no re-encode) — see
 **[faststart](docs/DEPLOYMENT.md#faststart-for-whole-file-mp4)**.
 
+**One book acting up?** Drop a `.podspine.toml` next to it (or in its folder) to
+override settings — `storage_mode`, `title`/`author`, `disabled`, and more — for
+just that book. See **[per-book overrides](docs/DEPLOYMENT.md#per-book-overrides-podspinetoml)**.
+
 Each book's feed lives at an unguessable **capability URL** — `/feed/{feed_id}.xml`,
 with `/audio/{feed_id}/{n}` (episode audio, HTTP Range) and `/cover/{feed_id}`. The
 browse UI (`/`, `/book/{slug}`) enumerates your library, so keep it on the LAN or

--- a/crates/config/src/book_overrides.rs
+++ b/crates/config/src/book_overrides.rs
@@ -1,0 +1,207 @@
+//! Per-book `.podspine.toml` overrides (Sprint 6.4).
+//!
+//! A sidecar beside a single-file book, or inside a folder book, overrides
+//! per-book-meaningful server settings for that ONE book — handy for
+//! troubleshooting a misbehaving book without touching the whole server.
+//! Precedence: **sidecar → CLI/env → global TOML → default**.
+//!
+//! Sidecar location (supports every library layout):
+//! - **single-file book** (top-level `Author - Title.m4b`, or a lone file in its
+//!   own folder) → `Author - Title.podspine.toml` beside the audio (mirrors the
+//!   `.cue`/`.ffmeta` convention);
+//! - **MP3-folder book, or that lone-file-in-a-folder** → `.podspine.toml` inside
+//!   the folder;
+//! - a top-level file's parent is the library root, so no folder-level file
+//!   applies there (it would wrongly cover every top-level book).
+
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use crate::StorageMode;
+
+/// Overrides parsed from a book's `.podspine.toml`. Every field is optional; an
+/// unset field falls back to the resolved server config. Server-global keys are
+/// accepted (so a stray one doesn't hard-fail the parse) but reported by
+/// [`BookOverrides::ignored_global_keys`] and never applied. An unknown key is a
+/// parse error, surfaced as a per-book warning (a bad sidecar never aborts a scan).
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct BookOverrides {
+    // --- per-book-meaningful config overrides ---
+    /// Ignore `.cue`/`.ffmeta` sidecars for this book.
+    pub force_embedded_chapters: Option<bool>,
+    /// `full`/`saver` for this book (persisted so serve/evict honor it).
+    pub storage_mode: Option<StorageMode>,
+    /// Remux this book to faststart if it's a non-faststart whole-file mp4.
+    pub remux_non_faststart: Option<bool>,
+    /// Feed-level fallback cover for this book.
+    pub default_cover_url: Option<String>,
+    // --- troubleshooting-only (no global equivalent) ---
+    /// Skip this book entirely (removed from the index + every surface).
+    pub disabled: Option<bool>,
+    /// Override the feed/book title.
+    pub title: Option<String>,
+    /// Override the author.
+    pub author: Option<String>,
+    /// Force a re-ingest on the next scan (skips the idempotency early return).
+    pub force_reingest: Option<bool>,
+    // --- server-global keys: accepted, then ignored with a warning ---
+    library: Option<toml::Value>,
+    data_dir: Option<toml::Value>,
+    bind: Option<toml::Value>,
+    base_url: Option<toml::Value>,
+    config: Option<toml::Value>,
+    cache_size: Option<toml::Value>,
+    cache_ttl: Option<toml::Value>,
+}
+
+impl BookOverrides {
+    /// Names of any server-global keys present in the sidecar (each is ignored).
+    /// The caller logs these so a user learns why `bind: …` in a per-book file
+    /// did nothing.
+    pub fn ignored_global_keys(&self) -> Vec<&'static str> {
+        [
+            ("library", self.library.is_some()),
+            ("data_dir", self.data_dir.is_some()),
+            ("bind", self.bind.is_some()),
+            ("base_url", self.base_url.is_some()),
+            ("config", self.config.is_some()),
+            ("cache_size", self.cache_size.is_some()),
+            ("cache_ttl", self.cache_ttl.is_some()),
+        ]
+        .into_iter()
+        .filter_map(|(name, present)| present.then_some(name))
+        .collect()
+    }
+}
+
+/// The sidecar path for a book whose `source` is a file (single-file book) or a
+/// directory (MP3 folder), or `None` if none exists. Both `source` and
+/// `library_root` should be canonical/absolute (the scanner canonicalizes them).
+pub fn sidecar_path(source: &Path, library_root: &Path) -> Option<PathBuf> {
+    if source.is_dir() {
+        let p = source.join(".podspine.toml");
+        return p.is_file().then_some(p);
+    }
+    // Single-file book → the stem sibling first (matches the `.cue` convention).
+    let stem = source.with_extension("podspine.toml");
+    if stem.is_file() {
+        return Some(stem);
+    }
+    // ...then a folder-level file, but only when the file lives in its own
+    // subfolder (never the library root, which every top-level book shares).
+    let parent = source.parent()?;
+    if parent != library_root {
+        let p = parent.join(".podspine.toml");
+        if p.is_file() {
+            return Some(p);
+        }
+    }
+    None
+}
+
+/// Read + parse a book's per-book overrides. `Ok(None)` when there is no sidecar;
+/// `Err(msg)` on a read/parse failure — the caller logs `msg` and proceeds with
+/// no overrides (a bad sidecar is a per-book warning, never fatal to the scan).
+pub fn load(source: &Path, library_root: &Path) -> Result<Option<BookOverrides>, String> {
+    let Some(path) = sidecar_path(source, library_root) else {
+        return Ok(None);
+    };
+    let text = std::fs::read_to_string(&path)
+        .map_err(|e| format!("could not read {}: {e}", path.display()))?;
+    toml::from_str::<BookOverrides>(&text)
+        .map(Some)
+        .map_err(|e| format!("could not parse {}: {e}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scratch(tag: &str) -> PathBuf {
+        let d = std::env::temp_dir().join(format!("podspine-bookoverrides-{tag}"));
+        let _ = std::fs::remove_dir_all(&d);
+        std::fs::create_dir_all(&d).unwrap();
+        // Canonicalize so the `parent != library_root` check compares like-for-like.
+        d.canonicalize().unwrap()
+    }
+
+    #[test]
+    fn stem_sidecar_for_a_top_level_file() {
+        let lib = scratch("stem");
+        let audio = lib.join("Author - Title.m4b");
+        std::fs::write(&audio, b"x").unwrap();
+        // No folder-level file applies at the library root.
+        std::fs::write(lib.join(".podspine.toml"), b"disabled = true").unwrap();
+        assert_eq!(sidecar_path(&audio, &lib), None, "no sidecar yet (stem)");
+
+        let side = lib.join("Author - Title.podspine.toml");
+        std::fs::write(&side, b"storage_mode = \"saver\"").unwrap();
+        assert_eq!(sidecar_path(&audio, &lib), Some(side));
+        let _ = std::fs::remove_dir_all(&lib);
+    }
+
+    #[test]
+    fn folder_sidecar_for_an_mp3_folder_and_a_lone_file_in_a_subfolder() {
+        let lib = scratch("folder");
+        // MP3-folder book: source is the dir.
+        let book = lib.join("A Folder Book");
+        std::fs::create_dir_all(&book).unwrap();
+        std::fs::write(book.join(".podspine.toml"), b"storage_mode = \"full\"").unwrap();
+        assert_eq!(
+            sidecar_path(&book, &lib),
+            Some(book.join(".podspine.toml")),
+            "mp3 folder → inside file"
+        );
+
+        // A lone file in its own subfolder: folder-level file applies (no stem one).
+        let sub = lib.join("Single");
+        std::fs::create_dir_all(&sub).unwrap();
+        let audio = sub.join("audio.m4b");
+        std::fs::write(&audio, b"x").unwrap();
+        std::fs::write(sub.join(".podspine.toml"), b"disabled = true").unwrap();
+        assert_eq!(
+            sidecar_path(&audio, &lib),
+            Some(sub.join(".podspine.toml")),
+            "lone file in a subfolder → folder-level file applies"
+        );
+        let _ = std::fs::remove_dir_all(&lib);
+    }
+
+    #[test]
+    fn parses_overrides_and_reports_ignored_global_keys() {
+        let lib = scratch("parse");
+        let audio = lib.join("Book.m4a");
+        std::fs::write(&audio, b"x").unwrap();
+        std::fs::write(
+            lib.join("Book.podspine.toml"),
+            b"storage_mode = \"saver\"\nforce_embedded_chapters = true\ntitle = \"Fixed Title\"\ndisabled = false\nbind = \"0.0.0.0:9\"\ncache_size = \"1GB\"\n",
+        )
+        .unwrap();
+
+        let o = load(&audio, &lib).unwrap().unwrap();
+        assert_eq!(o.storage_mode, Some(StorageMode::Saver));
+        assert_eq!(o.force_embedded_chapters, Some(true));
+        assert_eq!(o.title.as_deref(), Some("Fixed Title"));
+        assert_eq!(o.disabled, Some(false));
+        // Server-global keys parse but are reported for the caller to warn + drop.
+        let mut ignored = o.ignored_global_keys();
+        ignored.sort_unstable();
+        assert_eq!(ignored, vec!["bind", "cache_size"]);
+        let _ = std::fs::remove_dir_all(&lib);
+    }
+
+    #[test]
+    fn no_sidecar_is_ok_none_and_a_typo_is_an_err() {
+        let lib = scratch("errs");
+        let audio = lib.join("Book.m4b");
+        std::fs::write(&audio, b"x").unwrap();
+        assert_eq!(load(&audio, &lib).unwrap(), None, "no sidecar → Ok(None)");
+
+        // An unknown key (typo) is a parse error → per-book warning, not fatal.
+        std::fs::write(lib.join("Book.podspine.toml"), b"stroage_mode = \"saver\"").unwrap();
+        assert!(load(&audio, &lib).is_err(), "unknown key → Err");
+        let _ = std::fs::remove_dir_all(&lib);
+    }
+}

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -14,6 +14,9 @@ use std::time::Duration;
 use clap::{Parser, ValueEnum};
 use serde::Deserialize;
 
+pub mod book_overrides;
+pub use book_overrides::BookOverrides;
+
 const DEFAULT_BIND: &str = "0.0.0.0:8080";
 const DEFAULT_DATA_DIR: &str = "./data";
 /// Default `saver`-mode cache cap when unset: 2 GiB.

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -561,9 +561,30 @@ mod tests {
     }
 
     #[test]
-    fn preflight_finds_ffmpeg() {
-        // CI and dev both have ffmpeg on PATH.
-        preflight().expect("ffmpeg/ffprobe present");
+    fn preflight_matches_ffmpeg_availability() {
+        // ffmpeg/ffprobe aren't on every runner (e.g. the informational Windows
+        // leg, or a bare dev box), so don't hard-require them — assert instead that
+        // preflight's result MATCHES whether they're actually invocable.
+        let have = ["ffmpeg", "ffprobe"].iter().all(|t| {
+            std::process::Command::new(t)
+                .arg("-version")
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+        });
+        match preflight() {
+            Ok(()) => assert!(
+                have,
+                "preflight passed but ffmpeg/ffprobe are not both present"
+            ),
+            Err(ConfigError::ToolMissing(_)) => {
+                assert!(
+                    !have,
+                    "preflight reported a tool missing but both are present"
+                )
+            }
+            Err(e) => panic!("unexpected preflight error: {e:?}"),
+        }
     }
 
     #[test]

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -47,7 +47,7 @@ use tower_http::timeout::TimeoutLayer;
 use tower_http::trace::TraceLayer;
 
 use podspine_feed::{FeedBook, FeedEpisode, render_checked};
-use podspine_index::Index;
+use podspine_index::{BookRow, Index};
 use podspine_splitter::{ChapterCut, remux_faststart, split_chapter};
 use podspine_ui::{BookCard, BookDetail, book_page, index_page, subscribe_page};
 
@@ -440,12 +440,14 @@ fn build_feed_xml(state: &AppState, feed_id: &str) -> Result<String, AppError> {
     };
 
     let base = &state.base_url;
-    // Per-book cover served at /cover/{feed_id} when extracted; otherwise the
-    // configured feed-level fallback (or no image at all). See Task 3.4.
+    // Per-book cover served at /cover/{feed_id} when extracted; otherwise a
+    // per-book `.podspine.toml` fallback (Sprint 6.4), then the server-wide one,
+    // then no image at all. See Task 3.4.
     let cover_url = book
         .cover_path
         .as_ref()
         .map(|_| format!("{base}/cover/{feed_id}"))
+        .or_else(|| book.default_cover_url.clone())
         .or_else(|| state.default_cover_url.clone());
     let feed_book = FeedBook {
         id: book.id,
@@ -477,6 +479,17 @@ fn build_feed_xml(state: &AppState, feed_id: &str) -> Result<String, AppError> {
 /// Resolve `(feed_id, episode number)` to a validated on-disk path.
 /// What `/audio` needs: the canonical target file (which may not exist yet in
 /// `saver` mode) and, in `saver` mode, everything to regenerate it on demand.
+/// Whether a book's effective storage mode is `saver`: its per-book
+/// `.podspine.toml` override (Sprint 6.4) if set, else the server default. An
+/// empty string is a pre-6.4 row that follows the server config until re-scanned.
+fn book_is_saver(book: &BookRow, global_saver: bool) -> bool {
+    match book.storage_mode.as_str() {
+        "saver" => true,
+        "full" => false,
+        _ => global_saver,
+    }
+}
+
 struct AudioTarget {
     path: PathBuf,
     regen: Option<Regen>,
@@ -634,25 +647,27 @@ fn resolve_audio_target(
             },
         })
     } else {
-        // A chaptered episode. Regen is possible only in `saver` mode when the
-        // book's source is a single file to re-split; the `is_file` guard is
-        // belt-and-suspenders (a directory source would make `ffmpeg <directory>`
-        // fail), so a missing file is a clean 404, not a 500.
-        (state.saver && FsPath::new(&book.source_path).is_file()).then(|| Regen {
-            source: PathBuf::from(&book.source_path),
-            out_dir,
-            out_ext,
-            // `end_sec` is reconstructed as start + duration. This is EXACT, not an
-            // approximation: the scanner stores `duration_sec = cut.end - cut.start`
-            // (the requested cut length, not a measured output duration), so this
-            // yields the same `[start, end)` the ingest split used — and ffmpeg's
-            // 6-decimal arg formatting absorbs any float round-trip. The stream
-            // copy is therefore byte-identical (asserted in the serve test).
-            op: RegenOp::Chapter(ChapterCut {
-                idx: idx as usize,
-                start_sec: ep.start_sec,
-                end_sec: ep.start_sec + ep.duration_sec,
-            }),
+        // A chaptered episode. Regen is possible only in `saver` mode (per-book,
+        // Sprint 6.4) when the book's source is a single file to re-split; the
+        // `is_file` guard is belt-and-suspenders (a directory source would make
+        // `ffmpeg <directory>` fail), so a missing file is a clean 404, not a 500.
+        (book_is_saver(&book, state.saver) && FsPath::new(&book.source_path).is_file()).then(|| {
+            Regen {
+                source: PathBuf::from(&book.source_path),
+                out_dir,
+                out_ext,
+                // `end_sec` is reconstructed as start + duration. This is EXACT, not an
+                // approximation: the scanner stores `duration_sec = cut.end - cut.start`
+                // (the requested cut length, not a measured output duration), so this
+                // yields the same `[start, end)` the ingest split used — and ffmpeg's
+                // 6-decimal arg formatting absorbs any float round-trip. The stream
+                // copy is therefore byte-identical (asserted in the serve test).
+                op: RegenOp::Chapter(ChapterCut {
+                    idx: idx as usize,
+                    start_sec: ep.start_sec,
+                    end_sec: ep.start_sec + ep.duration_sec,
+                }),
+            }
         })
     };
     Ok(AudioTarget { path, regen })
@@ -724,24 +739,32 @@ async fn enforce_cache(state: &AppState, keep: &FsPath) {
         return; // unbounded + no TTL: nothing to evict
     }
     let books = state.data_dir.join("books");
-    // Only single-file-source books are regenerable; their cached chapters are
-    // safe to evict (they re-split on demand). A non-regenerable book dir must be
-    // left alone — nothing would rebuild it: whole-file books are served in place
-    // (any dir here is just a cover, or a legacy pre-6.2 copy not yet reclaimed).
-    // So restrict eviction to the regenerable book dirs. Snapshot the sources
+    // Evict only from **effective-`saver`, single-file-source** books (per-book
+    // storage_mode, Sprint 6.4): their cached chapters re-split on demand, so
+    // deleting one is safe. A `full` book's chapters are kept — evicting them
+    // would 404 (no regen) — and a non-single-file book (MP3 folder) is served in
+    // place, so those dirs are left alone. (A `full` book's remux cache, if any,
+    // therefore persists — a minor, safe over-conservatism.) Snapshot the sources
     // without holding the lock across the `is_file` stats.
-    let sources: Vec<(String, String)> = {
+    let sources: Vec<(String, bool)> = {
         let Ok(index) = state.index.lock() else {
             return;
         };
         match index.list_books() {
-            Ok(bs) => bs.into_iter().map(|b| (b.id, b.source_path)).collect(),
+            Ok(bs) => bs
+                .into_iter()
+                .map(|b| {
+                    let regen =
+                        book_is_saver(&b, state.saver) && FsPath::new(&b.source_path).is_file();
+                    (b.id, regen)
+                })
+                .collect(),
             Err(_) => return,
         }
     };
     let regenerable: HashSet<PathBuf> = sources
         .into_iter()
-        .filter(|(_, src)| FsPath::new(src).is_file())
+        .filter(|(_, regen)| *regen)
         .map(|(id, _)| books.join(id))
         .collect();
     let keep = keep.to_path_buf();

--- a/crates/http/tests/server.rs
+++ b/crates/http/tests/server.rs
@@ -11,7 +11,7 @@ use tower::ServiceExt;
 
 use podspine_http::{AppState, router};
 use podspine_index::Index;
-use podspine_scanner::{scan_book, scan_book_as};
+use podspine_scanner::{BookOverrides, scan_book, scan_book_as, scan_library};
 
 fn ffmpeg_available() -> bool {
     Command::new("ffmpeg")
@@ -162,7 +162,17 @@ async fn saver_mode_regenerates_a_chapter_on_demand() {
     let index = Index::open_in_memory().unwrap();
     let input = synth_three_chapters(&dir);
     // Ingest in `saver` mode: sizes recorded, split files deleted.
-    let book = scan_book_as(&input, "saverbook", &data, &index, false, true, false).unwrap();
+    let book = scan_book_as(
+        &input,
+        "saverbook",
+        &data,
+        &index,
+        false,
+        true,
+        false,
+        &BookOverrides::default(),
+    )
+    .unwrap();
     let feed_id = book.feed_id.clone();
 
     let eps = index.episodes_for_book(&book.id).unwrap();
@@ -237,7 +247,17 @@ async fn saver_cache_evicts_over_the_size_cap() {
 
     let index = Index::open_in_memory().unwrap();
     let input = synth_three_chapters(&dir);
-    let book = scan_book_as(&input, "evictbook", &data, &index, false, true, false).unwrap();
+    let book = scan_book_as(
+        &input,
+        "evictbook",
+        &data,
+        &index,
+        false,
+        true,
+        false,
+        &BookOverrides::default(),
+    )
+    .unwrap();
     let feed_id = book.feed_id.clone();
     let book_out = data.join("books").join(&book.id);
 
@@ -571,7 +591,17 @@ async fn serves_a_remuxed_faststart_copy_on_demand() {
     let index = Index::open_in_memory().unwrap();
     // A non-faststart m4a (moov at end) under the library. Ingest with remux ON.
     let input = synth_flat(&library);
-    let book = scan_book_as(&input, "remuxbook", &data, &index, false, false, true).unwrap();
+    let book = scan_book_as(
+        &input,
+        "remuxbook",
+        &data,
+        &index,
+        false,
+        false,
+        true,
+        &BookOverrides::default(),
+    )
+    .unwrap();
     let feed_id = book.feed_id.clone();
 
     // Recorded as a faststart cache episode: file_path (cache) != source_path, and
@@ -642,6 +672,69 @@ async fn serves_a_remuxed_faststart_copy_on_demand() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::PARTIAL_CONTENT);
     assert_eq!(body_bytes(resp).await.len(), 10, "range served 10 bytes");
+
+    let _ = std::fs::remove_dir_all(&base);
+}
+
+#[tokio::test]
+async fn per_book_saver_serves_even_when_server_is_full() {
+    if !ffmpeg_available() {
+        eprintln!("skipping: ffmpeg not available");
+        return;
+    }
+    let base = std::env::temp_dir().join("podspine-http-perbook-saver");
+    let _ = std::fs::remove_dir_all(&base);
+    let library = base.join("library");
+    let data = base.join("data");
+    std::fs::create_dir_all(&library).unwrap();
+    let input = synth_three_chapters(&library);
+    // Per-book override: `saver`, even though the server below runs `full`.
+    let side = input
+        .canonicalize()
+        .unwrap()
+        .with_extension("podspine.toml");
+    std::fs::write(&side, b"storage_mode = \"saver\"").unwrap();
+
+    let index = Index::open_in_memory().unwrap();
+    // Global full (saver = false); the sidecar forces this one book to saver.
+    scan_library(&library, &data, &index, false, false, false);
+    let books = index.list_books().unwrap();
+    assert_eq!(books.len(), 1);
+    assert_eq!(books[0].storage_mode, "saver", "per-book saver persisted");
+    let feed_id = books[0].feed_id.clone();
+    let eps = index.episodes_for_book(&books[0].id).unwrap();
+    assert!(
+        !std::path::Path::new(&eps[0].file_path).exists(),
+        "saver ingest deleted the split"
+    );
+
+    // The server is FULL, but the per-book saver mode must still regenerate the
+    // chapter on demand rather than 404.
+    let state = AppState::new(
+        index,
+        "http://test".to_string(),
+        &data,
+        &library,
+        None,
+        false,
+        None,
+        None,
+    );
+    let app = router(state);
+    let resp = app
+        .oneshot(
+            Request::get(format!("/audio/{feed_id}/1"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "per-book saver regenerated despite the global full mode"
+    );
+    assert_eq!(body_bytes(resp).await.len() as i64, eps[0].byte_length);
 
     let _ = std::fs::remove_dir_all(&base);
 }

--- a/crates/index/src/lib.rs
+++ b/crates/index/src/lib.rs
@@ -49,7 +49,9 @@ CREATE TABLE IF NOT EXISTS book (
     cover_path   TEXT,
     source_path  TEXT NOT NULL,
     source_mtime INTEGER NOT NULL,
-    status       TEXT NOT NULL
+    status       TEXT NOT NULL,
+    storage_mode TEXT NOT NULL DEFAULT '',
+    default_cover_url TEXT
 );
 CREATE TABLE IF NOT EXISTS episode (
     guid          TEXT PRIMARY KEY,
@@ -89,6 +91,14 @@ pub struct BookRow {
     pub source_mtime: i64,
     /// Processing status (e.g. `ready`).
     pub status: String,
+    /// Effective per-book storage mode as a string (`"full"`/`"saver"`), or `""`
+    /// to follow the global config (a pre-6.4 row, until re-scanned). Persisted so
+    /// the serve/evict layers honor a per-book `.podspine.toml` override without
+    /// the sidecar (Sprint 6.4).
+    pub storage_mode: String,
+    /// Per-book feed cover fallback (a `.podspine.toml` override), tried before
+    /// the server-wide `default_cover_url`.
+    pub default_cover_url: Option<String>,
 }
 
 /// One episode (a split chapter). Numeric fields are stored as SQLite integers.
@@ -211,6 +221,28 @@ impl Index {
                 [],
             )?;
         }
+        // `book.storage_mode` + `book.default_cover_url` (per-book overrides,
+        // Sprint 6.4). Existing rows default to `''`/NULL, meaning "follow the
+        // global config"; a re-scan records the effective per-book value.
+        let has_book_storage_mode: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM pragma_table_info('book') WHERE name = 'storage_mode'",
+            [],
+            |r| r.get(0),
+        )?;
+        if has_book_storage_mode == 0 {
+            conn.execute(
+                "ALTER TABLE book ADD COLUMN storage_mode TEXT NOT NULL DEFAULT ''",
+                [],
+            )?;
+        }
+        let has_book_cover_url: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM pragma_table_info('book') WHERE name = 'default_cover_url'",
+            [],
+            |r| r.get(0),
+        )?;
+        if has_book_cover_url == 0 {
+            conn.execute("ALTER TABLE book ADD COLUMN default_cover_url TEXT", [])?;
+        }
         Ok(())
     }
 
@@ -223,12 +255,13 @@ impl Index {
     pub fn upsert_book(&self, b: &BookRow) -> Result<(), IndexError> {
         self.conn.execute(
             "INSERT INTO book
-               (id, slug, feed_id, title, author, cover_path, source_path, source_mtime, status)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+               (id, slug, feed_id, title, author, cover_path, source_path, source_mtime, status, storage_mode, default_cover_url)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
              ON CONFLICT(id) DO UPDATE SET
                slug=excluded.slug, title=excluded.title, author=excluded.author,
                cover_path=excluded.cover_path, source_path=excluded.source_path,
-               source_mtime=excluded.source_mtime, status=excluded.status",
+               source_mtime=excluded.source_mtime, status=excluded.status,
+               storage_mode=excluded.storage_mode, default_cover_url=excluded.default_cover_url",
             params![
                 b.id,
                 b.slug,
@@ -239,6 +272,8 @@ impl Index {
                 b.source_path,
                 b.source_mtime,
                 b.status,
+                b.storage_mode,
+                b.default_cover_url,
             ],
         )?;
         Ok(())
@@ -278,7 +313,7 @@ impl Index {
         Ok(self
             .conn
             .query_row(
-                "SELECT id, slug, feed_id, title, author, cover_path, source_path, source_mtime, status
+                "SELECT id, slug, feed_id, title, author, cover_path, source_path, source_mtime, status, storage_mode, default_cover_url
                  FROM book WHERE id = ?1",
                 [id],
                 book_from_row,
@@ -291,7 +326,7 @@ impl Index {
         Ok(self
             .conn
             .query_row(
-                "SELECT id, slug, feed_id, title, author, cover_path, source_path, source_mtime, status
+                "SELECT id, slug, feed_id, title, author, cover_path, source_path, source_mtime, status, storage_mode, default_cover_url
                  FROM book WHERE slug = ?1",
                 [slug],
                 book_from_row,
@@ -302,7 +337,7 @@ impl Index {
     /// All books, ordered by title.
     pub fn list_books(&self) -> Result<Vec<BookRow>, IndexError> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, slug, feed_id, title, author, cover_path, source_path, source_mtime, status
+            "SELECT id, slug, feed_id, title, author, cover_path, source_path, source_mtime, status, storage_mode, default_cover_url
              FROM book ORDER BY title",
         )?;
         let rows = stmt.query_map([], book_from_row)?;
@@ -326,7 +361,7 @@ impl Index {
         Ok(self
             .conn
             .query_row(
-                "SELECT id, slug, feed_id, title, author, cover_path, source_path, source_mtime, status
+                "SELECT id, slug, feed_id, title, author, cover_path, source_path, source_mtime, status, storage_mode, default_cover_url
                  FROM book WHERE feed_id = ?1",
                 [feed_id],
                 book_from_row,
@@ -379,6 +414,8 @@ fn book_from_row(row: &Row) -> rusqlite::Result<BookRow> {
         source_path: row.get(6)?,
         source_mtime: row.get(7)?,
         status: row.get(8)?,
+        storage_mode: row.get(9)?,
+        default_cover_url: row.get(10)?,
     })
 }
 
@@ -413,6 +450,8 @@ mod tests {
             source_path: format!("/library/{id}.m4b"),
             source_mtime: 1_700_000_000,
             status: "ready".to_string(),
+            storage_mode: String::new(),
+            default_cover_url: None,
         }
     }
 

--- a/crates/index/src/lib.rs
+++ b/crates/index/src/lib.rs
@@ -51,7 +51,8 @@ CREATE TABLE IF NOT EXISTS book (
     source_mtime INTEGER NOT NULL,
     status       TEXT NOT NULL,
     storage_mode TEXT NOT NULL DEFAULT '',
-    default_cover_url TEXT
+    default_cover_url TEXT,
+    force_embedded INTEGER NOT NULL DEFAULT 0
 );
 CREATE TABLE IF NOT EXISTS episode (
     guid          TEXT PRIMARY KEY,
@@ -99,6 +100,10 @@ pub struct BookRow {
     /// Per-book feed cover fallback (a `.podspine.toml` override), tried before
     /// the server-wide `default_cover_url`.
     pub default_cover_url: Option<String>,
+    /// Effective `force_embedded_chapters` at last ingest (a `.podspine.toml`
+    /// override). Persisted only so a scan can detect a toggle and re-ingest;
+    /// not read at serve time.
+    pub force_embedded: bool,
 }
 
 /// One episode (a split chapter). Numeric fields are stored as SQLite integers.
@@ -243,6 +248,20 @@ impl Index {
         if has_book_cover_url == 0 {
             conn.execute("ALTER TABLE book ADD COLUMN default_cover_url TEXT", [])?;
         }
+        // `book.force_embedded` (per-book overrides, 6.4). Recorded so a scan can
+        // detect a `.podspine.toml` `force_embedded_chapters` toggle (which changes
+        // the chapter source without changing the audio mtime) and re-ingest.
+        let has_force_embedded: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM pragma_table_info('book') WHERE name = 'force_embedded'",
+            [],
+            |r| r.get(0),
+        )?;
+        if has_force_embedded == 0 {
+            conn.execute(
+                "ALTER TABLE book ADD COLUMN force_embedded INTEGER NOT NULL DEFAULT 0",
+                [],
+            )?;
+        }
         Ok(())
     }
 
@@ -255,13 +274,14 @@ impl Index {
     pub fn upsert_book(&self, b: &BookRow) -> Result<(), IndexError> {
         self.conn.execute(
             "INSERT INTO book
-               (id, slug, feed_id, title, author, cover_path, source_path, source_mtime, status, storage_mode, default_cover_url)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+               (id, slug, feed_id, title, author, cover_path, source_path, source_mtime, status, storage_mode, default_cover_url, force_embedded)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
              ON CONFLICT(id) DO UPDATE SET
                slug=excluded.slug, title=excluded.title, author=excluded.author,
                cover_path=excluded.cover_path, source_path=excluded.source_path,
                source_mtime=excluded.source_mtime, status=excluded.status,
-               storage_mode=excluded.storage_mode, default_cover_url=excluded.default_cover_url",
+               storage_mode=excluded.storage_mode, default_cover_url=excluded.default_cover_url,
+               force_embedded=excluded.force_embedded",
             params![
                 b.id,
                 b.slug,
@@ -274,6 +294,7 @@ impl Index {
                 b.status,
                 b.storage_mode,
                 b.default_cover_url,
+                b.force_embedded,
             ],
         )?;
         Ok(())
@@ -313,7 +334,7 @@ impl Index {
         Ok(self
             .conn
             .query_row(
-                "SELECT id, slug, feed_id, title, author, cover_path, source_path, source_mtime, status, storage_mode, default_cover_url
+                "SELECT id, slug, feed_id, title, author, cover_path, source_path, source_mtime, status, storage_mode, default_cover_url, force_embedded
                  FROM book WHERE id = ?1",
                 [id],
                 book_from_row,
@@ -326,7 +347,7 @@ impl Index {
         Ok(self
             .conn
             .query_row(
-                "SELECT id, slug, feed_id, title, author, cover_path, source_path, source_mtime, status, storage_mode, default_cover_url
+                "SELECT id, slug, feed_id, title, author, cover_path, source_path, source_mtime, status, storage_mode, default_cover_url, force_embedded
                  FROM book WHERE slug = ?1",
                 [slug],
                 book_from_row,
@@ -337,7 +358,7 @@ impl Index {
     /// All books, ordered by title.
     pub fn list_books(&self) -> Result<Vec<BookRow>, IndexError> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, slug, feed_id, title, author, cover_path, source_path, source_mtime, status, storage_mode, default_cover_url
+            "SELECT id, slug, feed_id, title, author, cover_path, source_path, source_mtime, status, storage_mode, default_cover_url, force_embedded
              FROM book ORDER BY title",
         )?;
         let rows = stmt.query_map([], book_from_row)?;
@@ -361,7 +382,7 @@ impl Index {
         Ok(self
             .conn
             .query_row(
-                "SELECT id, slug, feed_id, title, author, cover_path, source_path, source_mtime, status, storage_mode, default_cover_url
+                "SELECT id, slug, feed_id, title, author, cover_path, source_path, source_mtime, status, storage_mode, default_cover_url, force_embedded
                  FROM book WHERE feed_id = ?1",
                 [feed_id],
                 book_from_row,
@@ -416,6 +437,7 @@ fn book_from_row(row: &Row) -> rusqlite::Result<BookRow> {
         status: row.get(8)?,
         storage_mode: row.get(9)?,
         default_cover_url: row.get(10)?,
+        force_embedded: row.get(11)?,
     })
 }
 
@@ -452,6 +474,7 @@ mod tests {
             status: "ready".to_string(),
             storage_mode: String::new(),
             default_cover_url: None,
+            force_embedded: false,
         }
     }
 

--- a/crates/scanner/Cargo.toml
+++ b/crates/scanner/Cargo.toml
@@ -10,6 +10,7 @@ authors.workspace = true
 publish = false
 
 [dependencies]
+podspine-config = { path = "../config" }
 podspine-prober = { path = "../prober" }
 podspine-chapters = { path = "../chapters" }
 podspine-splitter = { path = "../splitter" }

--- a/crates/scanner/src/lib.rs
+++ b/crates/scanner/src/lib.rs
@@ -31,6 +31,8 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
+pub use podspine_config::BookOverrides;
+use podspine_config::{StorageMode, book_overrides};
 use podspine_feed::{episode_guid, pubdate_epoch};
 use podspine_index::{BookRow, EpisodeRow, Index, IndexError};
 use podspine_prober::{ProbeError, needs_faststart, probe};
@@ -84,7 +86,16 @@ pub enum ScanError {
 /// name. Convenience wrapper over [`scan_book_as`] for single-book callers.
 pub fn scan_book(input: &Path, data_dir: &Path, index: &Index) -> Result<BookRow, ScanError> {
     let id = slugify(&file_stem(input));
-    scan_book_as(input, &id, data_dir, index, false, false, false)
+    scan_book_as(
+        input,
+        &id,
+        data_dir,
+        index,
+        false,
+        false,
+        false,
+        &BookOverrides::default(),
+    )
 }
 
 /// Scan one audiobook `input` into `index` under the explicit `id` (also used as
@@ -100,6 +111,9 @@ pub fn scan_book(input: &Path, data_dir: &Path, index: &Index) -> Result<BookRow
 /// but the file is deleted immediately afterwards — the http layer regenerates
 /// it on demand. Peak extra disk is one chapter, not a full second copy of the
 /// book. `false` is the default (pre-split, files kept).
+// TODO(6.4+): the global flags + `overrides` are getting numerous; if a further
+// per-book knob lands, bundle the globals into a `ScanOptions` struct.
+#[allow(clippy::too_many_arguments)]
 pub fn scan_book_as(
     input: &Path,
     id: &str,
@@ -108,6 +122,7 @@ pub fn scan_book_as(
     force_embedded: bool,
     saver: bool,
     remux_non_faststart: bool,
+    overrides: &BookOverrides,
 ) -> Result<BookRow, ScanError> {
     if !input.is_file() {
         return Err(ScanError::NotAFile(input.to_path_buf()));
@@ -122,6 +137,17 @@ pub fn scan_book_as(
     // canonicalize succeeds; the fallback only guards a race.
     let input_canonical = input.canonicalize().unwrap_or_else(|_| input.to_path_buf());
     let input = input_canonical.as_path();
+
+    // Per-book `.podspine.toml` overrides refine the global flags for this book
+    // (Sprint 6.4); `disabled` is handled by the caller before we're reached.
+    let force_embedded = overrides.force_embedded_chapters.unwrap_or(force_embedded);
+    let remux_non_faststart = overrides.remux_non_faststart.unwrap_or(remux_non_faststart);
+    let saver = match overrides.storage_mode {
+        Some(StorageMode::Saver) => true,
+        Some(StorageMode::Full) => false,
+        None => saver,
+    };
+    let force_reingest = overrides.force_reingest == Some(true);
 
     let id = id.to_string();
     let source_mtime = mtime_epoch(input)?;
@@ -163,7 +189,14 @@ pub fn scan_book_as(
                 || (!e.source_path.is_empty() && e.file_path != e.source_path);
             regenerable || Path::new(&e.file_path).exists()
         });
-        if !eps.is_empty() && start_secs_recorded && faststart_consistent && files_present {
+        // `force_reingest` (a `.podspine.toml` troubleshooting knob) always skips
+        // the early return so the book is re-processed on every scan while set.
+        if !force_reingest
+            && !eps.is_empty()
+            && start_secs_recorded
+            && faststart_consistent
+            && files_present
+        {
             return Ok(existing);
         }
     }
@@ -306,12 +339,16 @@ pub fn scan_book_as(
         id: id.clone(),
         slug: id.clone(),
         feed_id: podspine_index::capability::generate(),
-        title: file_stem(input),
-        author: None,
+        // Per-book overrides (Sprint 6.4): title/author from the sidecar if set.
+        title: overrides.title.clone().unwrap_or_else(|| file_stem(input)),
+        author: overrides.author.clone(),
         cover_path,
         source_path: input.to_string_lossy().into_owned(),
         source_mtime,
         status: "ready".to_string(),
+        // Persist the effective mode so serve/evict honor it without the sidecar.
+        storage_mode: if saver { "saver" } else { "full" }.to_string(),
+        default_cover_url: overrides.default_cover_url.clone(),
     };
     index.upsert_book(&book)?;
 
@@ -390,6 +427,7 @@ fn scan_mp3_folder(
     id: &str,
     data_dir: &Path,
     index: &Index,
+    overrides: &BookOverrides,
 ) -> Result<BookRow, ScanError> {
     // Canonicalize the folder so every track path stored below is absolute and
     // symlink-resolved — in-place serving must not depend on the server's cwd.
@@ -414,7 +452,8 @@ fn scan_mp3_folder(
     // The `source_path` guard forces a one-time re-ingest of a pre-6.2 book
     // (tracks copied under <data_dir>, empty `source_path`) so it flips to
     // in-place serving and its copies get reclaimed.
-    if let Some(existing) = index.get_book(id)?
+    if overrides.force_reingest != Some(true)
+        && let Some(existing) = index.get_book(id)?
         && existing.source_mtime == source_mtime
     {
         let eps = index.episodes_for_book(id)?;
@@ -452,12 +491,17 @@ fn scan_mp3_folder(
         id: id.to_string(),
         slug: id.to_string(),
         feed_id: podspine_index::capability::generate(),
-        title: dir_name(dir),
-        author: None,
+        // Per-book overrides (Sprint 6.4). storage_mode/remux/force_embedded are
+        // no-ops for MP3 folders (tracks are always served in place), so only
+        // title/author/cover apply; persist storage_mode as `""` (follow global).
+        title: overrides.title.clone().unwrap_or_else(|| dir_name(dir)),
+        author: overrides.author.clone(),
         cover_path: None,
         source_path: dir.to_string_lossy().into_owned(),
         source_mtime,
         status: "ready".to_string(),
+        storage_mode: String::new(),
+        default_cover_url: overrides.default_cover_url.clone(),
     };
     index.upsert_book(&book)?;
 
@@ -576,6 +620,29 @@ impl BookSource {
 /// are deliberately absent and logged as skipped during discovery (PRD W5).
 const AUDIO_EXTENSIONS: &[&str] = &["m4b", "m4a", "mp3", "ogg", "oga", "opus", "flac"];
 
+/// Resolve + parse a book's `.podspine.toml` (Sprint 6.4). A missing sidecar
+/// yields the empty default; a bad sidecar or a server-global key that doesn't
+/// apply per book is logged and dropped — never fatal to the scan. `source` is
+/// canonicalized so the folder-vs-library-root check compares like-for-like.
+fn resolve_book_overrides(source: &Path, library_root: &Path) -> BookOverrides {
+    let source = source
+        .canonicalize()
+        .unwrap_or_else(|_| source.to_path_buf());
+    match book_overrides::load(&source, library_root) {
+        Ok(Some(o)) => {
+            for key in o.ignored_global_keys() {
+                tracing::warn!(source = %source.display(), key, "ignoring server-global key in .podspine.toml");
+            }
+            o
+        }
+        Ok(None) => BookOverrides::default(),
+        Err(msg) => {
+            tracing::warn!("{msg}; ignoring per-book overrides");
+            BookOverrides::default()
+        }
+    }
+}
+
 /// Scan a library root of many audiobooks into `index`, writing each book's
 /// episodes under `<data_dir>/books/<slug>/`. One independent book per top-level
 /// audio file or per-book subfolder. Slugs are collision-free and deterministic
@@ -589,6 +656,11 @@ pub fn scan_library(
     remux_non_faststart: bool,
 ) -> ScanSummary {
     let sources = discover(library);
+    // Canonical library root, for resolving per-book `.podspine.toml` sidecars
+    // (Sprint 6.4) — matched against each book's canonical source path.
+    let library_root = library
+        .canonicalize()
+        .unwrap_or_else(|_| library.to_path_buf());
 
     let mut seen = HashSet::new();
     let mut summary = ScanSummary::default();
@@ -596,6 +668,21 @@ pub fn scan_library(
         // Reserve a slug for every candidate in deterministic order so a book's
         // slug is stable across re-scans regardless of siblings' outcomes.
         let slug = unique_slug(&slugify(&source.base_name()), &mut seen);
+        let source_path = match &source {
+            BookSource::File(p) => p.as_path(),
+            BookSource::Mp3Folder(d) => d.as_path(),
+        };
+        let overrides = resolve_book_overrides(source_path, &library_root);
+        // `disabled` (a `.podspine.toml` troubleshooting knob): drop the book from
+        // every surface — prune it if it was previously indexed, and skip.
+        if overrides.disabled == Some(true) {
+            if matches!(index.get_book(&slug), Ok(Some(_))) {
+                let _ = index.delete_book(&slug);
+            }
+            tracing::info!(slug = %slug, "book disabled by .podspine.toml — skipped");
+            summary.skipped += 1;
+            continue;
+        }
         match source {
             BookSource::File(path) => {
                 match scan_book_as(
@@ -606,6 +693,7 @@ pub fn scan_library(
                     force_embedded,
                     saver,
                     remux_non_faststart,
+                    &overrides,
                 ) {
                     Ok(book) => {
                         summary.indexed += 1;
@@ -617,16 +705,18 @@ pub fn scan_library(
                     }
                 }
             }
-            BookSource::Mp3Folder(dir) => match scan_mp3_folder(&dir, &slug, data_dir, index) {
-                Ok(book) => {
-                    summary.indexed += 1;
-                    tracing::info!(slug = %book.slug, title = %book.title, "indexed MP3-folder book");
+            BookSource::Mp3Folder(dir) => {
+                match scan_mp3_folder(&dir, &slug, data_dir, index, &overrides) {
+                    Ok(book) => {
+                        summary.indexed += 1;
+                        tracing::info!(slug = %book.slug, title = %book.title, "indexed MP3-folder book");
+                    }
+                    Err(err) => {
+                        summary.skipped += 1;
+                        tracing::warn!(error = %err, path = %dir.display(), "skipped");
+                    }
                 }
-                Err(err) => {
-                    summary.skipped += 1;
-                    tracing::warn!(error = %err, path = %dir.display(), "skipped");
-                }
-            },
+            }
         }
     }
     tracing::info!(
@@ -1184,7 +1274,17 @@ mod tests {
         // force_embedded ignores the sidecar -> back to 3 embedded chapters.
         let data2 = dir.join("data2");
         let index2 = Index::open_in_memory().unwrap();
-        let book2 = scan_book_as(&input, "forced", &data2, &index2, true, false, false).unwrap();
+        let book2 = scan_book_as(
+            &input,
+            "forced",
+            &data2,
+            &index2,
+            true,
+            false,
+            false,
+            &podspine_config::BookOverrides::default(),
+        )
+        .unwrap();
         assert_eq!(
             index2.episodes_for_book(&book2.id).unwrap().len(),
             3,
@@ -1207,7 +1307,17 @@ mod tests {
         let data = dir.join("data");
         let index = Index::open_in_memory().unwrap();
 
-        let book = scan_book_as(&input, "saver-book", &data, &index, false, true, false).unwrap();
+        let book = scan_book_as(
+            &input,
+            "saver-book",
+            &data,
+            &index,
+            false,
+            true,
+            false,
+            &podspine_config::BookOverrides::default(),
+        )
+        .unwrap();
         let eps = index.episodes_for_book(&book.id).unwrap();
         assert_eq!(eps.len(), 3);
         for (i, e) in eps.iter().enumerate() {
@@ -1230,7 +1340,17 @@ mod tests {
 
         // Idempotent: re-scanning at the same mtime is a no-op despite the files
         // being absent (the index entry alone satisfies the check in saver mode).
-        let again = scan_book_as(&input, "saver-book", &data, &index, false, true, false).unwrap();
+        let again = scan_book_as(
+            &input,
+            "saver-book",
+            &data,
+            &index,
+            false,
+            true,
+            false,
+            &podspine_config::BookOverrides::default(),
+        )
+        .unwrap();
         assert_eq!(again.id, book.id);
 
         let _ = std::fs::remove_dir_all(&dir);
@@ -1250,7 +1370,17 @@ mod tests {
         let index = Index::open_in_memory().unwrap();
 
         // A normal full-mode ingest first: files on disk, real offsets recorded.
-        let book = scan_book_as(&input, "mig", &data, &index, false, false, false).unwrap();
+        let book = scan_book_as(
+            &input,
+            "mig",
+            &data,
+            &index,
+            false,
+            false,
+            false,
+            &podspine_config::BookOverrides::default(),
+        )
+        .unwrap();
         let eps = index.episodes_for_book(&book.id).unwrap();
         assert!(
             eps.iter().any(|e| e.start_sec > 0.0),
@@ -1266,7 +1396,17 @@ mod tests {
 
         // Re-scan at the SAME mtime in saver mode. The zeroed non-first chapters
         // must force a one-time re-split, not an idempotent skip.
-        let book2 = scan_book_as(&input, "mig", &data, &index, false, true, false).unwrap();
+        let book2 = scan_book_as(
+            &input,
+            "mig",
+            &data,
+            &index,
+            false,
+            true,
+            false,
+            &podspine_config::BookOverrides::default(),
+        )
+        .unwrap();
         assert_eq!(book2.id, book.id);
         let eps2 = index.episodes_for_book(&book.id).unwrap();
         assert!(
@@ -1629,7 +1769,17 @@ mod tests {
         {
             let data = dir.join("data-off");
             let index = Index::open_in_memory().unwrap();
-            let book = scan_book_as(&input, "ft", &data, &index, false, false, false).unwrap();
+            let book = scan_book_as(
+                &input,
+                "ft",
+                &data,
+                &index,
+                false,
+                false,
+                false,
+                &podspine_config::BookOverrides::default(),
+            )
+            .unwrap();
             let eps = index.episodes_for_book(&book.id).unwrap();
             assert!(eps[0].needs_faststart, "non-faststart mp4 flagged");
             assert_eq!(
@@ -1647,7 +1797,17 @@ mod tests {
         {
             let data = dir.join("data-on");
             let index = Index::open_in_memory().unwrap();
-            let book = scan_book_as(&input, "ft", &data, &index, false, false, true).unwrap();
+            let book = scan_book_as(
+                &input,
+                "ft",
+                &data,
+                &index,
+                false,
+                false,
+                true,
+                &podspine_config::BookOverrides::default(),
+            )
+            .unwrap();
             let eps = index.episodes_for_book(&book.id).unwrap();
             assert!(eps[0].needs_faststart);
             assert_ne!(
@@ -1705,7 +1865,17 @@ mod tests {
         // Even with remux ON, a faststart mp4 is served in place (nothing to fix).
         let data = dir.join("data");
         let index = Index::open_in_memory().unwrap();
-        let book = scan_book_as(&input, "ok", &data, &index, false, false, true).unwrap();
+        let book = scan_book_as(
+            &input,
+            "ok",
+            &data,
+            &index,
+            false,
+            false,
+            true,
+            &podspine_config::BookOverrides::default(),
+        )
+        .unwrap();
         let eps = index.episodes_for_book(&book.id).unwrap();
         assert!(!eps[0].needs_faststart);
         assert_eq!(
@@ -1728,13 +1898,33 @@ mod tests {
         let index = Index::open_in_memory().unwrap();
 
         // remux OFF → in place.
-        scan_book_as(&input, "t", &data, &index, false, false, false).unwrap();
+        scan_book_as(
+            &input,
+            "t",
+            &data,
+            &index,
+            false,
+            false,
+            false,
+            &podspine_config::BookOverrides::default(),
+        )
+        .unwrap();
         let e1 = index.episodes_for_book("t").unwrap();
         assert_eq!(e1[0].source_path, e1[0].file_path, "remux off → in place");
 
         // Same mtime, flag flipped ON: the faststart toggle guard forces a
         // re-ingest instead of the idempotent early return.
-        scan_book_as(&input, "t", &data, &index, false, false, true).unwrap();
+        scan_book_as(
+            &input,
+            "t",
+            &data,
+            &index,
+            false,
+            false,
+            true,
+            &podspine_config::BookOverrides::default(),
+        )
+        .unwrap();
         let e2 = index.episodes_for_book("t").unwrap();
         assert_ne!(
             e2[0].source_path, e2[0].file_path,
@@ -1742,7 +1932,17 @@ mod tests {
         );
 
         // Flip back OFF: re-ingest again, back to in place.
-        scan_book_as(&input, "t", &data, &index, false, false, false).unwrap();
+        scan_book_as(
+            &input,
+            "t",
+            &data,
+            &index,
+            false,
+            false,
+            false,
+            &podspine_config::BookOverrides::default(),
+        )
+        .unwrap();
         let e3 = index.episodes_for_book("t").unwrap();
         assert_eq!(
             e3[0].source_path, e3[0].file_path,
@@ -1750,6 +1950,68 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn per_book_toml_overrides_apply_at_ingest() {
+        if !ffmpeg_available() {
+            eprintln!("skipping: ffmpeg not available");
+            return;
+        }
+        let root = scratch("perbook");
+        let input = synth(&root, false); // flat.m4a (top-level single-file book)
+        let side = input
+            .canonicalize()
+            .unwrap()
+            .with_extension("podspine.toml");
+        std::fs::write(
+            &side,
+            b"title = \"My Override\"\nauthor = \"Someone\"\nstorage_mode = \"saver\"\n",
+        )
+        .unwrap();
+        let data = root.join("data");
+        let index = Index::open_in_memory().unwrap();
+
+        // Server is `full`, but the sidecar forces `saver` for this one book.
+        scan_library(&root, &data, &index, false, false, false);
+        let books = index.list_books().unwrap();
+        assert_eq!(books.len(), 1);
+        assert_eq!(books[0].title, "My Override");
+        assert_eq!(books[0].author.as_deref(), Some("Someone"));
+        assert_eq!(
+            books[0].storage_mode, "saver",
+            "per-book storage_mode is persisted for serve/evict"
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn per_book_disabled_skips_and_prunes() {
+        if !ffmpeg_available() {
+            eprintln!("skipping: ffmpeg not available");
+            return;
+        }
+        let root = scratch("perbook-disabled");
+        let input = synth(&root, false);
+        let data = root.join("data");
+        let index = Index::open_in_memory().unwrap();
+
+        scan_library(&root, &data, &index, false, false, false);
+        assert_eq!(index.list_books().unwrap().len(), 1, "indexed first");
+
+        // A disabling sidecar removes it from the index on the next scan.
+        let side = input
+            .canonicalize()
+            .unwrap()
+            .with_extension("podspine.toml");
+        std::fs::write(&side, b"disabled = true").unwrap();
+        scan_library(&root, &data, &index, false, false, false);
+        assert_eq!(
+            index.list_books().unwrap().len(),
+            0,
+            "disabled book is pruned"
+        );
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/crates/scanner/src/lib.rs
+++ b/crates/scanner/src/lib.rs
@@ -205,7 +205,11 @@ pub fn scan_book_as(
         let metadata_consistent = existing.title == eff_title
             && existing.author == eff_author
             && existing.storage_mode == eff_storage_mode
-            && existing.default_cover_url == eff_cover;
+            && existing.default_cover_url == eff_cover
+            // `force_embedded_chapters` changes the chapter SOURCE (embedded vs a
+            // `.cue`/`.ffmeta` sidecar) without touching the fields above, so a
+            // toggle must also re-ingest (Greptile 6.4 P1).
+            && existing.force_embedded == force_embedded;
         // `force_reingest` (a troubleshooting knob) always skips the early return
         // so the book is re-processed on every scan while set.
         if !force_reingest
@@ -368,6 +372,7 @@ pub fn scan_book_as(
         // Persist the effective mode so serve/evict honor it without the sidecar.
         storage_mode: eff_storage_mode,
         default_cover_url: eff_cover,
+        force_embedded,
     };
     index.upsert_book(&book)?;
 
@@ -533,6 +538,8 @@ fn scan_mp3_folder(
         status: "ready".to_string(),
         storage_mode: String::new(),
         default_cover_url: eff_cover,
+        // No chapters in an MP3 folder, so force_embedded never applies.
+        force_embedded: false,
     };
     index.upsert_book(&book)?;
 
@@ -2051,6 +2058,38 @@ mod tests {
         assert_eq!(
             guid_before, guid_after,
             "guid stable across a metadata-only edit"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn toggling_only_force_embedded_reingests() {
+        if !ffmpeg_available() {
+            eprintln!("skipping: ffmpeg not available");
+            return;
+        }
+        let root = scratch("perbook-fe");
+        let input = synth(&root, false);
+        let data = root.join("data");
+        let index = Index::open_in_memory().unwrap();
+
+        scan_library(&root, &data, &index, false, false, false);
+        let id = index.list_books().unwrap().remove(0).id;
+        assert!(!index.get_book(&id).unwrap().unwrap().force_embedded);
+
+        // Change ONLY `force_embedded_chapters` (no title/storage/cover change): it
+        // alters the chapter source but not the other persisted fields, so the
+        // metadata guard must still re-ingest (Greptile P1).
+        let side = input
+            .canonicalize()
+            .unwrap()
+            .with_extension("podspine.toml");
+        std::fs::write(&side, b"force_embedded_chapters = true").unwrap();
+        scan_library(&root, &data, &index, false, false, false);
+        assert!(
+            index.get_book(&id).unwrap().unwrap().force_embedded,
+            "a force_embedded-only toggle re-ingested"
         );
 
         let _ = std::fs::remove_dir_all(&root);

--- a/crates/scanner/src/lib.rs
+++ b/crates/scanner/src/lib.rs
@@ -149,6 +149,14 @@ pub fn scan_book_as(
     };
     let force_reingest = overrides.force_reingest == Some(true);
 
+    // Effective per-book metadata (override → default). Computed up here so the
+    // idempotency check can spot a `.podspine.toml` edit (which doesn't change the
+    // audio mtime) and re-ingest, and so the BookRow build below reuses it.
+    let eff_title = overrides.title.clone().unwrap_or_else(|| file_stem(input));
+    let eff_author = overrides.author.clone();
+    let eff_storage_mode = if saver { "saver" } else { "full" }.to_string();
+    let eff_cover = overrides.default_cover_url.clone();
+
     let id = id.to_string();
     let source_mtime = mtime_epoch(input)?;
     let book_out = data_dir.join("books").join(&id);
@@ -189,9 +197,19 @@ pub fn scan_book_as(
                 || (!e.source_path.is_empty() && e.file_path != e.source_path);
             regenerable || Path::new(&e.file_path).exists()
         });
-        // `force_reingest` (a `.podspine.toml` troubleshooting knob) always skips
-        // the early return so the book is re-processed on every scan while set.
+        // A `.podspine.toml` edit doesn't change the audio mtime, so also re-ingest
+        // when the persisted metadata no longer matches the current overrides
+        // (Greptile 6.4 P1) — otherwise a changed title/author/storage_mode/cover
+        // would stay stale in the index. `source_mtime` is unchanged, so episode
+        // guids stay stable (no spurious client re-downloads).
+        let metadata_consistent = existing.title == eff_title
+            && existing.author == eff_author
+            && existing.storage_mode == eff_storage_mode
+            && existing.default_cover_url == eff_cover;
+        // `force_reingest` (a troubleshooting knob) always skips the early return
+        // so the book is re-processed on every scan while set.
         if !force_reingest
+            && metadata_consistent
             && !eps.is_empty()
             && start_secs_recorded
             && faststart_consistent
@@ -339,16 +357,17 @@ pub fn scan_book_as(
         id: id.clone(),
         slug: id.clone(),
         feed_id: podspine_index::capability::generate(),
-        // Per-book overrides (Sprint 6.4): title/author from the sidecar if set.
-        title: overrides.title.clone().unwrap_or_else(|| file_stem(input)),
-        author: overrides.author.clone(),
+        // Per-book overrides (Sprint 6.4), computed above and re-checked by the
+        // idempotency guard so a sidecar edit re-persists them.
+        title: eff_title,
+        author: eff_author,
         cover_path,
         source_path: input.to_string_lossy().into_owned(),
         source_mtime,
         status: "ready".to_string(),
         // Persist the effective mode so serve/evict honor it without the sidecar.
-        storage_mode: if saver { "saver" } else { "full" }.to_string(),
-        default_cover_url: overrides.default_cover_url.clone(),
+        storage_mode: eff_storage_mode,
+        default_cover_url: eff_cover,
     };
     index.upsert_book(&book)?;
 
@@ -448,13 +467,24 @@ fn scan_mp3_folder(
         .unwrap_or(0);
     let book_out = data_dir.join("books").join(id);
 
+    // Effective per-book metadata (override → default). `storage_mode`/`remux`/
+    // `force_embedded` are no-ops for MP3 folders, so only title/author/cover
+    // apply. Computed here to detect a `.podspine.toml` edit and reused below.
+    let eff_title = overrides.title.clone().unwrap_or_else(|| dir_name(dir));
+    let eff_author = overrides.author.clone();
+    let eff_cover = overrides.default_cover_url.clone();
+
     // Idempotency: unchanged and already served in place -> no re-probe.
     // The `source_path` guard forces a one-time re-ingest of a pre-6.2 book
     // (tracks copied under <data_dir>, empty `source_path`) so it flips to
-    // in-place serving and its copies get reclaimed.
+    // in-place serving and its copies get reclaimed. The metadata checks re-ingest
+    // on a `.podspine.toml` edit that didn't change the folder mtime (Greptile P1).
     if overrides.force_reingest != Some(true)
         && let Some(existing) = index.get_book(id)?
         && existing.source_mtime == source_mtime
+        && existing.title == eff_title
+        && existing.author == eff_author
+        && existing.default_cover_url == eff_cover
     {
         let eps = index.episodes_for_book(id)?;
         if !eps.is_empty()
@@ -491,17 +521,18 @@ fn scan_mp3_folder(
         id: id.to_string(),
         slug: id.to_string(),
         feed_id: podspine_index::capability::generate(),
-        // Per-book overrides (Sprint 6.4). storage_mode/remux/force_embedded are
-        // no-ops for MP3 folders (tracks are always served in place), so only
-        // title/author/cover apply; persist storage_mode as `""` (follow global).
-        title: overrides.title.clone().unwrap_or_else(|| dir_name(dir)),
-        author: overrides.author.clone(),
+        // Per-book overrides (Sprint 6.4), computed above and re-checked by the
+        // idempotency guard so a sidecar edit re-persists them. storage_mode/remux/
+        // force_embedded are no-ops for MP3 folders (tracks are served in place),
+        // so persist storage_mode as `""` (follow global).
+        title: eff_title,
+        author: eff_author,
         cover_path: None,
         source_path: dir.to_string_lossy().into_owned(),
         source_mtime,
         status: "ready".to_string(),
         storage_mode: String::new(),
-        default_cover_url: overrides.default_cover_url.clone(),
+        default_cover_url: eff_cover,
     };
     index.upsert_book(&book)?;
 
@@ -1982,6 +2013,46 @@ mod tests {
             books[0].storage_mode, "saver",
             "per-book storage_mode is persisted for serve/evict"
         );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn editing_sidecar_reingests_without_touching_audio() {
+        if !ffmpeg_available() {
+            eprintln!("skipping: ffmpeg not available");
+            return;
+        }
+        let root = scratch("perbook-edit");
+        let input = synth(&root, false);
+        let data = root.join("data");
+        let index = Index::open_in_memory().unwrap();
+
+        // First scan: no sidecar → default title, `full`.
+        scan_library(&root, &data, &index, false, false, false);
+        let before = index.list_books().unwrap().remove(0);
+        assert_eq!(before.storage_mode, "full");
+        let guid_before = index.episodes_for_book(&before.id).unwrap()[0].guid.clone();
+
+        // Edit the sidecar — the AUDIO file is untouched (same mtime). The edit
+        // must still take effect on the next scan (Greptile 6.4 P1).
+        let side = input
+            .canonicalize()
+            .unwrap()
+            .with_extension("podspine.toml");
+        std::fs::write(&side, b"title = \"Edited\"\nstorage_mode = \"saver\"\n").unwrap();
+        scan_library(&root, &data, &index, false, false, false);
+
+        let after = index.get_book(&before.id).unwrap().unwrap();
+        assert_eq!(after.title, "Edited", "sidecar title applied on re-scan");
+        assert_eq!(after.storage_mode, "saver", "sidecar storage_mode applied");
+        // source_mtime is unchanged, so the episode guid is stable — a metadata
+        // edit doesn't make podcast clients re-download.
+        let guid_after = index.episodes_for_book(&before.id).unwrap()[0].guid.clone();
+        assert_eq!(
+            guid_before, guid_after,
+            "guid stable across a metadata-only edit"
+        );
+
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -96,6 +96,44 @@ chapter, **not** a pinned second copy. The default is **off** because in-place
 serving costs no disk; enable it if slow seeking on those books bothers you and
 you can spare the cache. (A faststart mp4, or any non-mp4, is left untouched.)
 
+## Per-book overrides (`.podspine.toml`)
+
+Any of the per-book-meaningful settings above can be overridden for **one book**
+with a small `.podspine.toml` sidecar — handy for troubleshooting a single
+misbehaving book without changing the whole server. Precedence: **sidecar → CLI /
+env → global config file → default.**
+
+**Where to put it** (works for every library layout):
+
+- **A single file** — name it after the file: `Author - Title.podspine.toml`
+  beside `Author - Title.m4b` (same as a `.cue` sidecar). Works whether the file
+  is at the top level or in its own folder.
+- **A multi-file (MP3-folder) book, or a lone file kept in its own folder** — drop
+  a `.podspine.toml` **inside that folder**.
+
+**Keys you can set:**
+
+| Key | Effect |
+|---|---|
+| `storage_mode` | `"full"`/`"saver"` for just this book (serve + eviction honor it). |
+| `force_embedded_chapters` | Ignore this book's `.cue`/`.ffmeta` sidecar. |
+| `remux_non_faststart` | Remux this book to faststart if it's a non-faststart mp4. |
+| `default_cover_url` | Feed cover fallback for this book. |
+| `title` / `author` | Override the feed title/author (fix metadata without renaming files). |
+| `disabled` | `true` removes this book from the index and every feed/page. |
+| `force_reingest` | `true` re-processes the book on every scan (drop it once you're done). |
+
+```toml
+# Author - Title.podspine.toml — force this one big book onto saver, fix its title
+storage_mode = "saver"
+title = "The Correct Title"
+```
+
+Server-wide keys (`bind`, `base_url`, `library`, `data_dir`, `cache_size`,
+`cache_ttl`, …) are **ignored with a log warning** if they appear in a per-book
+file — they only make sense server-wide. An unparseable sidecar is logged and
+skipped for that book; it never aborts the scan.
+
 ## Exposing Podspine safely
 
 Podspine has two kinds of routes, and they want different exposure:


### PR DESCRIPTION
Sprint 6, Task 6.4 (expanded) — the last Sprint 6 storage task.

A per-book `.podspine.toml` sidecar overrides settings for **one book** — great for troubleshooting a misbehaving book without changing the whole server. Precedence: **sidecar → CLI/env → global config → default.**

## Sidecar location (every library layout)
- **Single-file book** (top-level `Author - Title.m4b`, or one file in its own folder) → `Author - Title.podspine.toml` beside the audio (same convention as `.cue`).
- **MP3-folder book, or a lone file in its own folder** → `.podspine.toml` inside the folder (never the shared library root).

## Keys
- **Config overrides:** `storage_mode`, `force_embedded_chapters`, `remux_non_faststart`, `default_cover_url`.
- **Troubleshooting-only:** `disabled` (skip + prune the book), `title`, `author`, `force_reingest` (re-process on every scan while set).
- **Server-wide keys** (`bind`/`base_url`/`library`/`data_dir`/`cache_*`) in a per-book file are **ignored with a warning**; an unparseable sidecar is a per-book warning, never fatal.

## How it's built
- **config** — new `book_overrides` module: `BookOverrides` (deny-unknown-fields → a typo warns; `ignored_global_keys` reports server-wide keys) + `sidecar_path` resolution.
- **index** — `book.storage_mode` + `book.default_cover_url` columns (additive migration; pre-6.4 rows default to "follow global").
- **scanner** — resolves + applies per book: effective `force_embedded`/`saver`/`remux`, `title`/`author`/cover, `disabled` → skip + `delete_book`, `force_reingest` → skip the idempotency early return.
- **http/feed** — `book_is_saver()` gates serve-regen **and** eviction per book, so a `full` book's kept chapters are never evicted (no 404); the feed uses a per-book cover fallback before the global one.

## Acceptance criteria (all met)
- [x] Sidecar resolves for top-level files, files-in-subfolders, and MP3 folders; unset keys fall back to server config.
- [x] `storage_mode="saver"` on one book serves/regenerates + evicts as saver even when the server is `full` (integration-tested).
- [x] `force_embedded_chapters`/`remux_non_faststart`/`default_cover_url` apply per book.
- [x] `disabled` removes the book from the index; `title`/`author` override the feed; `force_reingest` forces a re-ingest.
- [x] A server-global key is ignored with a warning (not fatal); a bad sidecar is a per-book warning.

## Security
Re-audited — **sound, no findings.** No filesystem path is built from sidecar content (fields are bools/strings/URLs); a `title` override can't repoint the storage dir or feed slug (those come from the opaque id/slug); `disabled` only prunes its own book by DB key; ffmpeg argv is unchanged. The auditor also noted the eviction change **fixes a latent 404/data-loss gap** (eviction now keys off the same predicate as serve-regen). One pre-existing, out-of-scope defense-in-depth note (chaptered regen source lacks the `starts_with(library_dir)` re-assertion the faststart arm has) is recorded as a follow-up.

## Tests / coverage
config (sidecar resolution for all layouts, parse + ignored-global-keys, typo→err); index (migration); scanner (override application, disabled→prune, toggle re-ingest); http (per-book saver served when server is full). Local gate green (fmt, clippy `-D warnings`, full suite); `cargo llvm-cov --workspace` at **92.9%** (floor 90%).

> Note: adds a **fourth** unreleased changeset; the held knope release PR (#54) will want an "Update branch" before you cut the release.

> Minor tech debt: `scan_book_as` is now 8 args (`#[allow(too_many_arguments)]` + a TODO to bundle the globals into a `ScanOptions` struct if a further knob lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)