### PR TITLE
docs: note that the first scan can take a while

### DIFF
--- a/.changeset/first-scan-duration-docs.md
+++ b/.changeset/first-scan-duration-docs.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Document that the first scan can take a while: the README and docs quick-start now explain that the initial run splits every book (so a large library takes minutes), shows a self-refreshing "Scanning…" page meanwhile, and answers 503 + Retry-After on feed/audio until it finishes — while a warm restart stays fast

--- a/.changeset/first-scan-duration-docs.md
+++ b/.changeset/first-scan-duration-docs.md
@@ -2,4 +2,4 @@
 default: patch
 ---
 
-Document that the first scan can take a while: the README and docs quick-start now explain that the initial run splits every book (so a large library takes minutes), shows a self-refreshing "Scanning…" page meanwhile, and answers 503 + Retry-After on feed/audio until it finishes — while a warm restart stays fast
+Document that the first scan can take a while: the README and docs quick-start now explain that the initial run splits chaptered books into per-chapter episodes (whole-file books stream in place), so a large chaptered library takes minutes, shows a self-refreshing "Scanning…" page meanwhile, and answers 503 + Retry-After on feed/audio until it finishes — while a warm restart stays fast

--- a/README.md
+++ b/README.md
@@ -56,12 +56,13 @@ docker run \
 
 Then open <http://localhost:8080> to browse your books and copy feed URLs.
 
-> **The first scan can take a while.** On first start Podspine splits every book
-> into per-chapter episodes, so a large library can take minutes. While it runs,
-> the browse page shows a self-refreshing **"Scanning…"** message (not an error —
-> it becomes your book grid when the scan finishes) and feed/audio requests answer
-> `503` with `Retry-After` so podcatchers retry. A restart with an already-populated
-> `/data` volume is fast — only new or changed books are processed.
+> **The first scan can take a while.** On first start Podspine processes your whole
+> library — **chaptered** books are split into per-chapter episodes (whole-file books,
+> like MP3 folders, stream in place), so a large chaptered library can take minutes.
+> While it runs, the browse page shows a self-refreshing **"Scanning…"** message (not
+> an error — it becomes your book grid when the scan finishes) and feed/audio requests
+> answer `503` with `Retry-After` so podcatchers retry. A restart with an
+> already-populated `/data` volume is fast — it only processes what's new or changed.
 
 > **Set `PODSPINE_BASE_URL`** to the address podcast apps will actually reach
 > (your LAN IP or public hostname). It defaults to `http://localhost:8080`, which

--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ docker run \
 
 Then open <http://localhost:8080> to browse your books and copy feed URLs.
 
+> **The first scan can take a while.** On first start Podspine splits every book
+> into per-chapter episodes, so a large library can take minutes. While it runs,
+> the browse page shows a self-refreshing **"Scanning…"** message (not an error —
+> it becomes your book grid when the scan finishes) and feed/audio requests answer
+> `503` with `Retry-After` so podcatchers retry. A restart with an already-populated
+> `/data` volume is fast — only new or changed books are processed.
+
 > **Set `PODSPINE_BASE_URL`** to the address podcast apps will actually reach
 > (your LAN IP or public hostname). It defaults to `http://localhost:8080`, which
 > only works from the same machine — feed and audio URLs are built from it.

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,12 +41,13 @@ Then open <http://localhost:8080> to browse your books, copy feed URLs, or scan 
 book's QR code to open its one-tap [subscribe page](importing.md).
 
 !!! note "The first scan can take a while"
-    On first start Podspine splits every book into per-chapter episodes, so a large
-    library can take minutes — longer the more books you have. While it runs, the
-    browse page shows a self-refreshing **"Scanning…"** message (it isn't broken —
-    it turns into your book grid when the scan finishes), and feed/audio requests
-    answer `503` with `Retry-After` so podcatchers simply retry. A restart with an
-    already-populated `/data` volume is fast — only new or changed books are processed.
+    On first start Podspine processes your whole library — **chaptered** books are
+    split into per-chapter episodes (whole-file books, like MP3 folders, stream in
+    place), so a large chaptered library can take minutes. While it runs, the browse
+    page shows a self-refreshing **"Scanning…"** message (it isn't broken — it turns
+    into your book grid when the scan finishes), and feed/audio requests answer `503`
+    with `Retry-After` so podcatchers simply retry. A restart with an already-populated
+    `/data` volume is fast — it only processes what's new or changed.
 
 !!! tip "Set `PODSPINE_BASE_URL`"
     Point it at the address podcast apps will actually reach (your LAN IP or public

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,14 @@ docker run \
 Then open <http://localhost:8080> to browse your books, copy feed URLs, or scan a
 book's QR code to open its one-tap [subscribe page](importing.md).
 
+!!! note "The first scan can take a while"
+    On first start Podspine splits every book into per-chapter episodes, so a large
+    library can take minutes — longer the more books you have. While it runs, the
+    browse page shows a self-refreshing **"Scanning…"** message (it isn't broken —
+    it turns into your book grid when the scan finishes), and feed/audio requests
+    answer `503` with `Retry-After` so podcatchers simply retry. A restart with an
+    already-populated `/data` volume is fast — only new or changed books are processed.
+
 !!! tip "Set `PODSPINE_BASE_URL`"
     Point it at the address podcast apps will actually reach (your LAN IP or public
     hostname). It defaults to `http://localhost:8080`, which only works from the same


### PR DESCRIPTION
## What

Documents that the **initial** scan can take minutes (longer for large libraries), so a slow first boot reads as "starting up" rather than "broken" — backlog item 5, and the doc half of the Scanning-page work (issue 159).

Adds a matching note to both quick-starts:
- `README.md` — `>` blockquote style.
- `docs/index.md` — MkDocs `!!! note` admonition.

Each explains: first run splits every book; the browse page shows a self-refreshing "Scanning…" message that becomes the grid when done; feed/audio answer `503 + Retry-After` meanwhile; a warm restart with a populated `/data` volume is fast.

Docs-only — labeled `no-changelog`.