### PR TITLE
test(scanner,splitter): collapse the ffmpeg skip arms into one macro

### DIFF
--- a/crates/scanner/src/lib.rs
+++ b/crates/scanner/src/lib.rs
@@ -1266,12 +1266,15 @@ mod tests {
     /// encoder for the format the test needs.
     ///
     /// The `eprintln!` and the `return` live here, once, instead of at every call
-    /// site. Wherever ffmpeg IS installed — CI, most dev machines — those two lines
-    /// are unreachable, and 60-odd copies of them dominated the uncovered-line
-    /// count on PR 152 (35 of the 56 lines in that diff). Whether that count now
-    /// collapses depends on llvm-cov attributing a `macro_rules!` body to its
-    /// definition rather than to each expansion; the call site itself always
-    /// executes, so the tests read the same either way.
+    /// site. Wherever ffmpeg IS installed — CI, most dev machines — they cannot
+    /// execute, and 62 copies of them dominated the uncovered-line count (35 of the
+    /// 56 lines in PR 152's diff).
+    ///
+    /// Measured, not assumed: llvm-cov attributes a macro body to each **expansion**,
+    /// not to the definition, so a call site still reports one unreachable line —
+    /// one instead of two, which took 63 lines off the report (scanner 158 → 105
+    /// misses, splitter 45 → 35). One line per skip is the floor for deciding at
+    /// runtime; something has to stand for "this didn't run".
     macro_rules! skip {
         ($($why:tt)*) => {{
             eprintln!("skipping: {}", format_args!($($why)*));

--- a/crates/scanner/src/lib.rs
+++ b/crates/scanner/src/lib.rs
@@ -1262,6 +1262,23 @@ mod tests {
     use super::*;
     use std::process::Command;
 
+    /// Skip the rest of a test that this machine cannot run — no ffmpeg, or no
+    /// encoder for the format the test needs.
+    ///
+    /// The `eprintln!` and the `return` live here, once, instead of at every call
+    /// site. Wherever ffmpeg IS installed — CI, most dev machines — those two lines
+    /// are unreachable, and 60-odd copies of them dominated the uncovered-line
+    /// count on PR 152 (35 of the 56 lines in that diff). Whether that count now
+    /// collapses depends on llvm-cov attributing a `macro_rules!` body to its
+    /// definition rather than to each expansion; the call site itself always
+    /// executes, so the tests read the same either way.
+    macro_rules! skip {
+        ($($why:tt)*) => {{
+            eprintln!("skipping: {}", format_args!($($why)*));
+            return;
+        }};
+    }
+
     fn ffmpeg_available() -> bool {
         Command::new("ffmpeg")
             .arg("-version")
@@ -1389,8 +1406,7 @@ mod tests {
     #[test]
     fn mp3_folder_serves_tracks_in_place_in_track_order() {
         if !ffmpeg_available() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         let root = scratch("mp3-order");
         let book = root.join("A Folder Book");
@@ -1399,8 +1415,7 @@ mod tests {
         let b = synth_mp3(&book, "a-second.mp3", Some(2), 4);
         let c = synth_mp3(&book, "m-third.mp3", Some(3), 2);
         if a.is_none() || b.is_none() || c.is_none() {
-            eprintln!("skipping: ffmpeg has no libmp3lame encoder");
-            return;
+            skip!("ffmpeg has no libmp3lame encoder");
         }
 
         let data = root.join("data");
@@ -1455,8 +1470,7 @@ mod tests {
     #[test]
     fn mp3_folder_falls_back_to_filename_order_on_missing_track() {
         if !ffmpeg_available() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         let root = scratch("mp3-fallback");
         let book = root.join("Mixed Book");
@@ -1464,8 +1478,7 @@ mod tests {
         let a = synth_mp3(&book, "01-intro.mp3", None, 2);
         let b = synth_mp3(&book, "02-body.mp3", Some(5), 4);
         if a.is_none() || b.is_none() {
-            eprintln!("skipping: ffmpeg has no libmp3lame encoder");
-            return;
+            skip!("ffmpeg has no libmp3lame encoder");
         }
 
         let data = root.join("data");
@@ -1487,8 +1500,7 @@ mod tests {
     #[test]
     fn cue_sidecar_overrides_embedded_chapters() {
         if !ffmpeg_available() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         // synth() embeds THREE 10s chapters. A sibling .cue defines only TWO
         // chapters (0–5s, 5–30s), which must win.
@@ -1536,8 +1548,7 @@ mod tests {
     #[test]
     fn saver_mode_records_real_sizes_and_starts_but_deletes_the_files() {
         if !ffmpeg_available() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         let dir = scratch("saver-mode");
         let _ = std::fs::remove_dir_all(&dir);
@@ -1600,8 +1611,7 @@ mod tests {
     #[test]
     fn saver_reingests_migrated_rows_with_zero_start_sec() {
         if !ffmpeg_available() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         let dir = scratch("saver-migrated");
         let _ = std::fs::remove_dir_all(&dir);
@@ -1755,13 +1765,11 @@ mod tests {
     #[test]
     fn flac_with_cue_transcodes_to_aac_when_enabled() {
         if !ffmpeg_available() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         let dir = scratch("flac-transcode-aac");
         let Some(flac) = synth_encoded(&dir, "book.flac", &["-c:a", "flac"], 20) else {
-            eprintln!("skipping: no flac encoder");
-            return;
+            skip!("no flac encoder");
         };
         std::fs::write(
             flac.with_extension("cue"),
@@ -1816,13 +1824,11 @@ mod tests {
     #[test]
     fn chapterless_flac_transcodes_into_the_data_dir_instead_of_serving_in_place() {
         if !ffmpeg_available() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         let dir = scratch("flac-transcode-whole");
         let Some(flac) = synth_encoded(&dir, "whole.flac", &["-c:a", "flac"], 8) else {
-            eprintln!("skipping: no flac encoder");
-            return;
+            skip!("no flac encoder");
         };
         let data = dir.join("data");
         let index = Index::open_in_memory().unwrap();
@@ -1861,18 +1867,14 @@ mod tests {
     #[test]
     fn flac_transcodes_to_mp3_when_that_target_is_chosen() {
         if !ffmpeg_available() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         let dir = scratch("flac-transcode-mp3");
         let Some(flac) = synth_encoded(&dir, "book.flac", &["-c:a", "flac"], 6) else {
-            eprintln!("skipping: no flac encoder");
-            return;
+            skip!("no flac encoder");
         };
         if synth_encoded(&dir, "probe.mp3", &["-c:a", "libmp3lame"], 1).is_none() {
-            eprintln!("skipping: no libmp3lame encoder");
-            let _ = std::fs::remove_dir_all(&dir);
-            return;
+            skip!("no libmp3lame encoder");
         }
         let data = dir.join("data");
         let index = Index::open_in_memory().unwrap();
@@ -1913,13 +1915,11 @@ mod tests {
     #[test]
     fn a_transcoded_saver_book_keeps_its_episodes_on_disk() {
         if !ffmpeg_available() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         let dir = scratch("flac-transcode-saver");
         let Some(flac) = synth_encoded(&dir, "book.flac", &["-c:a", "flac"], 12) else {
-            eprintln!("skipping: no flac encoder");
-            return;
+            skip!("no flac encoder");
         };
         std::fs::write(
             flac.with_extension("cue"),
@@ -1996,13 +1996,11 @@ mod tests {
     #[test]
     fn switching_the_transcode_target_reclaims_the_previous_container() {
         if !ffmpeg_available() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         let dir = scratch("flac-transcode-reclaim");
         let Some(flac) = synth_encoded(&dir, "book.flac", &["-c:a", "flac"], 12) else {
-            eprintln!("skipping: no flac encoder");
-            return;
+            skip!("no flac encoder");
         };
         std::fs::write(
             flac.with_extension("cue"),
@@ -2069,13 +2067,11 @@ mod tests {
     #[test]
     fn a_failed_reingest_leaves_the_previous_episodes_in_place() {
         if !ffmpeg_available() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         let dir = scratch("flac-transcode-failed-reingest");
         let Some(flac) = synth_encoded(&dir, "book.flac", &["-c:a", "flac"], 12) else {
-            eprintln!("skipping: no flac encoder");
-            return;
+            skip!("no flac encoder");
         };
         std::fs::write(
             flac.with_extension("cue"),
@@ -2145,13 +2141,11 @@ mod tests {
     #[test]
     fn a_pre_transcode_row_is_not_reingested_but_a_stale_mode_is() {
         if !ffmpeg_available() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         let dir = scratch("flac-transcode-upgrade");
         let Some(flac) = synth_encoded(&dir, "book.flac", &["-c:a", "flac"], 12) else {
-            eprintln!("skipping: no flac encoder");
-            return;
+            skip!("no flac encoder");
         };
         // Chaptered, so the episodes are extracted under the data dir — a
         // chapterless book is served in place and `file_path` is the library file.
@@ -2221,13 +2215,11 @@ mod tests {
     #[test]
     fn toggling_transcode_reingests_a_flac_book() {
         if !ffmpeg_available() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         let dir = scratch("flac-transcode-toggle");
         let Some(flac) = synth_encoded(&dir, "book.flac", &["-c:a", "flac"], 8) else {
-            eprintln!("skipping: no flac encoder");
-            return;
+            skip!("no flac encoder");
         };
         let data = dir.join("data");
         let index = Index::open_in_memory().unwrap();
@@ -2291,14 +2283,12 @@ mod tests {
     #[test]
     fn flac_with_cue_splits_by_sidecar_no_reencode() {
         if !ffmpeg_available() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         let dir = scratch("flac-cue");
         // FLAC has no titled embedded chapters, so it leans on a .cue (PRD S7).
         let Some(flac) = synth_encoded(&dir, "book.flac", &["-c:a", "flac"], 20) else {
-            eprintln!("skipping: no flac encoder");
-            return;
+            skip!("no flac encoder");
         };
         std::fs::write(
             flac.with_extension("cue"),
@@ -2327,13 +2317,11 @@ mod tests {
     #[test]
     fn flac_without_cue_degrades_to_single_episode() {
         if !ffmpeg_available() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         let dir = scratch("flac-plain");
         let Some(flac) = synth_encoded(&dir, "plain.flac", &["-c:a", "flac"], 8) else {
-            eprintln!("skipping: no flac encoder");
-            return;
+            skip!("no flac encoder");
         };
         let data = dir.join("data");
         let index = Index::open_in_memory().unwrap();
@@ -2354,15 +2342,13 @@ mod tests {
     #[test]
     fn opus_single_file_served_in_place() {
         if !ffmpeg_available() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         let dir = scratch("opus");
         let flac = synth_encoded(&dir, "b.opus", &["-c:a", "libopus"], 6)
             .or_else(|| synth_encoded(&dir, "b.opus", &["-c:a", "opus", "-strict", "-2"], 6));
         let Some(opus) = flac else {
-            eprintln!("skipping: no opus encoder");
-            return;
+            skip!("no opus encoder");
         };
         let data = dir.join("data");
         let index = Index::open_in_memory().unwrap();
@@ -2395,8 +2381,7 @@ mod tests {
     #[test]
     fn scans_and_extracts_an_embedded_cover() {
         if !ffmpeg_available() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         let dir = scratch("cover");
         let input = synth_with_cover(&dir);
@@ -2450,8 +2435,7 @@ mod tests {
     #[test]
     fn library_scan_disambiguates_same_named_books() {
         if !ffmpeg_available() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         // Two books that slugify identically, in separate folders. The folder
         // names must differ by more than case so they stay distinct on
@@ -2497,8 +2481,7 @@ mod tests {
     #[test]
     fn library_scan_skips_bad_books_without_aborting() {
         if !ffmpeg_available() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         let root = scratch("mixed-lib");
         synth(&root, true); // chapters.m4a at the top level (the good book)
@@ -2546,8 +2529,7 @@ mod tests {
     #[test]
     fn scans_chapters_into_the_index_and_is_idempotent() {
         if !ffmpeg_available() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         let dir = scratch("chapters");
         let input = synth(&dir, true);
@@ -2585,8 +2567,7 @@ mod tests {
     #[test]
     fn non_faststart_single_file_is_flagged_and_optionally_remuxed() {
         if !ffmpeg_available() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         let dir = scratch("faststart");
         // ffmpeg's mp4 muxer writes `moov` at the END by default → non-faststart.
@@ -2663,8 +2644,7 @@ mod tests {
     #[test]
     fn faststart_single_file_is_never_remuxed() {
         if !ffmpeg_available() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         let dir = scratch("faststart-ok");
         std::fs::create_dir_all(&dir).unwrap();
@@ -2688,8 +2668,7 @@ mod tests {
             .map(|s| s.success())
             .unwrap_or(false);
         if !ok {
-            eprintln!("skipping: no aac encoder");
-            return;
+            skip!("no aac encoder");
         }
         assert!(!needs_faststart(&input), "precondition: file is faststart");
 
@@ -2721,8 +2700,7 @@ mod tests {
     #[test]
     fn toggling_remux_flag_reingests_the_episode() {
         if !ffmpeg_available() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         let dir = scratch("faststart-toggle");
         let input = synth(&dir, false); // non-faststart m4a
@@ -2784,8 +2762,7 @@ mod tests {
     #[test]
     fn per_book_toml_overrides_apply_at_ingest() {
         if !ffmpeg_available() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         let root = scratch("perbook");
         let input = synth(&root, false); // flat.m4a (top-level single-file book)
@@ -2817,8 +2794,7 @@ mod tests {
     #[test]
     fn editing_sidecar_reingests_without_touching_audio() {
         if !ffmpeg_available() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         let root = scratch("perbook-edit");
         let input = synth(&root, false);
@@ -2857,8 +2833,7 @@ mod tests {
     #[test]
     fn toggling_only_force_embedded_reingests() {
         if !ffmpeg_available() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         let root = scratch("perbook-fe");
         let input = synth(&root, false);
@@ -2889,8 +2864,7 @@ mod tests {
     #[test]
     fn per_book_disabled_skips_and_prunes() {
         if !ffmpeg_available() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         let root = scratch("perbook-disabled");
         let input = synth(&root, false);
@@ -2918,8 +2892,7 @@ mod tests {
     #[test]
     fn per_book_full_override_beats_global_saver() {
         if !ffmpeg_available() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         let root = scratch("perbook-full");
         let input = synth(&root, true); // chaptered, so storage_mode matters
@@ -2957,8 +2930,7 @@ mod tests {
     #[test]
     fn sidecar_global_key_is_ignored_and_a_typo_is_non_fatal() {
         if !ffmpeg_available() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         // A server-global key in a sidecar is ignored (warned); the per-book key
         // still applies.
@@ -3002,8 +2974,7 @@ mod tests {
     #[test]
     fn mp3_folder_with_no_probeable_tracks_is_skipped() {
         if !ffmpeg_available() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         let root = scratch("mp3-unprobeable");
         let book = root.join("Broken");
@@ -3023,8 +2994,7 @@ mod tests {
     #[test]
     fn library_watcher_indexes_a_book_added_after_startup() {
         if !ffmpeg_available() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         let root = scratch("watcher-lib");
         let data = scratch("watcher-data");
@@ -3071,8 +3041,7 @@ mod tests {
     #[test]
     fn chapterless_file_becomes_a_single_episode() {
         if !ffmpeg_available() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         let dir = scratch("flat");
         let input = synth(&dir, false);
@@ -3103,16 +3072,14 @@ mod tests {
     #[test]
     fn mp3_folder_rescan_is_idempotent_and_stays_in_place() {
         if !ffmpeg_available() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         let root = scratch("mp3-idem");
         let book = root.join("Idem Book");
         let a = synth_mp3(&book, "01.mp3", Some(1), 2);
         let b = synth_mp3(&book, "02.mp3", Some(2), 2);
         if a.is_none() || b.is_none() {
-            eprintln!("skipping: ffmpeg has no libmp3lame encoder");
-            return;
+            skip!("ffmpeg has no libmp3lame encoder");
         }
         let data = root.join("data");
         let index = Index::open_in_memory().unwrap();
@@ -3177,8 +3144,7 @@ mod tests {
     #[test]
     fn prune_orphans_removes_a_deleted_source_and_its_split_output() {
         if !ffmpeg_available() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         // Chaptered books (not whole-file) so each materializes a per-chapter
         // split dir under <data> — that's the "split output" prune must remove.
@@ -3212,8 +3178,7 @@ mod tests {
     #[test]
     fn prune_orphans_empty_root_guard_preserves_the_index() {
         if !ffmpeg_available() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         let (root, data, index) = two_book_library("prune-guard");
         scan_library(&root, &data, &index, ScanOptions::default());
@@ -3238,8 +3203,7 @@ mod tests {
     #[test]
     fn reconcile_indexes_new_books_and_prunes_deleted_ones() {
         if !ffmpeg_available() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         let (root, data, index) = two_book_library("reconcile");
 

--- a/crates/splitter/src/lib.rs
+++ b/crates/splitter/src/lib.rs
@@ -734,12 +734,15 @@ mod tests {
     /// encoder for the format the test needs.
     ///
     /// The `eprintln!` and the `return` live here, once, instead of at every call
-    /// site. Wherever ffmpeg IS installed — CI, most dev machines — those two lines
-    /// are unreachable, and 60-odd copies of them dominated the uncovered-line
-    /// count on PR 152 (35 of the 56 lines in that diff). Whether that count now
-    /// collapses depends on llvm-cov attributing a `macro_rules!` body to its
-    /// definition rather than to each expansion; the call site itself always
-    /// executes, so the tests read the same either way.
+    /// site. Wherever ffmpeg IS installed — CI, most dev machines — they cannot
+    /// execute, and 62 copies of them dominated the uncovered-line count (35 of the
+    /// 56 lines in PR 152's diff).
+    ///
+    /// Measured, not assumed: llvm-cov attributes a macro body to each **expansion**,
+    /// not to the definition, so a call site still reports one unreachable line —
+    /// one instead of two, which took 63 lines off the report (scanner 158 → 105
+    /// misses, splitter 45 → 35). One line per skip is the floor for deciding at
+    /// runtime; something has to stand for "this didn't run".
     macro_rules! skip {
         ($($why:tt)*) => {{
             eprintln!("skipping: {}", format_args!($($why)*));

--- a/crates/splitter/src/lib.rs
+++ b/crates/splitter/src/lib.rs
@@ -730,6 +730,23 @@ fn fmt_secs(v: f64) -> String {
 mod tests {
     use super::*;
 
+    /// Skip the rest of a test that this machine cannot run — no ffmpeg, or no
+    /// encoder for the format the test needs.
+    ///
+    /// The `eprintln!` and the `return` live here, once, instead of at every call
+    /// site. Wherever ffmpeg IS installed — CI, most dev machines — those two lines
+    /// are unreachable, and 60-odd copies of them dominated the uncovered-line
+    /// count on PR 152 (35 of the 56 lines in that diff). Whether that count now
+    /// collapses depends on llvm-cov attributing a `macro_rules!` body to its
+    /// definition rather than to each expansion; the call site itself always
+    /// executes, so the tests read the same either way.
+    macro_rules! skip {
+        ($($why:tt)*) => {{
+            eprintln!("skipping: {}", format_args!($($why)*));
+            return;
+        }};
+    }
+
     fn have_ffmpeg() -> bool {
         Command::new("ffmpeg")
             .arg("-version")
@@ -955,8 +972,7 @@ mod tests {
                 .unwrap_or(false)
         }
         if !ffmpeg_available() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         // A real-time, unbounded encode that never terminates on its own; the
         // per-child timeout must kill it. Uses a deliberately tiny timeout via a
@@ -1016,8 +1032,7 @@ mod tests {
     #[test]
     fn split_maps_a_nonzero_ffmpeg_exit_to_a_split_error() {
         if !have_ffmpeg() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         // A positive-duration cut on a non-audio input: ffmpeg fails to read it
         // and exits non-zero, exercising run_ffmpeg's failure path + the mapping.
@@ -1084,8 +1099,7 @@ mod tests {
     #[test]
     fn a_blocked_rename_is_reported_and_never_leaves_a_half_published_file() {
         if !have_ffmpeg() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         // A directory sitting where the episode must land blocks the atomic
         // rename. The encode itself succeeds, so this exercises the publish step.
@@ -1125,8 +1139,7 @@ mod tests {
     #[test]
     fn a_failed_encode_leaves_the_published_episode_untouched() {
         if !have_ffmpeg() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         // The re-ingest hazard: an episode is already published and being served
         // when a new encode of it fails. The old bytes — and the byte_length the
@@ -1160,8 +1173,7 @@ mod tests {
     #[test]
     fn a_finished_encode_only_appears_at_the_final_path() {
         if !have_ffmpeg() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         let dir = std::env::temp_dir().join("podspine-atomic-ok");
         let _ = std::fs::remove_dir_all(&dir);
@@ -1203,8 +1215,7 @@ mod tests {
     #[test]
     fn split_chapter_maps_a_nonzero_ffmpeg_exit_to_an_error() {
         if !have_ffmpeg() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         // `split_chapter` (the saver/regen entry point) on a non-audio input:
         // ffmpeg exits non-zero → the error arm, carrying the chapter index.
@@ -1227,8 +1238,7 @@ mod tests {
     #[test]
     fn remux_faststart_produces_a_deterministic_faststart_file() {
         if !have_ffmpeg() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         let dir = std::env::temp_dir().join("podspine-remux-ft");
         let _ = std::fs::remove_dir_all(&dir);
@@ -1253,8 +1263,7 @@ mod tests {
             .map(|s| s.success())
             .unwrap_or(false);
         if !ok {
-            eprintln!("skipping: no aac encoder");
-            return;
+            skip!("no aac encoder");
         }
 
         let out = dir.join("out");
@@ -1292,8 +1301,7 @@ mod tests {
     #[test]
     fn remux_maps_a_nonzero_ffmpeg_exit_to_a_split_error() {
         if !have_ffmpeg() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         // A non-audio input makes ffmpeg exit non-zero → the remux error arm.
         let dir = std::env::temp_dir().join("podspine-remux-fail");
@@ -1338,8 +1346,7 @@ mod tests {
     #[test]
     fn extract_cover_maps_a_nonzero_ffmpeg_exit_to_a_cover_error() {
         if !have_ffmpeg() {
-            eprintln!("skipping: ffmpeg not available");
-            return;
+            skip!("ffmpeg not available");
         }
         // No video stream to map -> ffmpeg exits non-zero -> CoverError::Ffmpeg.
         let dir = std::env::temp_dir().join("podspine-cover-fail");


### PR DESCRIPTION
Follow-up to PR 152. It was opened as an experiment with a kill criterion; **the criterion was met — results at the bottom.**

## The problem

Every ffmpeg-gated test opened with its own copy of:

```rust
if !ffmpeg_available() { eprintln!("skipping: …"); return; }
```

Those two lines cannot execute on any machine that has ffmpeg — which is every machine that reports coverage. There are 62 copies across the two files, and they made up **35 of the 56 uncovered lines** in PR 152's diff. The practical effect: adding a test that closed a real gap pushed the "N missing" count *up*, and the handful of lines actually worth reviewing were buried in skip arms.

## The change

The message and the `return` now live in one `skip!` macro per test module. Each call site becomes a single line:

```rust
if !ffmpeg_available() { skip!("ffmpeg not available") }
let Some(flac) = synth_encoded(&dir, "book.flac", &["-c:a", "flac"], 20) else { skip!("no flac encoder") };
```

No test changes what it asserts, or the conditions under which it skips. 41 `if` arms and 11 `let … else` arms in `scanner`, 10 `if` arms in `splitter`. Net −33 lines.

One incidental change, called out because it isn't mechanical: the `libmp3lame` skip in `flac_transcodes_to_mp3_when_that_target_is_chosen` no longer removes its scratch directory on the way out. `scratch()` clears that directory when the test next runs, so it was redundant.

## Result

| File | misses on `main` | misses here | Δ |
|---|---|---|---|
| `crates/scanner/src/lib.rs` | 158 | **105** | **−53** |
| `crates/splitter/src/lib.rs` | 45 | **35** | **−10** |
| repo total | 249 | **186** | **−63** |

Coverage: scanner 92.53% → **94.91%**, splitter 94.58% → **95.73%**, repo 96.02% → **97.02%**.

The premise was half wrong, and the numbers say how. llvm-cov attributes a `macro_rules!` body to each **expansion**, not to the definition, so the arms did not collapse to a single reported line. What they did do is go from **two** unreachable lines per site to **one** — 62 sites, 63 lines. One line per skip is the floor for deciding at runtime; something has to stand for "this didn't run".

### Why `codecov/patch` reads 0%

Every line this PR adds is a `skip!` call site, and those are by construction the lines that cannot execute where ffmpeg is installed. Patch coverage only looks at added lines, so 0% is the arithmetic working correctly, not a regression. The whole-file numbers above are the ones that describe the change. Labelled `no-changelog`: test-only, nothing user-facing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)