### PR TITLE
fix(http): validate the saver regen source stays under the library root

### DIFF
--- a/.changeset/saver-regen-source-containment.md
+++ b/.changeset/saver-regen-source-containment.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Harden the saver-mode chapter-regeneration path: the book source is now canonicalized and asserted to live under the library root before it can reach ffmpeg, matching the checks the serve-in-place and faststart-remux paths already had

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -500,8 +500,10 @@ struct AudioTarget {
 
 /// Inputs to regenerate one cache file on demand — a `saver` chapter split, or a
 /// faststart remux of a whole-file episode (Sprint 6.3). The source is always a
-/// validated file under a trusted root; the op decides which ffmpeg call rebuilds
-/// the deterministic output.
+/// canonicalized file asserted to live under the library root — both arms of
+/// [`resolve_audio_target`] validate before constructing this, so nothing that
+/// reaches ffmpeg can have escaped. The op decides which ffmpeg call rebuilds the
+/// deterministic output.
 struct Regen {
     source: PathBuf,
     out_dir: PathBuf,
@@ -649,29 +651,46 @@ fn resolve_audio_target(
                 duration_sec: ep.duration_sec,
             },
         })
-    } else {
+    } else if book_is_saver(&book, state.saver) && FsPath::new(&book.source_path).is_file() {
         // A chaptered episode. Regen is possible only in `saver` mode (per-book,
         // Sprint 6.4) when the book's source is a single file to re-split; the
         // `is_file` guard is belt-and-suspenders (a directory source would make
         // `ffmpeg <directory>` fail), so a missing file is a clean 404, not a 500.
-        (book_is_saver(&book, state.saver) && FsPath::new(&book.source_path).is_file()).then(|| {
-            Regen {
-                source: PathBuf::from(&book.source_path),
-                out_dir,
-                out_ext,
-                // `end_sec` is reconstructed as start + duration. This is EXACT, not an
-                // approximation: the scanner stores `duration_sec = cut.end - cut.start`
-                // (the requested cut length, not a measured output duration), so this
-                // yields the same `[start, end)` the ingest split used — and ffmpeg's
-                // 6-decimal arg formatting absorbs any float round-trip. The stream
-                // copy is therefore byte-identical (asserted in the serve test).
-                op: RegenOp::Chapter(ChapterCut {
-                    idx: idx as usize,
-                    start_sec: ep.start_sec,
-                    end_sec: ep.start_sec + ep.duration_sec,
-                }),
-            }
+        //
+        // Same A01 containment rule as the remux arm above: `book.source_path` is
+        // an opaque DB value, so canonicalize it and assert it stays under the
+        // library root before it can reach ffmpeg. Checked here rather than at
+        // regen time so a poisoned row is rejected before anything is opened or
+        // written — including when the cached chapter happens to already exist.
+        let src = FsPath::new(&book.source_path)
+            .canonicalize()
+            .map_err(|_| AppError::NotFound)?;
+        if !src.starts_with(&state.library_dir) {
+            tracing::warn!(
+                feed_id,
+                number,
+                "saver regen source escaped the library root"
+            );
+            return Err(AppError::NotFound);
+        }
+        Some(Regen {
+            source: src,
+            out_dir,
+            out_ext,
+            // `end_sec` is reconstructed as start + duration. This is EXACT, not an
+            // approximation: the scanner stores `duration_sec = cut.end - cut.start`
+            // (the requested cut length, not a measured output duration), so this
+            // yields the same `[start, end)` the ingest split used — and ffmpeg's
+            // 6-decimal arg formatting absorbs any float round-trip. The stream
+            // copy is therefore byte-identical (asserted in the serve test).
+            op: RegenOp::Chapter(ChapterCut {
+                idx: idx as usize,
+                start_sec: ep.start_sec,
+                end_sec: ep.start_sec + ep.duration_sec,
+            }),
         })
+    } else {
+        None
     };
     Ok(AudioTarget { path, regen })
 }

--- a/crates/http/tests/server.rs
+++ b/crates/http/tests/server.rs
@@ -1339,3 +1339,128 @@ async fn a_feed_failing_the_self_check_is_a_500_not_a_broken_feed() {
     );
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+/// The saver-mode regen arm re-splits from `book.source_path`, an opaque DB
+/// value that reaches ffmpeg. A poisoned row pointing outside the library root
+/// must 404 rather than hand ffmpeg an arbitrary file — the same A01 containment
+/// rule the remux arm already enforced (Sprint 6.4 follow-up).
+///
+/// The escape target is a real file, so a pass means the containment check
+/// rejected it and not that the path merely failed to canonicalize.
+#[tokio::test]
+async fn saver_regen_source_outside_the_library_is_a_404() {
+    let dir = std::env::temp_dir().join("podspine-http-saver-regen-escape");
+    let _ = std::fs::remove_dir_all(&dir);
+    let library = dir.join("library");
+    let data = dir.join("data");
+    let book_id = "saver-escape-book";
+    // The book dir must exist: resolve_audio_target canonicalizes it first.
+    std::fs::create_dir_all(data.join("books").join(book_id)).unwrap();
+    std::fs::create_dir_all(&library).unwrap();
+    // A real file, outside the library root.
+    let outside = dir.join("outside.m4b");
+    std::fs::write(&outside, b"not yours to split").unwrap();
+
+    let index = Index::open_in_memory().unwrap();
+    let feed_id = "capabilityidforsaverescape";
+    let mut book = book_row(book_id, feed_id);
+    book.source_path = outside.to_string_lossy().into_owned();
+    book.storage_mode = "saver".to_string(); // per-book override; independent of the global flag
+    index.upsert_book(&book).unwrap();
+    // A chaptered episode: empty source_path, so it takes the saver-regen arm
+    // rather than the serve-in-place or faststart-remux arms.
+    index
+        .upsert_episode(&episode_row(book_id, 0, 1024))
+        .unwrap();
+
+    let state = AppState::new(
+        index,
+        "http://test".to_string(),
+        &data,
+        &library,
+        None,
+        false, // global full: the per-book "saver" override is what selects the arm
+        None,
+        None,
+    );
+    let resp = router(state)
+        .oneshot(
+            Request::get(format!("/audio/{feed_id}/1"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    assert!(
+        body_bytes(resp).await.is_empty(),
+        "a rejected source must not leak bytes or filesystem detail"
+    );
+    // The rejection must happen before ffmpeg is invoked: nothing may be written
+    // into the book's cache dir.
+    let produced = std::fs::read_dir(data.join("books").join(book_id))
+        .unwrap()
+        .count();
+    assert_eq!(
+        produced, 0,
+        "no cache file may be regenerated from an escaped source"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// The containment check must not break the legitimate path: a saver book whose
+/// source is inside the library still resolves (here the chapter file already
+/// exists, so it serves without invoking ffmpeg).
+#[tokio::test]
+async fn saver_source_inside_the_library_still_serves() {
+    let dir = std::env::temp_dir().join("podspine-http-saver-regen-ok");
+    let _ = std::fs::remove_dir_all(&dir);
+    let library = dir.join("library");
+    let data = dir.join("data");
+    let book_id = "saver-ok-book";
+    let book_dir = data.join("books").join(book_id);
+    std::fs::create_dir_all(&book_dir).unwrap();
+    std::fs::create_dir_all(&library).unwrap();
+    let source = library.join("book.m4b");
+    std::fs::write(&source, b"source inside the library").unwrap();
+    // Pre-seed the cached chapter so the request is served without ffmpeg.
+    std::fs::write(book_dir.join("001.m4a"), b"cached chapter bytes").unwrap();
+
+    let index = Index::open_in_memory().unwrap();
+    let feed_id = "capabilityidforsaverok";
+    let mut book = book_row(book_id, feed_id);
+    book.source_path = source.to_string_lossy().into_owned();
+    book.storage_mode = "saver".to_string();
+    index.upsert_book(&book).unwrap();
+    index
+        .upsert_episode(&episode_row(
+            book_id,
+            0,
+            "cached chapter bytes".len() as i64,
+        ))
+        .unwrap();
+
+    let state = AppState::new(
+        index,
+        "http://test".to_string(),
+        &data,
+        &library,
+        None,
+        false,
+        None,
+        None,
+    );
+    let resp = router(state)
+        .oneshot(
+            Request::get(format!("/audio/{feed_id}/1"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(body_bytes(resp).await, b"cached chapter bytes");
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
The last deferred item from the Sprint 6.4 audit.

## The gap

`resolve_audio_target` has three arms. Two of them canonicalize `source_path` and assert it stays under the library root before use. The chaptered **saver-regen** arm did neither:

```rust
Regen { source: PathBuf::from(&book.source_path), .. }   // raw
```

That value is what reaches ffmpeg when a chapter is re-split on demand.

**This is defense-in-depth, not a fix for a known-exploitable issue.** The path comes from the index, written by the scanner — never from user input, and no request can steer it. But it was the one place an opaque DB value reached a subprocess unvalidated, it's exactly the A01 rule in TAD §7, and `Regen`'s own doc comment already claimed *"the source is always a validated file under a trusted root"* — false for a third of its constructors. Code and comment now agree.

## The change

Canonicalize + `starts_with(library_dir)`, 404 on escape, with a `tracing::warn!` matching the sibling arms.

Validated **before anything is opened or written**, mirroring the remux arm — so a poisoned row is rejected even when the cached chapter already exists and could have been served. That fail-closed behaviour is the only behaviour change in this PR, and it's the intended one for a corrupt row.

The arm moved from `bool.then(|| ..)` to an `else if` so the check can propagate a 404. The `is_file` guard is unchanged and still runs first, so an MP3-folder source still means "no regen" rather than an error.

## Testing

Two tests, both using the poisoned-row helpers added in #106:

- **Escape → 404.** Points `source_path` at a *real* file outside the library, asserts 404, an empty body, and **nothing written into the book's cache dir** (so the rejection provably precedes ffmpeg). **Verified failing against the unfixed code** — it covers the new guard, not an earlier one.
- **Positive control.** An in-library saver source still resolves and serves.

210 tests pass; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)