### PR TITLE
feat(ui): follow the OS light/dark preference automatically

### DIFF
--- a/.changeset/ui-auto-dark-mode.md
+++ b/.changeset/ui-auto-dark-mode.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Follow the operating system's light/dark preference automatically: a `prefers-color-scheme: dark` override of the existing CSS variables (plus `color-scheme: light dark` so native controls adapt) gives the whole UI an AA-contrast dark palette with no JavaScript, while the QR codes keep their scannable white background

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -53,9 +53,21 @@ pub struct BookDetail {
 /// Shared styles + a page shell. Inlined so the binary needs no static assets.
 /// The palette is chosen for WCAG AA contrast (NFR-C3): `#18181b` text on white
 /// (~16:1), `#52525b` muted (~7:1), and white on the `#1d4ed8` accent (~5.3:1).
+/// Everything is driven through the `--*` custom properties, so the dark palette
+/// below is just an OS-preference override of those same variables — no per-rule
+/// duplication. `color-scheme` lets native controls/scrollbars follow suit.
 const STYLE: &str = r#"
-:root { --bg:#ffffff; --surface:#f4f4f5; --border:#d4d4d8; --text:#18181b;
+:root { color-scheme: light dark;
+        --bg:#ffffff; --surface:#f4f4f5; --border:#d4d4d8; --text:#18181b;
         --muted:#52525b; --accent:#1d4ed8; --accent-text:#ffffff; --danger:#b91c1c; }
+/* Auto dark mode: follows the OS setting, no JS, no toggle. AA-contrast dark
+   palette — `#f4f4f5` text on `#18181b` (~16:1), `#a1a1aa` muted (~7:1), and
+   `#0b1120` text on the lighter `#60a5fa` accent (~7:1). The QR SVGs keep their
+   own white background (set inline on `.appqr svg`) so a phone can still scan. */
+@media (prefers-color-scheme: dark) {
+  :root { --bg:#18181b; --surface:#27272a; --border:#3f3f46; --text:#f4f4f5;
+          --muted:#a1a1aa; --accent:#60a5fa; --accent-text:#0b1120; --danger:#f87171; }
+}
 * { box-sizing:border-box; }
 body { margin:0; font:16px/1.5 system-ui,-apple-system,Segoe UI,Roboto,sans-serif;
        color:var(--text); background:var(--bg); }
@@ -531,6 +543,16 @@ mod tests {
         let html = index_page(&[]).into_string();
         assert!(html.contains("No audiobooks found"));
         assert!(!html.contains("<ul"));
+    }
+
+    #[test]
+    fn style_supports_os_dark_mode() {
+        // Auto dark mode is an OS-preference override of the same --* variables,
+        // with color-scheme so native controls follow. No JS/toggle.
+        assert!(STYLE.contains("color-scheme: light dark"));
+        assert!(STYLE.contains("@media (prefers-color-scheme: dark)"));
+        // The dark override redefines the palette variables.
+        assert!(STYLE.contains("--bg:#18181b"));
     }
 
     fn detail() -> BookDetail {


### PR DESCRIPTION
## What

Auto light/dark theme (backlog item 4). The UI is already fully CSS-variable-driven, so this adds a `@media (prefers-color-scheme: dark)` override of the same `--*` variables plus `color-scheme: light dark` on `:root`. No JavaScript, no toggle, no per-rule duplication.

- AA-contrast dark palette: `#f4f4f5` text on `#18181b` (~16:1), `#a1a1aa` muted (~7:1), `#0b1120` on the lighter `#60a5fa` accent (~7:1).
- QR SVGs keep their inline white background, so a phone can still scan in dark mode.

## Verification

- `cargo test -p podspine-ui` green (added `style_supports_os_dark_mode`).
- fmt / clippy clean (pre-commit).

## Deliberate scope

OS-following only. A **manual toggle** that overrides the OS preference is a follow-up: podspine ships no client JS and is server-rendered (maud), so persistence needs a cookie or a small inline script — weighed separately. Auto dark covers the majority case.