### PR TITLE
ci(packaging): fix asset-wait guard that broke on the first attempt

### DIFF
--- a/.github/workflows/packaging-bump.yml
+++ b/.github/workflows/packaging-bump.yml
@@ -37,7 +37,9 @@ jobs:
     # ref can't run this write-capable job. (release events use the default branch anyway.)
     if: ${{ github.event_name == 'release' || github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Must exceed the checksums.txt wait budget below (~20 min) plus the download +
+    # bump + PR work, or Actions kills the job mid-wait for a slow release build.
+    timeout-minutes: 25
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/packaging-bump.yml
+++ b/.github/workflows/packaging-bump.yml
@@ -105,19 +105,22 @@ jobs:
           tmp="$(mktemp -d)"
           # release.yml publishes the release before its 5-platform matrix finishes
           # uploading assets, so `release: published` can fire before checksums.txt
-          # exists. Wait for it (up to ~5 min) instead of racing to a hard failure.
-          for i in $(seq 1 20); do
-            # `|| asset_index=null` so a transient gh/API failure keeps waiting
-            # rather than yielding "" (which would pass the != "null" test and
-            # break early, right back into the race this loop exists to avoid).
-            asset_index="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
-                    --json assets --jq '[.assets[].name]|index("checksums.txt")')" \
-                    || asset_index="null"
-            if [ "$asset_index" != "null" ]; then
+          # exists. Wait for it (up to ~20 min) instead of racing to a hard failure.
+          #
+          # `any(...)` yields a literal `true`/`false` and never an empty string, so a
+          # "not present yet" result can't be misread as "present". The previous
+          # `index(...) != "null"` check broke on attempt 1 because `gh --jq` prints
+          # "" (not "null") for a JSON null, which passed the `!= "null"` test.
+          # `|| have=retry` additionally keeps waiting through a transient gh/API error.
+          for i in $(seq 1 40); do
+            have="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
+                    --json assets --jq 'any(.assets[].name; . == "checksums.txt")')" \
+                    || have=retry
+            if [ "$have" = "true" ]; then
               break
             fi
-            echo "checksums.txt not on $TAG yet (attempt $i/20) — waiting 15s..."
-            sleep 15
+            echo "checksums.txt not on $TAG yet (attempt $i/40, state=$have) — waiting 30s..."
+            sleep 30
           done
           gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern checksums.txt --dir "$tmp"
           python3 scripts/bump_packaging.py "$VERSION" "$GITHUB_REPOSITORY" "$tmp/checksums.txt"


### PR DESCRIPTION
The `checksums.txt` wait-loop in `packaging-bump.yml` is supposed to poll (~5 min) while `release.yml` uploads assets, but it **gave up in ~1 second** — which is why the **1.3.0 packaging bump failed** while the binaries were still building.

## Root cause
`gh --json assets --jq '[.assets[].name]|index("checksums.txt")'` prints an **empty string** for a JSON `null` (no match), not the literal `"null"`. The `|| asset_index="null"` fallback only fires on a **non-zero gh exit**, so a *successful-but-empty* result passed the `!= "null"` test and `break`s on attempt 1 → `gh release download` then failed with `no assets to download`. (The existing comment even predicted this failure mode.)

## Fix
- Probe with `any(.assets[].name; . == "checksums.txt")` → yields a literal `true`/`false`, never empty, so "not yet" can't be misread as "present". Break only on `"true"`; `|| have=retry` still rides out a transient gh/API error.
- Widen the budget to ~20 min (40 × 30s); a 5-platform + cosign + GHCR build can exceed the old 5-min window.

## Alternative considered
Switching the trigger to `workflow_run` on **Release completed** so it can't start before assets exist. Left out to keep this minimal — the fixed guard + longer wait resolves the actual failure; happy to follow up if you'd prefer the trigger change.

Workflow-only; no product code. The 1.3.0 manifests are being recovered separately by re-running the failed bump once assets land.