### PR TITLE
chore(github): drop the duplicated and dead issue-template links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
-contact_links:
-  - name: Question or help
-    url: https://github.com/schubydoo/podspine/discussions
-    about: Ask usage questions and share setups in Discussions.
-  - name: Report a security vulnerability
-    url: https://github.com/schubydoo/podspine/security/advisories/new
-    about: Please report vulnerabilities privately, not as a public issue. See SECURITY.md.
+# No contact_links, deliberately:
+#   - Discussions is not enabled for this repo, so a link to /discussions 404s.
+#     Usage questions belong in Issues (Bug Report / Feature Request).
+#   - Private vulnerability reporting IS enabled, so GitHub renders its own
+#     "Report a security vulnerability" entry in the chooser. The hand-written
+#     link to /security/advisories/new duplicated it — the same option appeared
+#     twice, with two different descriptions.


### PR DESCRIPTION
Two fixes to the "Create new issue" chooser.

**"Report a security vulnerability" appeared twice.** Once as GitHub's own entry — rendered automatically now that private vulnerability reporting is enabled — and once from a hand-written `contact_link` pointing at the same `/security/advisories/new` URL. Same destination, two different descriptions, no way for a reporter to tell them apart. The hand-written one is now redundant and is removed.

**"Question or help" pointed at `/discussions`, which 404s.** Discussions was never enabled, and we've now decided against enabling it. Usage questions belong in Issues, which the Bug Report and Feature Request templates already cover.

That empties `contact_links` entirely, so the key is dropped rather than left as an empty list — with a comment recording why each entry went and the condition under which it would come back (if Discussions is ever enabled, or if private vulnerability reporting is ever turned off).

## Checked

No other tracked file references Discussions. `.bestpractices.json` mentions "discussion" only in its justification text, which points at Issues and pull requests — so the OpenSSF Best Practices answer remains accurate and the badge is unaffected.

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)