### PR TITLE
chore: ignore local MCP and Serena config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,11 @@
 /CLAUDE.md
 /.claude/
 
+# Local MCP server config and Serena project state (machine-specific)
+/.mcp.json
+/.mcp.json.lock
+/.serena/
+
 # Release build output (per-arch binaries for the Docker image)
 /dist/
 


### PR DESCRIPTION
## What

Adds `.mcp.json`, `.mcp.json.lock`, and `.serena/` to `.gitignore`.

## Why

These surfaced as untracked after a local working-directory rename. All three are machine-local tooling state and none of it is portable — the Serena project file pins an absolute workspace path, and the MCP config points at locally-installed servers. Ignoring them keeps a stray `git add -A` from committing state that would only break other checkouts.

They sit next to the existing `/.claude/` entry, which is the same class of thing.

## Testing

Docs-only change to `.gitignore`; no code touched. Verified locally:

- `git check-ignore -v` matches all three paths, and `git status --untracked-files=all` is clean
- `cargo test --workspace` on a fresh `cargo clean` build: 177 passed, 0 failed across 25 suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)