### PR TITLE
chore: centralize Renovate config via shared preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,30 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended",
-    ":semanticCommits",
-    "helpers:pinGitHubActionDigests"
-  ],
-  "labels": ["dependencies"],
-  "schedule": ["before 6am on monday"],
-  "lockFileMaintenance": {
-    "description": "Keep flake.lock (nixpkgs/flake-utils) fresh weekly.",
-    "enabled": true,
-    "automerge": true,
-    "schedule": ["before 7am on monday"]
-  },
-  "packageRules": [
-    {
-      "description": "One PR for all GitHub Actions bumps.",
-      "matchManagers": ["github-actions"],
-      "groupName": "github-actions"
-    },
-    {
-      "description": "Batch non-major Cargo updates for STABLE (>=1.0) crates only. A 0.x minor bump is a breaking change under Cargo semver, so 0.x updates are left ungrouped as individual PRs that get reviewed with any required code change.",
-      "matchManagers": ["cargo"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "matchCurrentVersion": "!/^0\\./",
-      "groupName": "cargo (minor & patch)"
-    }
-  ]
+  "extends": ["local>schubydoo/renovate-config:podspine"]
 }


### PR DESCRIPTION
Swaps this repo's inline `renovate.json` for the shared preset `local>schubydoo/renovate-config:podspine`.

All prior custom managers / holds / overrides moved into that preset verbatim; fleet policy (Pacific TZ, daily cadence, auto-merge of patch/digest/stable-minor, one grouped github-actions PR, dashboard off, SHA-pinned actions) comes from the shared base. Part of the centralized-Renovate rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)