### PR TITLE
chore(greptile): exclude renokeeper[bot] from code review

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -7,6 +7,7 @@
   "excludeAuthors": [
     "dependabot[bot]",
     "renovate[bot]",
+    "renokeeper[bot]",
     "pre-commit-ci[bot]",
     "github-actions[bot]",
     "podspine-ci[bot]",


### PR DESCRIPTION
## Why

The fleet migrated from the Mend cloud app (`renovate[bot]`) to **self-hosted Renovate CE**, whose bot is **`renokeeper[bot]`**. Greptile selects review targets by PR author via `excludeAuthors`, so the bot rename silently pulled every dependency PR back under Greptile review/gating.

## What

Add `renokeeper[bot]` to `excludeAuthors` in `.greptile/config.json` (keeping `renovate[bot]` for historical PRs). One-line change; JSON validated with `jq`.

Part of the fleet-wide author-rename fixup after the Renovate CE cutover (2026-07-22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)