### PR TITLE
docs: fix 1.3.0 changelog contradiction + make version-pin examples release-agnostic

### DIFF
--- a/.changeset/storage-saver-mode.md
+++ b/.changeset/storage-saver-mode.md
@@ -2,4 +2,4 @@
 default: minor
 ---
 
-Add an opt-in `saver` storage mode (`PODSPINE_STORAGE_MODE=saver`) that keeps chapters in a bounded on-demand cache (`PODSPINE_CACHE_SIZE`/`PODSPINE_CACHE_TTL`) instead of keeping every chapter split on disk — cutting the data-dir footprint for chaptered books (folder-of-MP3 books are still copied in full) for a small first-play delay per chapter. Ingest still splits each chapter once to record its real byte length, so `saver` saves disk, not ingest time.
+Add an opt-in `saver` storage mode (`PODSPINE_STORAGE_MODE=saver`) that keeps chapters in a bounded on-demand cache (`PODSPINE_CACHE_SIZE`/`PODSPINE_CACHE_TTL`) instead of keeping every chapter split on disk — cutting the data-dir footprint for chaptered books (whole-file books such as folder-of-MP3 tracks stream in place regardless of storage mode) for a small first-play delay per chapter. Ingest still splits each chapter once to record its real byte length, so `saver` saves disk, not ingest time.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -41,13 +41,13 @@ Overrides (environment variables):
 
 | Var | Default | Purpose |
 |---|---|---|
-| `PODSPINE_VERSION` | latest release | Pin a version, e.g. `1.2.0` |
+| `PODSPINE_VERSION` | latest release | Pin a specific release tag, e.g. `X.Y.Z` |
 | `PODSPINE_INSTALL_DIR` | `~/.local/bin` | Install location (uses `sudo` only if it isn't writable) |
 
 ```bash
-# Pin a version and install system-wide:
+# Pin a specific version (replace X.Y.Z) and install system-wide:
 curl -fsSL https://raw.githubusercontent.com/schubydoo/podspine/main/install.sh \
-  | PODSPINE_VERSION=1.2.0 PODSPINE_INSTALL_DIR=/usr/local/bin bash
+  | PODSPINE_VERSION=X.Y.Z PODSPINE_INSTALL_DIR=/usr/local/bin bash
 ```
 
 **Uninstall** (removes the binary only — never your library or data dir):

--- a/install.ps1
+++ b/install.ps1
@@ -13,7 +13,7 @@
   install them separately and keep them on PATH (this script warns if missing).
 
   Environment overrides:
-    PODSPINE_VERSION       pin a version (e.g. 1.1.0); default: latest release
+    PODSPINE_VERSION       pin a specific release tag (e.g. X.Y.Z); default: latest release
     PODSPINE_INSTALL_DIR   install directory; default: %LOCALAPPDATA%\Programs\podspine
 #>
 

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 # missing).
 #
 # Environment overrides:
-#   PODSPINE_VERSION       pin a version (e.g. 1.1.0); default: latest release
+#   PODSPINE_VERSION       pin a specific release tag (e.g. X.Y.Z); default: latest release
 #   PODSPINE_INSTALL_DIR   install directory; default: ~/.local/bin
 # ============================================================================
 


### PR DESCRIPTION
## 1. Changelog self-contradiction (release-blocking)
The `saver` changeset (`#53`) still said *"folder-of-MP3 books are still copied in full"*, but serve-in-place (`#59`) — shipping in the **same 1.3.0 release** — streams those tracks in place, never copying them. Reworded to scope `saver` to chaptered books and note whole-file books stream in place regardless of mode.

**Release sequencing:** merge this **before** running *Update branch* on the release PR (#54) so knope regenerates the CHANGELOG with the corrected text.

## 2. Version-pin examples made release-agnostic
The `PODSPINE_VERSION` pin examples hard-coded a concrete release (`1.2.0` in `docs/installation.md`, `1.1.0` in the install-script usage), so they went stale on every release. Replaced with an `X.Y.Z` placeholder in `installation.md`, `install.sh`, and `install.ps1` so they never need a per-release bump. (The `v1.1.0 -> 1.1.0` comment lines in `install.sh` just illustrate the v-strip transform and are left as-is.)

No product code changes. Found during a pre-release doc audit; the rest of the docs (README / DEPLOYMENT / ARCHITECTURE / index) already describe serve-in-place correctly.