### PR TITLE
ci: publish a :nightly image from main for pre-release testing

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,9 +31,12 @@ concurrency:
 
 jobs:
   binaries:
-    # Scheduled runs only on the canonical repo (a fork won't build nightlies on a
-    # cron it never asked for); a manual dispatch is allowed anywhere.
-    if: ${{ github.event_name == 'workflow_dispatch' || github.repository == 'schubydoo/podspine' }}
+    # Canonical repo AND the `main` ref only. `:nightly` is contracted to be the tip
+    # of main, so a dispatch on a feature branch or tag (workflow_dispatch lets you
+    # pick any ref) must not publish its build under that tag; a scheduled run's ref
+    # is already refs/heads/main. This also keeps forks from building nightlies on a
+    # cron they never asked for.
+    if: ${{ github.repository == 'schubydoo/podspine' && github.ref == 'refs/heads/main' }}
     name: Build ${{ matrix.name }} binary (musl)
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,8 +25,11 @@ permissions:
   contents: read
 
 concurrency:
-  # A newer nightly supersedes an in-flight one — cancel the stale build.
-  group: nightly
+  # Scope by ref, not a bare "nightly": concurrency is evaluated BEFORE the job's
+  # ref guard, so a shared group would let an off-main dispatch cancel a running
+  # main nightly and then skip — killing the image with nothing to replace it.
+  # Per-ref, a newer main build still supersedes an in-flight main build.
+  group: nightly-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,137 @@
+name: Nightly
+
+# Build the two Linux musl binaries from the tip of `main` and push a multi-arch
+# image to GHCR as `:nightly` (plus `:nightly-<shortsha>` for traceability). This
+# is a throwaway TEST image for trying merged-but-unreleased changes on a real
+# deployment before cutting a `v*` release — it NEVER moves `:latest` and publishes
+# no GitHub Release or binary assets. Run it on demand (workflow_dispatch) or let
+# the daily schedule refresh it.
+#
+# Mirrors release.yml's `binaries` + `image` jobs, trimmed to Linux (the image
+# consumes only the musl binaries). Action refs are pinned to full commit SHAs
+# (repo Actions policy / Scorecard Pinned-Dependencies); Renovate keeps them current.
+#
+# Cut a real release instead when the change is ready: merge the knope
+# `chore: prepare release X.Y.Z` PR, which tags `v*` and runs release.yml.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 07:00 UTC daily — after the day's merges land, before a morning test.
+    - cron: "0 7 * * *"
+
+# Least privilege by default; the image job elevates explicitly.
+permissions:
+  contents: read
+
+concurrency:
+  # A newer nightly supersedes an in-flight one — cancel the stale build.
+  group: nightly
+  cancel-in-progress: true
+
+jobs:
+  binaries:
+    # Scheduled runs only on the canonical repo (a fork won't build nightlies on a
+    # cron it never asked for); a manual dispatch is allowed anywhere.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.repository == 'schubydoo/podspine' }}
+    name: Build ${{ matrix.name }} binary (musl)
+    runs-on: ubuntu-latest
+    strategy:
+      # One arch failing shouldn't hide the other's result.
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            name: linux-amd64
+          - target: aarch64-unknown-linux-musl
+            name: linux-arm64
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          targets: ${{ matrix.target }}
+      # zig is the cross linker for the musl targets (incl. rusqlite's bundled
+      # SQLite C). No Actions cache: caching in an artifact-publishing workflow is a
+      # cache-poisoning vector (zizmor cache-poisoning), matching release.yml.
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: 0.13.0
+          use-cache: false
+      - name: Install cargo-zigbuild
+        run: cargo install cargo-zigbuild --locked
+      - name: Build (musl via zig)
+        run: cargo zigbuild --release --target ${{ matrix.target }} --bin podspine
+      - name: Stage binary
+        shell: bash
+        run: |
+          mkdir -p "dist/${{ matrix.name }}"
+          cp "target/${{ matrix.target }}/release/podspine" \
+             "dist/${{ matrix.name }}/podspine"
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dist-${{ matrix.name }}
+          path: dist/${{ matrix.name }}/podspine
+          retention-days: 1
+
+  image:
+    name: Multi-arch image → GHCR (:nightly)
+    needs: binaries
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # push to GHCR
+      id-token: write # cosign keyless
+      attestations: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Fetch prebuilt binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: artifacts
+      - name: Lay out dist/ for the Dockerfile
+        # The image is Linux-only; the Dockerfile selects dist/${TARGETARCH}/podspine.
+        run: |
+          mkdir -p dist/amd64 dist/arm64
+          cp artifacts/dist-linux-amd64/podspine dist/amd64/podspine
+          cp artifacts/dist-linux-arm64/podspine dist/arm64/podspine
+          chmod +x dist/amd64/podspine dist/arm64/podspine
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Image tags
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ghcr.io/${{ github.repository }}
+          # `:nightly` always points at the newest main build; `:nightly-<shortsha>`
+          # pins a specific one. Never `:latest` — that is stable-release only.
+          tags: |
+            type=raw,value=nightly
+            type=sha,prefix=nightly-,format=short
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: true # SLSA provenance attestation in the registry
+          sbom: true
+      - name: Sign the image (keyless)
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: cosign sign --yes "ghcr.io/${{ github.repository }}@${DIGEST}"


### PR DESCRIPTION
## What

Adds a **Nightly** workflow that builds the tip of `main` and pushes a multi-arch (linux/amd64+arm64) image to GHCR as **`:nightly`** (plus `:nightly-<shortsha>`). It's a throwaway **test** image so merged-but-unreleased changes can be deployed and tested on a real setup *before* cutting a `v*` release.

- Mirrors `release.yml`'s `binaries` + `image` jobs, trimmed to Linux (the image consumes only the musl binaries).
- **Never moves `:latest`** — that stays stable-release only. No GitHub Release, no binary/SBOM release assets.
- Signed (cosign keyless) with SLSA provenance + SBOM, same as the release image.

## Triggers

- `workflow_dispatch` — build a fresh nightly on demand (e.g. right after merging PRs you want to test).
- `schedule` — 07:00 UTC daily, canonical repo only (a fork won't build nightlies on a cron it never asked for).

## Verification

- `actionlint` clean; `zizmor` reports no findings.
- Pinned action SHAs (repo Actions policy / Scorecard Pinned-Dependencies), `use-cache: false` on zig (cache-poisoning), least-privilege `permissions`.

## Usage

Dispatch it, wait for the image job, then pull `ghcr.io/schubydoo/podspine:nightly`.

Labeled `no-changelog` — CI-only, no product code touched.