### PR TITLE
docs(pre-commit): correct the stale cargo-audit/cargo-deny comment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,9 +3,11 @@
 #   commit stage : fast hygiene + fmt --check + clippy (-D warnings) + lib unit tests   (~seconds)
 #   push  stage  : full workspace test suite (incl. ffmpeg-backed integration tests)
 #
-# cargo audit / cargo deny run in CI only — they need the online advisory DB and are
-# not installed locally. Hook commands mirror .github/workflows/ci.yml exactly so the
-# local gate and CI never drift. Bypass a hook deliberately with SKIP=<id> or --no-verify.
+# cargo audit / cargo deny also run at the PUSH stage locally (see below) — they need the
+# online advisory DB, and `language: system` means both binaries must be on PATH:
+# `cargo install cargo-audit cargo-deny`. Without them the pre-push hook fails.
+# Hook commands mirror .github/workflows/ci.yml exactly so the local gate and CI never
+# drift. Bypass a hook deliberately with SKIP=<id> or --no-verify.
 minimum_pre_commit_version: "3.2.0"
 default_install_hook_types: [pre-commit, pre-push]
 


### PR DESCRIPTION
The header comment in `.pre-commit-config.yaml` contradicted the config it introduces.

**Line 6-7 said:**
> cargo audit / cargo deny run in CI only — they need the online advisory DB and are not installed locally.

**But lines 84-95 define both as `pre-push` hooks** with `language: system`.

## The hooks are fine — only the comment was wrong

Verified on a dev host before writing this:

| check | result |
| --- | --- |
| `cargo-audit` on PATH | ✅ 0.22.2 |
| `cargo-deny` on PATH | ✅ 0.20.2 |
| both execute | ✅ |
| `pre-commit` installed, `.git/hooks/pre-push` wired | ✅ |

So the alternative reading — that these hooks had been silently failing — is **not** what was
happening.

The comment now states that both also run at the push stage locally, and that
`language: system` requires the binaries on PATH (`cargo install cargo-audit cargo-deny`),
so the next person hitting a pre-push failure knows why.

`pre-commit validate-config` passes (exit 0), and the same command exits 1 on a deliberately
broken config, so the check is meaningful. Comment-only — no hook, stage or command changed.

`no-changelog`: comment-only, no user-facing effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)