### PR TITLE
feat(http): cache cover images with ETag + Cache-Control (304 revalidation)

### DIFF
--- a/.changeset/cover-cache-headers.md
+++ b/.changeset/cover-cache-headers.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Cache cover images: `/cover` now sends an `ETag` (from the file's size+mtime) and `Cache-Control`, and honours `If-None-Match` with a bodyless `304`, so a browser stops re-downloading every cover on each page refresh — a real speed-up over slow links like Tailscale where the grid was pulling several MB of images every time

--- a/.changeset/cover-cache-headers.md
+++ b/.changeset/cover-cache-headers.md
@@ -2,4 +2,4 @@
 default: patch
 ---
 
-Cache cover images: `/cover` now sends an `ETag` (from the file's size+mtime) and `Cache-Control`, and honours `If-None-Match` with a bodyless `304`, so a browser stops re-downloading every cover on each page refresh — a real speed-up over slow links like Tailscale where the grid was pulling several MB of images every time
+Cache cover images: `/cover` now sends an `ETag` (a hash of the image bytes) and `Cache-Control`, and honours `If-None-Match` with a bodyless `304`, so a browser stops re-downloading every cover on each page refresh — a real speed-up over slow links like Tailscale where the grid was pulling several MB of images every time

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,6 +1262,7 @@ dependencies = [
  "axum",
  "axum-extra 0.12.6",
  "axum-range",
+ "blake3",
  "http-body-util",
  "podspine-feed",
  "podspine-index",

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -22,6 +22,7 @@ podspine-splitter = { path = "../splitter" }
 podspine-ui = { path = "../ui" }
 podspine-metrics = { path = "../metrics" }
 tracing = { workspace = true }
+blake3 = { workspace = true }
 
 [dev-dependencies]
 podspine-scanner = { path = "../scanner" }

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -35,7 +35,7 @@ use std::time::Duration;
 
 use axum::Router;
 use axum::extract::{Path, State};
-use axum::http::{HeaderMap, StatusCode, header};
+use axum::http::{HeaderMap, HeaderValue, StatusCode, header};
 use axum::response::{Html, IntoResponse, Redirect, Response};
 use axum::routing::{get, post};
 use axum_extra::TypedHeader;
@@ -393,9 +393,15 @@ async fn regenerate(
 /// isn't a guessable catalog-probe surface. Covers are populated by cover
 /// extraction (Task 3.4); until then books have no cover and this 404s. The
 /// stored path is canonicalized and confirmed under the data dir before serving.
+///
+/// Cached: an `ETag` (from the file's size+mtime) plus `Cache-Control` let a
+/// browser revalidate to a bodyless `304` instead of re-downloading the (often
+/// multi-MB) image on every page refresh — the grid pulls many covers at once, so
+/// over a slow link (e.g. Tailscale) that re-download was the bottleneck.
 async fn cover(
     State(state): State<AppState>,
     Path(feed_id): Path<String>,
+    headers: HeaderMap,
 ) -> Result<Response, AppError> {
     // No covers extracted until the first scan finishes — 503 (retry), not 404.
     if !state.is_ready() {
@@ -421,15 +427,50 @@ async fn cover(
         tracing::warn!(feed_id, "resolved cover path escaped the data dir");
         return Err(AppError::NotFound);
     }
+
+    // Validator from size+mtime: a re-extracted cover (different bytes) bumps mtime,
+    // so the ETag changes and clients refetch; otherwise it revalidates cheaply.
+    let meta = tokio::fs::metadata(&canonical)
+        .await
+        .map_err(|_| AppError::NotFound)?;
+    let mtime = meta
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let etag = format!("\"{:x}-{:x}\"", meta.len(), mtime);
+    let etag_value = HeaderValue::from_str(&etag).map_err(AppError::internal)?;
+    // Short max-age so a refresh burst skips the network entirely, while a covered
+    // book that gets re-extracted goes stale for at most that window.
+    let cache_control = HeaderValue::from_static("public, max-age=300");
+
+    // If-None-Match: honour a matching tag (weak `W/` prefix, comma list, or `*`)
+    // with a 304 so the client keeps its cached image and no body is sent.
+    let unchanged = headers
+        .get(header::IF_NONE_MATCH)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|h| {
+            h.trim() == "*"
+                || h.split(',')
+                    .any(|t| t.trim().trim_start_matches("W/") == etag)
+        });
+    if unchanged {
+        let mut resp = StatusCode::NOT_MODIFIED.into_response();
+        resp.headers_mut().insert(header::ETAG, etag_value);
+        resp.headers_mut()
+            .insert(header::CACHE_CONTROL, cache_control);
+        return Ok(resp);
+    }
+
     let bytes = tokio::fs::read(&canonical)
         .await
         .map_err(|_| AppError::NotFound)?;
-    Ok((
-        StatusCode::OK,
-        [(header::CONTENT_TYPE, image_mime(&cover_path))],
-        bytes,
-    )
-        .into_response())
+    let mut resp = ([(header::CONTENT_TYPE, image_mime(&cover_path))], bytes).into_response();
+    let h = resp.headers_mut();
+    h.insert(header::ETAG, etag_value);
+    h.insert(header::CACHE_CONTROL, cache_control);
+    Ok(resp)
 }
 
 /// `GET /audio/{feed_id}/{number}` — stream an episode with Range support.

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -394,7 +394,7 @@ async fn regenerate(
 /// extraction (Task 3.4); until then books have no cover and this 404s. The
 /// stored path is canonicalized and confirmed under the data dir before serving.
 ///
-/// Cached: an `ETag` (from the file's size+mtime) plus `Cache-Control` let a
+/// Cached: an `ETag` (a blake3 hash of the served bytes) plus `Cache-Control` let a
 /// browser revalidate to a bodyless `304` instead of re-downloading the (often
 /// multi-MB) image on every page refresh — the grid pulls many covers at once, so
 /// over a slow link (e.g. Tailscale) that re-download was the bottleneck.
@@ -428,25 +428,24 @@ async fn cover(
         return Err(AppError::NotFound);
     }
 
-    // Validator from size+mtime: a re-extracted cover (different bytes) bumps mtime,
-    // so the ETag changes and clients refetch; otherwise it revalidates cheaply.
-    let meta = tokio::fs::metadata(&canonical)
+    // Read the bytes first, then derive the ETag from *those exact bytes* (blake3).
+    // A validator built from stat() metadata could advertise the old file's tag
+    // against new bytes if a rescan overwrites the cover between the stat and the
+    // read (TOCTOU), and whole-second mtime wouldn't change for a same-length,
+    // same-second replacement. A content hash matches whatever is served, always.
+    let bytes = tokio::fs::read(&canonical)
         .await
         .map_err(|_| AppError::NotFound)?;
-    let mtime = meta
-        .modified()
-        .ok()
-        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
-    let etag = format!("\"{:x}-{:x}\"", meta.len(), mtime);
+    let etag = format!("\"{}\"", blake3::hash(&bytes).to_hex());
     let etag_value = HeaderValue::from_str(&etag).map_err(AppError::internal)?;
     // Short max-age so a refresh burst skips the network entirely, while a covered
     // book that gets re-extracted goes stale for at most that window.
     let cache_control = HeaderValue::from_static("public, max-age=300");
 
     // If-None-Match: honour a matching tag (weak `W/` prefix, comma list, or `*`)
-    // with a 304 so the client keeps its cached image and no body is sent.
+    // with a 304 so the client keeps its cached image and no body is sent. We still
+    // read the file to hash it, but skip re-sending the (multi-MB) body — the
+    // network transfer was the cost over a slow link, not the local disk read.
     let unchanged = headers
         .get(header::IF_NONE_MATCH)
         .and_then(|v| v.to_str().ok())
@@ -463,9 +462,6 @@ async fn cover(
         return Ok(resp);
     }
 
-    let bytes = tokio::fs::read(&canonical)
-        .await
-        .map_err(|_| AppError::NotFound)?;
     let mut resp = ([(header::CONTENT_TYPE, image_mime(&cover_path))], bytes).into_response();
     let h = resp.headers_mut();
     h.insert(header::ETAG, etag_value);

--- a/crates/http/tests/server.rs
+++ b/crates/http/tests/server.rs
@@ -186,10 +186,10 @@ async fn serves_cover_when_present() {
     let input = synth_with_cover(&dir);
     let book = scan_book(&input, &data, &index).unwrap();
     let feed_id = book.feed_id.clone();
-    assert!(
-        book.cover_path.is_some(),
-        "cover should have been extracted"
-    );
+    let cover_file = book
+        .cover_path
+        .clone()
+        .expect("cover should have been extracted");
 
     let state = AppState::new(
         index,
@@ -239,6 +239,7 @@ async fn serves_cover_when_present() {
     // A conditional re-request with that ETag gets a bodyless 304, not the image
     // again — the fix for re-pulling covers on every refresh.
     let resp = app
+        .clone()
         .oneshot(
             Request::get(format!("/cover/{feed_id}"))
                 .header(header::IF_NONE_MATCH, &etag)
@@ -253,6 +254,26 @@ async fn serves_cover_when_present() {
         etag
     );
     assert!(body_bytes(resp).await.is_empty(), "a 304 carries no body");
+
+    // Content-addressed ETag: if the cover bytes change (a re-extraction), the old
+    // tag no longer matches, so the same conditional request now gets a fresh 200
+    // with a *different* ETag — never a stale 304 for the wrong bytes.
+    std::fs::write(&cover_file, b"different cover bytes").unwrap();
+    let resp = app
+        .oneshot(
+            Request::get(format!("/cover/{feed_id}"))
+                .header(header::IF_NONE_MATCH, &etag)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "changed bytes must not 304");
+    assert_ne!(
+        resp.headers().get(header::ETAG).unwrap().to_str().unwrap(),
+        etag,
+        "a changed cover gets a new ETag"
+    );
 
     let _ = std::fs::remove_dir_all(&dir);
 }

--- a/crates/http/tests/server.rs
+++ b/crates/http/tests/server.rs
@@ -205,6 +205,7 @@ async fn serves_cover_when_present() {
 
     // Covers are served by capability id, not the slug.
     let resp = app
+        .clone()
         .oneshot(
             Request::get(format!("/cover/{feed_id}"))
                 .body(Body::empty())
@@ -217,7 +218,41 @@ async fn serves_cover_when_present() {
         resp.headers().get(header::CONTENT_TYPE).unwrap(),
         "image/jpeg"
     );
+    // Cacheable: an ETag + Cache-Control so a refresh revalidates instead of
+    // re-downloading the image every time.
+    let etag = resp
+        .headers()
+        .get(header::ETAG)
+        .expect("cover carries an ETag")
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert!(
+        resp.headers()
+            .get(header::CACHE_CONTROL)
+            .and_then(|v| v.to_str().ok())
+            .is_some_and(|v| v.contains("max-age")),
+        "cover carries Cache-Control"
+    );
     assert!(!body_bytes(resp).await.is_empty(), "cover bytes served");
+
+    // A conditional re-request with that ETag gets a bodyless 304, not the image
+    // again — the fix for re-pulling covers on every refresh.
+    let resp = app
+        .oneshot(
+            Request::get(format!("/cover/{feed_id}"))
+                .header(header::IF_NONE_MATCH, &etag)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_MODIFIED);
+    assert_eq!(
+        resp.headers().get(header::ETAG).unwrap().to_str().unwrap(),
+        etag
+    );
+    assert!(body_bytes(resp).await.is_empty(), "a 304 carries no body");
 
     let _ = std::fs::remove_dir_all(&dir);
 }


### PR DESCRIPTION
## Problem

`/cover/{feed_id}` read the full image and returned only `Content-Type` — no `ETag`, no `Cache-Control` (`http/lib.rs`). So a browser re-downloaded **every** cover on **every** page refresh. The grid loads many covers at once, so over a slow link (Tailscale/Funnel) that was several MB per refresh and the visible bottleneck.

## Fix

- Add an **`ETag`** derived from the cover file's size+mtime.
- Add **`Cache-Control: public, max-age=300`**.
- Honour **`If-None-Match`** (weak `W/` prefix, comma-list, or `*`) with a bodyless **`304`**.

A re-extracted cover bumps mtime → the ETag changes → clients refetch. Otherwise a refresh revalidates to a 304 (no body) or, within the short max-age, skips the network entirely. Security unchanged: the path is still canonicalized and asserted under the data dir first.

## Verification

- `cargo test -p podspine-http serves_cover_when_present` — extended to assert the `ETag` + `Cache-Control` on the `200`, then that a conditional re-request with the ETag returns `304` with an empty body.
- clippy clean.

## Deliberate scope (follow-up)

**Caching only — no resizing yet.** Generating a smaller cover derivative at ingest (thumbnail for the grid, larger for detail) is the other half of backlog item 3 and a bigger change (touches the prober + storage). This PR fixes the re-download-on-refresh pain first; the thumbnail work is a separate PR. See `scratch/backlog.md`.