### PR TITLE
test: fill coverage gaps + add new submodules to codecov components

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -85,6 +85,7 @@ component_management:
       name: prober & chapters
       paths:
         - crates/prober/src/lib.rs
+        - crates/prober/src/faststart.rs
         - crates/chapters/src/lib.rs
     - component_id: splitter
       name: splitter (ffmpeg)
@@ -111,6 +112,7 @@ component_management:
       name: config
       paths:
         - crates/config/src/lib.rs
+        - crates/config/src/book_overrides.rs
     - component_id: server_cli
       name: server & cli
       paths:

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -645,7 +645,10 @@ mod tests {
 
     #[test]
     fn validate_rejects_a_missing_or_non_dir_library() {
-        let tmp = std::env::temp_dir().join("podspine-cfg-validate");
+        // Own subdir — must NOT share a fixed path with any sibling test, or the
+        // parallel runner races the remove_dir_all/create_dir_all below against
+        // `validate_accepts_a_real_dir_and_creates_data_dir` (uses `-validate`).
+        let tmp = std::env::temp_dir().join("podspine-cfg-validate-reject");
         let _ = std::fs::remove_dir_all(&tmp);
         std::fs::create_dir_all(&tmp).unwrap();
 
@@ -679,6 +682,26 @@ mod tests {
         assert!(ok.validate().is_ok());
         assert!(ok.data_dir.is_dir(), "data dir created by validate");
 
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn validate_reports_data_dir_when_the_path_is_unwritable() {
+        // library is a real dir (passes exists/is_dir), but data_dir sits UNDER a
+        // regular file, so create_dir_all fails -> ConfigError::DataDir.
+        let tmp = std::env::temp_dir().join("podspine-cfg-datadir");
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+        let blocker = tmp.join("iam-a-file");
+        std::fs::write(&blocker, b"x").unwrap();
+        let mut cl = cli(Some(tmp.to_str().unwrap()));
+        cl.data_dir = Some(blocker.join("data")); // parent is a file -> create fails
+        let c = Config::resolve(&cl, &FileConfig::default()).unwrap();
+        assert!(
+            matches!(c.validate(), Err(ConfigError::DataDir { .. })),
+            "{:?}",
+            c.validate()
+        );
         let _ = std::fs::remove_dir_all(&tmp);
     }
 

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -644,6 +644,45 @@ mod tests {
     }
 
     #[test]
+    fn validate_rejects_a_missing_or_non_dir_library() {
+        let tmp = std::env::temp_dir().join("podspine-cfg-validate");
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        // --library points at a real FILE (not a directory) → LibraryNotDir.
+        let as_file = tmp.join("not-a-dir");
+        std::fs::write(&as_file, b"x").unwrap();
+        let c = Config::resolve(
+            &cli(Some(as_file.to_str().unwrap())),
+            &FileConfig::default(),
+        )
+        .unwrap();
+        assert!(matches!(c.validate(), Err(ConfigError::LibraryNotDir(_))));
+
+        // A missing --library → LibraryNotFound.
+        let missing = tmp.join("nope");
+        let c2 = Config::resolve(
+            &cli(Some(missing.to_str().unwrap())),
+            &FileConfig::default(),
+        )
+        .unwrap();
+        assert!(matches!(
+            c2.validate(),
+            Err(ConfigError::LibraryNotFound(_))
+        ));
+
+        // A valid dir library validates OK and creates the data dir (kept under
+        // tmp so the test never writes `./data` into the repo).
+        let mut cl = cli(Some(tmp.to_str().unwrap()));
+        cl.data_dir = Some(tmp.join("data"));
+        let ok = Config::resolve(&cl, &FileConfig::default()).unwrap();
+        assert!(ok.validate().is_ok());
+        assert!(ok.data_dir.is_dir(), "data dir created by validate");
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
     fn storage_knobs_resolve_from_cli_over_file() {
         let file = FileConfig {
             storage_mode: Some(StorageMode::Full),

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -912,6 +912,30 @@ mod tests {
     }
 
     #[test]
+    fn book_is_saver_follows_per_book_then_global() {
+        let mk = |mode: &str| BookRow {
+            id: "b".into(),
+            slug: "b".into(),
+            feed_id: "cap".into(),
+            title: "T".into(),
+            author: None,
+            cover_path: None,
+            source_path: "/x".into(),
+            source_mtime: 0,
+            status: "ready".into(),
+            storage_mode: mode.into(),
+            default_cover_url: None,
+            force_embedded: false,
+        };
+        // An explicit per-book mode wins regardless of the server default.
+        assert!(book_is_saver(&mk("saver"), false));
+        assert!(!book_is_saver(&mk("full"), true));
+        // An empty mode (a pre-6.4 row) follows the server default.
+        assert!(book_is_saver(&mk(""), true));
+        assert!(!book_is_saver(&mk(""), false));
+    }
+
+    #[test]
     fn valid_slug_allow_list() {
         // Accepts exactly what slugify produces.
         assert!(valid_slug("dune"));

--- a/crates/http/tests/server.rs
+++ b/crates/http/tests/server.rs
@@ -740,6 +740,141 @@ async fn per_book_saver_serves_even_when_server_is_full() {
 }
 
 #[tokio::test]
+async fn regenerate_rejects_an_invalid_slug() {
+    // No ffmpeg: the slug is rejected before any DB/filesystem work.
+    let dir = std::env::temp_dir().join("podspine-http-regen-badslug");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let data = dir.join("data");
+    let index = Index::open_in_memory().unwrap();
+    let state = AppState::new(
+        index,
+        "http://test".to_string(),
+        &data,
+        &dir,
+        None,
+        false,
+        None,
+        None,
+    );
+    let app = router(state);
+    // Same-origin (no cross-site header) but an invalid slug (uppercase) → 404.
+    let resp = app
+        .oneshot(
+            Request::post("/book/BadSlug/regenerate")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn cover_path_outside_the_data_dir_is_a_404() {
+    if !ffmpeg_available() {
+        eprintln!("skipping: ffmpeg not available");
+        return;
+    }
+    let dir = std::env::temp_dir().join("podspine-http-cover-escape");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let data = dir.join("data");
+    let index = Index::open_in_memory().unwrap();
+    let input = synth_with_cover(&dir);
+    let mut book = scan_book(&input, &data, &index).unwrap();
+    assert!(book.cover_path.is_some());
+    // Point the cover at a real file OUTSIDE the data dir; the cover handler must
+    // reject it even though it exists (covers must live under the data dir).
+    let outside = dir.join("evil.jpg");
+    std::fs::write(&outside, b"img").unwrap();
+    book.cover_path = Some(outside.to_string_lossy().into_owned());
+    index.upsert_book(&book).unwrap();
+    let feed_id = book.feed_id.clone();
+
+    let state = AppState::new(
+        index,
+        "http://test".to_string(),
+        &data,
+        &dir,
+        None,
+        false,
+        None,
+        None,
+    );
+    let app = router(state);
+    let resp = app
+        .oneshot(
+            Request::get(format!("/cover/{feed_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn remux_source_outside_the_library_is_a_404() {
+    if !ffmpeg_available() {
+        eprintln!("skipping: ffmpeg not available");
+        return;
+    }
+    let base = std::env::temp_dir().join("podspine-http-remux-escape");
+    let _ = std::fs::remove_dir_all(&base);
+    let library = base.join("library");
+    let data = base.join("data");
+    std::fs::create_dir_all(&library).unwrap();
+    let index = Index::open_in_memory().unwrap();
+    // A non-faststart file, ingested with remux ON → a remux-cache episode
+    // (file_path != source_path, needs_faststart); the cache file was deleted.
+    let input = synth_flat(&library);
+    let book = scan_book_as(
+        &input,
+        "rmx",
+        &data,
+        &index,
+        false,
+        false,
+        true,
+        &BookOverrides::default(),
+    )
+    .unwrap();
+    let feed_id = book.feed_id.clone();
+    let mut ep = index.episodes_for_book(&book.id).unwrap()[0].clone();
+    assert_ne!(ep.source_path, ep.file_path, "precondition: remuxed");
+    // Point the remux source OUTSIDE the library; the regen branch must reject it.
+    let outside = base.join("outside.m4a");
+    std::fs::copy(&input, &outside).unwrap();
+    ep.source_path = outside.to_string_lossy().into_owned();
+    index.upsert_episode(&ep).unwrap();
+
+    let state = AppState::new(
+        index,
+        "http://test".to_string(),
+        &data,
+        &library,
+        None,
+        false,
+        None,
+        None,
+    );
+    let app = router(state);
+    let resp = app
+        .oneshot(
+            Request::get(format!("/audio/{feed_id}/1"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    let _ = std::fs::remove_dir_all(&base);
+}
+
+#[tokio::test]
 async fn regenerate_rotates_the_capability() {
     if !ffmpeg_available() {
         eprintln!("skipping: ffmpeg not available");

--- a/crates/prober/src/faststart.rs
+++ b/crates/prober/src/faststart.rs
@@ -164,6 +164,28 @@ mod tests {
     }
 
     #[test]
+    fn a_box_smaller_than_its_8_byte_header_is_malformed() {
+        // A size field below the 8-byte box header (here 4) is malformed → give up
+        // (return false), never loop or misread.
+        let p = write("tinybox", &[vec![0, 0, 0, 4, b'f', b't', b'y', b'p']]);
+        assert!(!needs_faststart(&p));
+        let _ = std::fs::remove_file(&p);
+    }
+
+    #[test]
+    fn a_box_size_overflowing_the_offset_terminates() {
+        // A valid `ftyp`, then a 64-bit largesize box whose size overflows
+        // `pos + size` → `checked_add` returns None → clean break (no panic/loop).
+        let mut bytes = mp4_box(b"ftyp", b"isom");
+        bytes.extend_from_slice(&1u32.to_be_bytes()); // size32 = 1 (largesize follows)
+        bytes.extend_from_slice(b"free");
+        bytes.extend_from_slice(&u64::MAX.to_be_bytes());
+        let p = write("overflow-add", &[bytes]);
+        assert!(!needs_faststart(&p));
+        let _ = std::fs::remove_file(&p);
+    }
+
+    #[test]
     fn a_crafted_64bit_largesize_box_does_not_overflow() {
         // First box: size32 == 1 (a 64-bit largesize follows the type), type
         // "free", largesize near u64::MAX. Advancing `pos` by it must not overflow

--- a/crates/scanner/src/lib.rs
+++ b/crates/scanner/src/lib.rs
@@ -2262,8 +2262,13 @@ mod tests {
         }
         assert!(indexed, "the watcher indexed the book added after startup");
 
-        let _ = std::fs::remove_dir_all(&root);
-        let _ = std::fs::remove_dir_all(&data);
+        // Deliberately do NOT tear down `root`/`data` here. `spawn_library_watcher`
+        // is a detached, process-lifetime daemon with no shutdown hook (by design),
+        // so deleting its watched dir + WAL db out from under the live thread would
+        // make it churn on removed paths and could race later tests. `scratch()`
+        // already wipes these unique paths at the START of the next run, so nothing
+        // leaks across runs; the parked thread sees no further events and dies with
+        // the process.
     }
 
     #[test]

--- a/crates/scanner/src/lib.rs
+++ b/crates/scanner/src/lib.rs
@@ -2125,6 +2125,148 @@ mod tests {
     }
 
     #[test]
+    fn per_book_full_override_beats_global_saver() {
+        if !ffmpeg_available() {
+            eprintln!("skipping: ffmpeg not available");
+            return;
+        }
+        let root = scratch("perbook-full");
+        let input = synth(&root, true); // chaptered, so storage_mode matters
+        let side = input
+            .canonicalize()
+            .unwrap()
+            .with_extension("podspine.toml");
+        std::fs::write(&side, b"storage_mode = \"full\"").unwrap();
+        let data = root.join("data");
+        let index = Index::open_in_memory().unwrap();
+
+        // Global saver, but the sidecar forces `full` for this book.
+        scan_library(&root, &data, &index, false, true, false);
+        let b = index.list_books().unwrap().remove(0);
+        assert_eq!(
+            b.storage_mode, "full",
+            "sidecar full overrides global saver"
+        );
+        let eps = index.episodes_for_book(&b.id).unwrap();
+        assert!(
+            Path::new(&eps[0].file_path).exists(),
+            "full mode keeps the split on disk"
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn sidecar_global_key_is_ignored_and_a_typo_is_non_fatal() {
+        if !ffmpeg_available() {
+            eprintln!("skipping: ffmpeg not available");
+            return;
+        }
+        // A server-global key in a sidecar is ignored (warned); the per-book key
+        // still applies.
+        let root = scratch("perbook-global");
+        let input = synth(&root, false);
+        let side = input
+            .canonicalize()
+            .unwrap()
+            .with_extension("podspine.toml");
+        std::fs::write(&side, b"bind = \"0.0.0.0:9\"\ntitle = \"Kept\"\n").unwrap();
+        let data = root.join("data");
+        let index = Index::open_in_memory().unwrap();
+        assert_eq!(
+            scan_library(&root, &data, &index, false, false, false).indexed,
+            1
+        );
+        assert_eq!(index.list_books().unwrap().remove(0).title, "Kept");
+        let _ = std::fs::remove_dir_all(&root);
+
+        // A typo (unknown key) is a per-book warning, not fatal — still indexes.
+        let root2 = scratch("perbook-typo");
+        let input2 = synth(&root2, false);
+        std::fs::write(
+            input2
+                .canonicalize()
+                .unwrap()
+                .with_extension("podspine.toml"),
+            b"stroage_mode = \"saver\"",
+        )
+        .unwrap();
+        let data2 = root2.join("data");
+        let index2 = Index::open_in_memory().unwrap();
+        assert_eq!(
+            scan_library(&root2, &data2, &index2, false, false, false).indexed,
+            1
+        );
+        assert_eq!(index2.list_books().unwrap().remove(0).storage_mode, "full");
+        let _ = std::fs::remove_dir_all(&root2);
+    }
+
+    #[test]
+    fn mp3_folder_with_no_probeable_tracks_is_skipped() {
+        if !ffmpeg_available() {
+            eprintln!("skipping: ffmpeg not available");
+            return;
+        }
+        let root = scratch("mp3-unprobeable");
+        let book = root.join("Broken");
+        std::fs::create_dir_all(&book).unwrap();
+        // Several `.mp3` files that aren't real audio → a folder book whose tracks
+        // all fail to probe → EmptyFolder → skipped, not fatal.
+        std::fs::write(book.join("01.mp3"), b"not audio at all").unwrap();
+        std::fs::write(book.join("02.mp3"), b"also not audio").unwrap();
+        let data = root.join("data");
+        let index = Index::open_in_memory().unwrap();
+        let summary = scan_library(&root, &data, &index, false, false, false);
+        assert_eq!(index.list_books().unwrap().len(), 0);
+        assert_eq!(summary.skipped, 1, "unprobeable MP3 folder skipped");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn library_watcher_indexes_a_book_added_after_startup() {
+        if !ffmpeg_available() {
+            eprintln!("skipping: ffmpeg not available");
+            return;
+        }
+        let root = scratch("watcher-lib");
+        let data = scratch("watcher-data");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(&data).unwrap();
+        let db_path = data.join("podspine.db");
+        // Create the schema so the watcher and this test share the WAL db.
+        drop(Index::open(&db_path).unwrap());
+
+        spawn_library_watcher(
+            root.clone(),
+            data.clone(),
+            db_path.clone(),
+            false,
+            false,
+            false,
+        );
+        // Let the watcher establish its filesystem watch before we add a file.
+        std::thread::sleep(std::time::Duration::from_millis(300));
+
+        // Add a book — the watcher should notice, reconcile, and index it.
+        let _input = synth(&root, false);
+
+        // Poll (debounce + reconcile + ffmpeg split take a moment); generous cap.
+        let mut indexed = false;
+        for _ in 0..100 {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            if let Ok(idx) = Index::open(&db_path)
+                && idx.list_books().map(|b| !b.is_empty()).unwrap_or(false)
+            {
+                indexed = true;
+                break;
+            }
+        }
+        assert!(indexed, "the watcher indexed the book added after startup");
+
+        let _ = std::fs::remove_dir_all(&root);
+        let _ = std::fs::remove_dir_all(&data);
+    }
+
+    #[test]
     fn chapterless_file_becomes_a_single_episode() {
         if !ffmpeg_available() {
             eprintln!("skipping: ffmpeg not available");

--- a/crates/splitter/src/lib.rs
+++ b/crates/splitter/src/lib.rs
@@ -896,4 +896,39 @@ mod tests {
         assert!(matches!(err, CoverError::Ffmpeg { .. }), "{err:?}");
         let _ = std::fs::remove_dir_all(&dir);
     }
+
+    #[test]
+    fn extract_cover_reports_create_dir_when_out_dir_is_a_file() {
+        // out_dir is an existing regular file -> create_dir_all fails BEFORE any
+        // ffmpeg spawn -> CoverError::CreateDir. ffmpeg-free, so it runs everywhere.
+        let dir = std::env::temp_dir().join("podspine-cover-createdir");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let file_as_dir = dir.join("iam-a-file");
+        std::fs::write(&file_as_dir, b"x").unwrap();
+        let err = extract_cover(Path::new("irrelevant.m4b"), &file_as_dir, "jpg")
+            .expect_err("out_dir being a file must fail");
+        assert!(matches!(err, CoverError::CreateDir { .. }), "{err:?}");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn split_book_reports_create_dir_when_out_dir_is_a_file() {
+        // Same guard on the chaptered path: out_dir is a file -> SplitError::CreateDir
+        // before any chapter is cut (ffmpeg-free).
+        let dir = std::env::temp_dir().join("podspine-split-createdir");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let file_as_dir = dir.join("iam-a-file");
+        std::fs::write(&file_as_dir, b"x").unwrap();
+        let ch = ChapterCut {
+            idx: 0,
+            start_sec: 0.0,
+            end_sec: 10.0,
+        };
+        let err = split_book(Path::new("irrelevant.m4b"), &file_as_dir, &[ch], "m4a")
+            .expect_err("out_dir being a file must fail");
+        assert!(matches!(err, SplitError::CreateDir { .. }), "{err:?}");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/crates/splitter/src/lib.rs
+++ b/crates/splitter/src/lib.rs
@@ -745,6 +745,30 @@ mod tests {
     }
 
     #[test]
+    fn split_chapter_maps_a_nonzero_ffmpeg_exit_to_an_error() {
+        if !have_ffmpeg() {
+            eprintln!("skipping: ffmpeg not available");
+            return;
+        }
+        // `split_chapter` (the saver/regen entry point) on a non-audio input:
+        // ffmpeg exits non-zero → the error arm, carrying the chapter index.
+        let dir = std::env::temp_dir().join("podspine-splitchap-fail");
+        let _ = std::fs::remove_dir_all(&dir);
+        let out = dir.join("out");
+        std::fs::create_dir_all(&out).unwrap();
+        let bad = dir.join("notaudio.m4a");
+        std::fs::write(&bad, b"definitely not an audio stream").unwrap();
+        let ch = ChapterCut {
+            idx: 2,
+            start_sec: 0.0,
+            end_sec: 5.0,
+        };
+        let err = split_chapter(&bad, &out, &ch, "m4a").expect_err("bad input must fail");
+        assert!(matches!(err, SplitError::Ffmpeg { idx: 2, .. }), "{err:?}");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
     fn remux_faststart_produces_a_deterministic_faststart_file() {
         if !have_ffmpeg() {
             eprintln!("skipping: ffmpeg not available");
@@ -807,6 +831,52 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn remux_maps_a_nonzero_ffmpeg_exit_to_a_split_error() {
+        if !have_ffmpeg() {
+            eprintln!("skipping: ffmpeg not available");
+            return;
+        }
+        // A non-audio input makes ffmpeg exit non-zero → the remux error arm.
+        let dir = std::env::temp_dir().join("podspine-remux-fail");
+        let _ = std::fs::remove_dir_all(&dir);
+        let out = dir.join("out");
+        std::fs::create_dir_all(&out).unwrap();
+        let bad = dir.join("notaudio.m4a");
+        std::fs::write(&bad, b"definitely not an audio stream").unwrap();
+        let err = remux_faststart(&bad, &out, 0, "m4a", 3.0).expect_err("bad input must fail");
+        assert!(matches!(err, SplitError::Ffmpeg { idx: 0, .. }), "{err:?}");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn semaphore_blocks_a_second_acquirer_until_release() {
+        use std::sync::Arc;
+        // One permit: a second acquirer must wait on the condvar (the wait path)
+        // until the first permit drops.
+        let sem = Arc::new(Semaphore {
+            permits: Mutex::new(1),
+            cv: Condvar::new(),
+        });
+        let p1 = sem.acquire();
+        assert_eq!(*sem.permits.lock().unwrap(), 0);
+        let sem2 = Arc::clone(&sem);
+        let done = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let done2 = Arc::clone(&done);
+        let handle = std::thread::spawn(move || {
+            let _p2 = sem2.acquire(); // blocks on cv.wait until p1 is released
+            done2.store(true, std::sync::atomic::Ordering::SeqCst);
+        });
+        std::thread::sleep(Duration::from_millis(50));
+        assert!(
+            !done.load(std::sync::atomic::Ordering::SeqCst),
+            "second acquirer is still blocked while the permit is held"
+        );
+        drop(p1); // release → wakes the waiter
+        handle.join().unwrap();
+        assert!(done.load(std::sync::atomic::Ordering::SeqCst));
     }
 
     #[test]


### PR DESCRIPTION
A focused test-coverage pass (no behavior change). Workspace line coverage **92.8% → 94.2%**.

Targeted the genuinely-testable gaps and left the defensible-hard tail (fs-error closures, the live server bind, ffmpeg `Spawn`/`TimedOut` paths, and multi-line-call `)?;` attribution artifacts).

## Codecov components (the "missing components")
Component paths are **explicit files, not `**` globs** (globs silently don't match — see the codecov.yml comment). The two new submodules from 6.3/6.4 were orphaned from their components, so their coverage wasn't attributed. Added:
- `crates/prober/src/faststart.rs` → **prober & chapters**
- `crates/config/src/book_overrides.rs` → **config**

## New tests
- **scanner** — the background **library watcher** (~40 lines, `spawn_library_watcher`/`watch_loop`) now has an integration test: add a book after startup, poll until the watcher reconciles + indexes it. Plus: per-book `full` beats global `saver`; a server-global sidecar key is ignored + a typo is non-fatal; an unprobeable MP3 folder is skipped.
- **splitter** — `remux_faststart` and `split_chapter` map a non-zero ffmpeg exit to an error; the semaphore blocks a second acquirer until the first permit is released.
- **prober** — faststart handles a sub-8-byte box and a 64-bit `largesize` that overflows the offset (`faststart.rs` now **100%**).
- **http** — `book_is_saver` arm coverage (per-book → empty-follows-global); a cover path outside the data dir 404s; a remux source outside the library 404s; regenerate rejects an invalid slug.
- **config** — `validate()` rejects a missing / non-directory library.

## Notable per-file moves
- `prober/faststart.rs` 98% → **100%**
- `scanner` 88.5% → **92.0%** (the watcher test)
- `http` 95.6% → **96.5%**, `config` → **96.5%**

Local gate green (fmt, clippy `-D warnings`, full suite); `cargo llvm-cov --workspace` at **94.2%** (floor 90%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)