### PR TITLE
feat(ui): add a light/dark theme picker with cookie persistence

### DIFF
--- a/.changeset/ui-theme-picker.md
+++ b/.changeset/ui-theme-picker.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add a light/dark theme picker to the header: it still defaults to following the operating system, but a visitor can now choose Auto, Light, or Dark and the choice persists in a first-party `theme` cookie the server reads to render the right theme — no JavaScript, no flash of the wrong theme

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -50,7 +50,9 @@ use tower_http::trace::TraceLayer;
 use podspine_feed::{FeedBook, FeedEpisode, render_checked};
 use podspine_index::{BookRow, Index};
 use podspine_splitter::{ChapterCut, remux_faststart, split_chapter};
-use podspine_ui::{BookCard, BookDetail, book_page, index_page, scanning_page, subscribe_page};
+use podspine_ui::{
+    BookCard, BookDetail, Theme, book_page, index_page, scanning_page, subscribe_page,
+};
 
 /// Max concurrent in-flight requests before backpressure (DoS guard). Generous
 /// for a homelab tool; only bounds a pathological flood.
@@ -83,8 +85,9 @@ fn valid_feed_id(id: &str) -> bool {
             .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
 }
 
-/// Same-origin guard for the state-changing `POST` routes (CSRF defense). This
-/// app uses **no cookies**, so `SameSite` is inapplicable; instead we check the
+/// Same-origin guard for the state-changing `POST` routes (CSRF defense). The only
+/// cookie the app sets is the non-auth `theme` preference (no session/auth cookie),
+/// so `SameSite` carries no ambient authority to protect; instead we check the
 /// browser-set fetch-metadata / `Origin` headers. Modern browsers always send
 /// `Sec-Fetch-Site`, so cross-site form posts are caught even in the proxy-auth
 /// deployment (where a forged request would otherwise ride the owner's proxy
@@ -99,6 +102,22 @@ fn same_origin(headers: &HeaderMap, base_url: &str) -> bool {
         Some(origin) => origin == base_url.split('/').take(3).collect::<Vec<_>>().join("/"),
         None => true,
     }
+}
+
+/// The visitor's colour [`Theme`] from the `theme` cookie (absent/garbage →
+/// [`Theme::System`], i.e. follow the OS). Parsed by hand — the app pulls in no
+/// cookie crate for one first-party, non-auth preference cookie.
+fn theme_from_cookie(headers: &HeaderMap) -> Theme {
+    headers
+        .get(header::COOKIE)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|cookies| {
+            cookies
+                .split(';')
+                .find_map(|kv| kv.trim().strip_prefix("theme="))
+        })
+        .map(Theme::parse)
+        .unwrap_or_default()
 }
 
 /// Shared server state.
@@ -207,6 +226,7 @@ pub fn router(state: AppState) -> Router {
         .route("/", get(index))
         .route("/book/{slug}", get(book))
         .route("/book/{slug}/regenerate", post(regenerate))
+        .route("/theme/{mode}", post(set_theme))
         .route("/subscribe/{feed_id}", get(subscribe))
         .route("/cover/{feed_id}", get(cover))
         .route("/feed/{feed_id}", get(feed))
@@ -270,11 +290,15 @@ async fn feed(
 }
 
 /// `GET /` — the browsable book grid.
-async fn index(State(state): State<AppState>) -> Result<Html<String>, AppError> {
+async fn index(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Result<Html<String>, AppError> {
+    let theme = theme_from_cookie(&headers);
     // Until the initial scan finishes, hold on a "Scanning…" page rather than
     // render an empty grid that reads as "no books / broken" (issue 159).
     if !state.is_ready() {
-        return Ok(Html(scanning_page().into_string()));
+        return Ok(Html(scanning_page(theme).into_string()));
     }
     let books = {
         let index = state.index.lock().map_err(AppError::internal)?;
@@ -290,17 +314,19 @@ async fn index(State(state): State<AppState>) -> Result<Html<String>, AppError> 
             has_cover: b.cover_path.is_some(),
         })
         .collect();
-    Ok(Html(index_page(&cards).into_string()))
+    Ok(Html(index_page(&cards, theme).into_string()))
 }
 
 /// `GET /book/{slug}` — a book's page: copy-feed-URL, QR, how-to panel.
 async fn book(
     State(state): State<AppState>,
     Path(slug): Path<String>,
+    headers: HeaderMap,
 ) -> Result<Html<String>, AppError> {
     if !valid_slug(&slug) {
         return Err(AppError::NotFound);
     }
+    let theme = theme_from_cookie(&headers);
     let (book, episode_count) = {
         let index = state.index.lock().map_err(AppError::internal)?;
         let book = index
@@ -324,7 +350,7 @@ async fn book(
         has_cover: book.cover_path.is_some(),
         episode_count,
     };
-    Ok(Html(book_page(&detail).into_string()))
+    Ok(Html(book_page(&detail, theme).into_string()))
 }
 
 /// `GET /subscribe/{feed_id}` — the "add to a podcast app" helper page (per-app
@@ -333,10 +359,12 @@ async fn book(
 async fn subscribe(
     State(state): State<AppState>,
     Path(feed_id): Path<String>,
+    headers: HeaderMap,
 ) -> Result<Html<String>, AppError> {
     if !valid_feed_id(&feed_id) {
         return Err(AppError::NotFound);
     }
+    let theme = theme_from_cookie(&headers);
     let (book, episode_count) = {
         let index = state.index.lock().map_err(AppError::internal)?;
         let book = index
@@ -359,7 +387,7 @@ async fn subscribe(
         has_cover: book.cover_path.is_some(),
         episode_count,
     };
-    Ok(Html(subscribe_page(&detail).into_string()))
+    Ok(Html(subscribe_page(&detail, theme).into_string()))
 }
 
 /// `POST /book/{slug}/regenerate` — rotate the book's capability `feed_id` (leak
@@ -387,6 +415,50 @@ async fn regenerate(
             .map_err(AppError::internal)?;
     }
     Ok(Redirect::to(&format!("/book/{slug}")))
+}
+
+/// `POST /theme/{mode}` — persist the visitor's colour theme. `mode` is
+/// `light`/`dark` (sets the `theme` cookie) or `system` (clears it, reverting to
+/// the OS preference). No-JS: the header picker is a form of submit buttons whose
+/// `formaction` posts here; we set the cookie and 303-redirect back (PRG) to the
+/// same-origin page they came from. Same-origin-guarded like [`regenerate`].
+async fn set_theme(
+    State(state): State<AppState>,
+    Path(mode): Path<String>,
+    headers: HeaderMap,
+) -> Result<Response, AppError> {
+    if !same_origin(&headers, &state.base_url) {
+        return Err(AppError::Forbidden);
+    }
+    // A year-long, first-party, non-`Secure` (so it also works on a LAN over http)
+    // cosmetic cookie. `SameSite=Lax` still lets the top-level POST navigation set
+    // it. `system` clears the cookie via Max-Age=0.
+    let cookie = match Theme::parse(&mode).cookie_value() {
+        Some(value) => format!("theme={value}; Path=/; Max-Age=31536000; SameSite=Lax"),
+        None => "theme=; Path=/; Max-Age=0; SameSite=Lax".to_string(),
+    };
+    // Redirect back to the page they came from, but only a same-origin one, reduced
+    // to a relative path so it can't be turned into an open redirect.
+    let origin = state
+        .base_url
+        .split('/')
+        .take(3)
+        .collect::<Vec<_>>()
+        .join("/");
+    let back = headers
+        .get(header::REFERER)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|r| r.strip_prefix(&origin))
+        .filter(|path| path.starts_with('/'))
+        .unwrap_or("/")
+        .to_string();
+
+    let mut resp = Redirect::to(&back).into_response();
+    resp.headers_mut().insert(
+        header::SET_COOKIE,
+        HeaderValue::from_str(&cookie).map_err(AppError::internal)?,
+    );
+    Ok(resp)
 }
 
 /// `GET /cover/{feed_id}` — the book's cover image, keyed by capability id so it

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -120,6 +120,24 @@ fn theme_from_cookie(headers: &HeaderMap) -> Theme {
         .unwrap_or_default()
 }
 
+/// The same-origin path to redirect back to after a `POST /theme` (PRG), taken from
+/// the `Referer`. Returns the path+query of an absolute `scheme://host/path` URL, or
+/// a value that is already a plain absolute path. Rejects protocol-relative
+/// (`//host`) and anything not starting with a single `/`, so it can never become an
+/// open redirect. `None` (→ caller falls back to `/`) when there's no usable path.
+fn referer_path(referer: &str) -> Option<String> {
+    // Strip `scheme://authority`, leaving `/path?query`; if there's no `://`, the
+    // header was already a bare path (defensive — Referer is normally absolute).
+    let candidate = match referer.split_once("://") {
+        Some((_, after_authority)) => match after_authority.find('/') {
+            Some(slash) => &after_authority[slash..],
+            None => "/", // authority with no path
+        },
+        None => referer,
+    };
+    (candidate.starts_with('/') && !candidate.starts_with("//")).then(|| candidate.to_string())
+}
+
 /// Shared server state.
 #[derive(Clone)]
 pub struct AppState {
@@ -437,21 +455,18 @@ async fn set_theme(
         Some(value) => format!("theme={value}; Path=/; Max-Age=31536000; SameSite=Lax"),
         None => "theme=; Path=/; Max-Age=0; SameSite=Lax".to_string(),
     };
-    // Redirect back to the page they came from, but only a same-origin one, reduced
-    // to a relative path so it can't be turned into an open redirect.
-    let origin = state
-        .base_url
-        .split('/')
-        .take(3)
-        .collect::<Vec<_>>()
-        .join("/");
+    // Redirect back to the page they came from. Take the *path* of the Referer, not
+    // a match against `base_url`: the POST already passed the same-origin guard, so
+    // the Referer is this origin's page, and the browse UI is often on a different
+    // origin than `base_url` (which addresses podcatchers) — comparing against it
+    // would bounce every toggle to `/`. Only a single-slash absolute path is kept,
+    // so a protocol-relative (`//host`) or off-site value can't become an open
+    // redirect.
     let back = headers
         .get(header::REFERER)
         .and_then(|v| v.to_str().ok())
-        .and_then(|r| r.strip_prefix(&origin))
-        .filter(|path| path.starts_with('/'))
-        .unwrap_or("/")
-        .to_string();
+        .and_then(referer_path)
+        .unwrap_or_else(|| "/".to_string());
 
     let mut resp = Redirect::to(&back).into_response();
     resp.headers_mut().insert(
@@ -1227,6 +1242,28 @@ mod tests {
         ] {
             assert!(!valid_feed_id(bad), "must reject {bad:?}");
         }
+    }
+
+    #[test]
+    fn referer_path_extracts_path_and_blocks_open_redirect() {
+        // Absolute URLs → their path+query, regardless of host/port (so a UI origin
+        // that differs from base_url still returns home to the right page).
+        assert_eq!(
+            referer_path("http://192.168.1.5:8080/book/dracula").as_deref(),
+            Some("/book/dracula")
+        );
+        assert_eq!(
+            referer_path("https://podspine.example/subscribe/x?y=1").as_deref(),
+            Some("/subscribe/x?y=1")
+        );
+        // An absolute URL with no path → root.
+        assert_eq!(referer_path("http://host").as_deref(), Some("/"));
+        // Already a bare path is accepted.
+        assert_eq!(referer_path("/book/x").as_deref(), Some("/book/x"));
+        // Open-redirect vectors are rejected (caller falls back to `/`).
+        assert_eq!(referer_path("http://evil.com//evil.com/x"), None);
+        assert_eq!(referer_path("//evil.com/x"), None);
+        assert_eq!(referer_path("javascript:alert(1)"), None);
     }
 
     #[test]

--- a/crates/http/tests/server.rs
+++ b/crates/http/tests/server.rs
@@ -1829,3 +1829,25 @@ async fn set_theme_rejects_cross_site() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 }
+
+#[tokio::test]
+async fn set_theme_redirects_back_even_when_ui_origin_differs() {
+    // base_url is http://test, but the browse UI is reached on a different origin
+    // (a LAN IP). The toggle must still return to the same page via the Referer's
+    // path, not bounce to `/` (Greptile P1).
+    let resp = router(empty_state())
+        .oneshot(
+            Request::post("/theme/dark")
+                .header("sec-fetch-site", "same-origin")
+                .header(header::REFERER, "http://192.168.1.5:8080/book/dracula")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+    assert_eq!(
+        resp.headers().get(header::LOCATION).unwrap(),
+        "/book/dracula"
+    );
+}

--- a/crates/http/tests/server.rs
+++ b/crates/http/tests/server.rs
@@ -1739,3 +1739,93 @@ async fn once_ready_the_browse_ui_serves_normally() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }
+
+// ---- theme picker + cookie (no ffmpeg) ----
+
+#[tokio::test]
+async fn theme_cookie_renders_data_theme() {
+    let state = empty_state();
+    // A `theme=dark` cookie makes GET / render <html data-theme="dark">.
+    let resp = router(state.clone())
+        .oneshot(
+            Request::get("/")
+                .header(header::COOKIE, "theme=dark")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let html = String::from_utf8(body_bytes(resp).await).unwrap();
+    // Assert on the <html> tag, not the CSS (which names data-theme in selectors).
+    assert!(
+        html.contains("<html lang=\"en\" data-theme=\"dark\">"),
+        "{html}"
+    );
+
+    // No cookie → no data-theme on <html> (follows the OS via prefers-color-scheme).
+    let resp = router(state)
+        .oneshot(Request::get("/").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let html = String::from_utf8(body_bytes(resp).await).unwrap();
+    assert!(html.contains("<html lang=\"en\">"), "{html}");
+}
+
+#[tokio::test]
+async fn set_theme_sets_cookie_then_clears_it() {
+    // Choosing dark sets a persistent cookie and redirects back (PRG).
+    let resp = router(empty_state())
+        .oneshot(
+            Request::post("/theme/dark")
+                .header("sec-fetch-site", "same-origin")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+    let cookie = resp
+        .headers()
+        .get(header::SET_COOKIE)
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert!(cookie.contains("theme=dark"), "{cookie}");
+    assert!(cookie.contains("Max-Age=31536000"), "{cookie}");
+
+    // Choosing "system" clears the cookie (Max-Age=0) → revert to the OS.
+    let resp = router(empty_state())
+        .oneshot(
+            Request::post("/theme/system")
+                .header("sec-fetch-site", "same-origin")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+    let cookie = resp
+        .headers()
+        .get(header::SET_COOKIE)
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert!(cookie.contains("theme="), "{cookie}");
+    assert!(cookie.contains("Max-Age=0"), "{cookie}");
+}
+
+#[tokio::test]
+async fn set_theme_rejects_cross_site() {
+    // A cross-site POST can't flip the theme (CSRF guard), same as regenerate.
+    let resp = router(empty_state())
+        .oneshot(
+            Request::post("/theme/dark")
+                .header("sec-fetch-site", "cross-site")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -53,29 +53,50 @@ pub struct BookDetail {
 /// Shared styles + a page shell. Inlined so the binary needs no static assets.
 /// The palette is chosen for WCAG AA contrast (NFR-C3): `#18181b` text on white
 /// (~16:1), `#52525b` muted (~7:1), and white on the `#1d4ed8` accent (~5.3:1).
-/// Everything is driven through the `--*` custom properties, so the dark palette
-/// below is just an OS-preference override of those same variables — no per-rule
-/// duplication. `color-scheme` lets native controls/scrollbars follow suit.
+/// Everything is driven through the `--*` custom properties, so a theme is just an
+/// override of those same variables — no per-rule duplication. The default (no
+/// `data-theme`) follows the OS via `prefers-color-scheme`; an explicit choice from
+/// the header picker sets `<html data-theme="light|dark">` (persisted in a cookie,
+/// read server-side) which wins over the media query. `color-scheme` keeps native
+/// controls/scrollbars in step. AA-contrast dark palette — `#f4f4f5` text on
+/// `#18181b` (~16:1), `#a1a1aa` muted (~7:1), `#0b1120` on the lighter `#60a5fa`
+/// accent (~7:1). The QR SVGs keep their own white background (`.appqr svg`) so a
+/// phone can still scan in dark mode.
 const STYLE: &str = r#"
 :root { color-scheme: light dark;
         --bg:#ffffff; --surface:#f4f4f5; --border:#d4d4d8; --text:#18181b;
         --muted:#52525b; --accent:#1d4ed8; --accent-text:#ffffff; --danger:#b91c1c; }
-/* Auto dark mode: follows the OS setting, no JS, no toggle. AA-contrast dark
-   palette — `#f4f4f5` text on `#18181b` (~16:1), `#a1a1aa` muted (~7:1), and
-   `#0b1120` text on the lighter `#60a5fa` accent (~7:1). The QR SVGs keep their
-   own white background (set inline on `.appqr svg`) so a phone can still scan. */
+/* Explicit "Light" from the picker: pin the scheme so native controls don't follow
+   a dark OS; the light palette above already applies. */
+:root[data-theme="light"] { color-scheme: light; }
+/* The dark palette lives in two selectors so it applies both for an explicit "Dark"
+   choice and for the OS default when the visitor hasn't chosen (:not([data-theme])). */
+:root[data-theme="dark"] { color-scheme: dark;
+        --bg:#18181b; --surface:#27272a; --border:#3f3f46; --text:#f4f4f5;
+        --muted:#a1a1aa; --accent:#60a5fa; --accent-text:#0b1120; --danger:#f87171; }
 @media (prefers-color-scheme: dark) {
-  :root { --bg:#18181b; --surface:#27272a; --border:#3f3f46; --text:#f4f4f5;
-          --muted:#a1a1aa; --accent:#60a5fa; --accent-text:#0b1120; --danger:#f87171; }
+  :root:not([data-theme]) { --bg:#18181b; --surface:#27272a; --border:#3f3f46;
+        --text:#f4f4f5; --muted:#a1a1aa; --accent:#60a5fa; --accent-text:#0b1120;
+        --danger:#f87171; }
 }
 * { box-sizing:border-box; }
 body { margin:0; font:16px/1.5 system-ui,-apple-system,Segoe UI,Roboto,sans-serif;
        color:var(--text); background:var(--bg); }
 a { color:var(--accent); }
 :focus-visible { outline:3px solid var(--accent); outline-offset:2px; border-radius:4px; }
-header.site { padding:1rem 1.25rem; border-bottom:1px solid var(--border); }
+header.site { padding:1rem 1.25rem; border-bottom:1px solid var(--border);
+        display:flex; align-items:center; justify-content:space-between; gap:1rem; }
 header.site h1 { margin:0; font-size:1.25rem; }
 header.site a { text-decoration:none; color:var(--text); }
+/* Theme picker: a no-JS segmented control (a form of submit buttons). The active
+   theme is marked with aria-pressed, which also styles it. */
+.themepicker { display:inline-flex; margin:0; border:1px solid var(--border);
+        border-radius:6px; overflow:hidden; }
+.themepicker button { font:inherit; font-size:.8rem; padding:.35rem .7rem; border:0;
+        border-left:1px solid var(--border); background:var(--surface); color:var(--text);
+        cursor:pointer; }
+.themepicker button:first-child { border-left:0; }
+.themepicker button[aria-pressed="true"] { background:var(--accent); color:var(--accent-text); }
 main { max-width:960px; margin:0 auto; padding:1.5rem 1.25rem; }
 .grid { list-style:none; margin:0; padding:0; display:grid; gap:1.25rem;
         grid-template-columns:repeat(auto-fill,minmax(150px,1fr)); }
@@ -164,11 +185,69 @@ document.addEventListener('click', function (e) {
 });
 "#;
 
-/// Wrap page `body` content in the full HTML document shell.
-fn page(title: &str, body: Markup) -> Markup {
+/// The visitor's chosen colour theme, decoded from the `theme` cookie. `System`
+/// (the default, no cookie) follows the OS via `prefers-color-scheme`; `Light` and
+/// `Dark` force it. Rendered as the `data-theme` attribute the CSS keys off.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum Theme {
+    /// Follow the operating system (no `data-theme` attribute).
+    #[default]
+    System,
+    Light,
+    Dark,
+}
+
+impl Theme {
+    /// Decode a `theme` cookie / picker `mode` value; anything else is `System`
+    /// (so a stale or garbage cookie safely falls back to following the OS).
+    pub fn parse(value: &str) -> Self {
+        match value {
+            "light" => Theme::Light,
+            "dark" => Theme::Dark,
+            _ => Theme::System,
+        }
+    }
+
+    /// The `data-theme` attribute value, or `None` for `System` (no attribute → the
+    /// `prefers-color-scheme` media query applies).
+    fn attr(self) -> Option<&'static str> {
+        match self {
+            Theme::System => None,
+            Theme::Light => Some("light"),
+            Theme::Dark => Some("dark"),
+        }
+    }
+
+    /// The value to persist in the `theme` cookie, or `None` for `System` (which
+    /// clears the cookie so the browser reverts to the OS preference).
+    pub fn cookie_value(self) -> Option<&'static str> {
+        self.attr()
+    }
+}
+
+/// The no-JS theme picker: a small form of submit buttons in the header. Each
+/// button's `formaction` posts to `/theme/{mode}`; the server sets the cookie and
+/// redirects back. The active theme is marked with `aria-pressed` (also styled).
+fn theme_picker(current: Theme) -> Markup {
+    html! {
+        form.themepicker method="post" aria-label="Colour theme" {
+            @for &(mode, value, label) in &[
+                (Theme::System, "system", "Auto"),
+                (Theme::Light, "light", "Light"),
+                (Theme::Dark, "dark", "Dark"),
+            ] {
+                button formaction=(format!("/theme/{value}"))
+                    aria-pressed=(mode == current) { (label) }
+            }
+        }
+    }
+}
+
+/// Wrap page `body` content in the full HTML document shell for the given `theme`.
+fn page(title: &str, theme: Theme, body: Markup) -> Markup {
     html! {
         (DOCTYPE)
-        html lang="en" {
+        html lang="en" data-theme=[theme.attr()] {
             head {
                 meta charset="utf-8";
                 meta name="viewport" content="width=device-width, initial-scale=1";
@@ -176,7 +255,10 @@ fn page(title: &str, body: Markup) -> Markup {
                 style { (PreEscaped(STYLE)) }
             }
             body {
-                header.site { h1 { a href="/" { "Podspine" } } }
+                header.site {
+                    h1 { a href="/" { "Podspine" } }
+                    (theme_picker(theme))
+                }
                 (body)
             }
         }
@@ -205,9 +287,10 @@ fn cover(id: &str, title: &str, has_cover: bool, class: &str) -> Markup {
 }
 
 /// The home page: a grid of books, each linking to its detail page.
-pub fn index_page(books: &[BookCard]) -> Markup {
+pub fn index_page(books: &[BookCard], theme: Theme) -> Markup {
     page(
         "Podspine",
+        theme,
         html! {
             main {
                 @if books.is_empty() {
@@ -236,10 +319,10 @@ pub fn index_page(books: &[BookCard]) -> Markup {
 /// becomes the normal book list on its own once the scan finishes. It reuses the
 /// page shell but needs its own `<head>` (the refresh directive and a distinct
 /// title), so it is built directly rather than through [`page`].
-pub fn scanning_page() -> Markup {
+pub fn scanning_page(theme: Theme) -> Markup {
     html! {
         (DOCTYPE)
-        html lang="en" {
+        html lang="en" data-theme=[theme.attr()] {
             head {
                 meta charset="utf-8";
                 meta name="viewport" content="width=device-width, initial-scale=1";
@@ -262,13 +345,14 @@ pub fn scanning_page() -> Markup {
 }
 
 /// A book's detail page: cover, copy-feed-URL, scannable QR, and how-to panel.
-pub fn book_page(book: &BookDetail) -> Markup {
+pub fn book_page(book: &BookDetail, theme: Theme) -> Markup {
     // The QR encodes the /subscribe helper page, not the raw feed: a raw RSS URL
     // scanned by the iOS Camera opens Safari to bare XML ("can't open"), whereas
     // the helper page offers real per-app "Open in…" deep links.
     let qr = qr_svg(&book.subscribe_url);
     page(
         &book.title,
+        theme,
         html! {
             main {
                 a.back href="/" { "← All books" }
@@ -401,10 +485,11 @@ pub fn subscribe_links(feed_url: &str) -> Vec<AppLink> {
 /// scan (desktop→phone handoff) — and a copy-the-URL fallback. This is what the
 /// book-page QR points at, so an iOS Camera scan lands on real app links instead of
 /// raw feed XML.
-pub fn subscribe_page(book: &BookDetail) -> Markup {
+pub fn subscribe_page(book: &BookDetail, theme: Theme) -> Markup {
     let apps = subscribe_links(&book.feed_url);
     page(
         &format!("Add \u{201c}{}\u{201d} to a podcast app", book.title),
+        theme,
         html! {
             main {
                 a.back href=(format!("/book/{}", book.slug)) { "← Back to book" }
@@ -518,7 +603,7 @@ mod tests {
             card("dracula", "Dracula", true),
             card("solaris", "Solaris", false),
         ];
-        let html = index_page(&books).into_string();
+        let html = index_page(&books, Theme::System).into_string();
         assert!(html.contains("href=\"/book/dracula\""));
         assert!(html.contains("href=\"/book/solaris\""));
         // Cover present -> img with alt; absent -> labelled placeholder.
@@ -530,7 +615,7 @@ mod tests {
 
     #[test]
     fn scanning_page_holds_and_self_refreshes() {
-        let html = scanning_page().into_string();
+        let html = scanning_page(Theme::System).into_string();
         // A clear scanning state, not an empty book grid...
         assert!(html.contains("Scanning your library…"));
         assert!(!html.contains("No audiobooks found"));
@@ -540,9 +625,37 @@ mod tests {
 
     #[test]
     fn empty_library_shows_a_message() {
-        let html = index_page(&[]).into_string();
+        let html = index_page(&[], Theme::System).into_string();
         assert!(html.contains("No audiobooks found"));
         assert!(!html.contains("<ul"));
+    }
+
+    #[test]
+    fn theme_picker_reflects_choice() {
+        // System (the default): no data-theme on <html>, so the page follows the OS.
+        // (The CSS names data-theme in selectors, so assert on the tag, not a substring.)
+        let sys = index_page(&[], Theme::System).into_string();
+        assert!(
+            sys.contains("<html lang=\"en\">"),
+            "System sets no data-theme"
+        );
+        assert!(sys.contains("themepicker"), "the picker is always present");
+        // The active option is marked on its button (assert on the label so the CSS
+        // selector `[aria-pressed="true"]` doesn't count as a match). Auto for System.
+        assert!(sys.contains("aria-pressed=\"true\">Auto</button>"));
+
+        // Dark: the <html> tag carries data-theme="dark" and posts to /theme/{mode}.
+        let dark = index_page(&[], Theme::Dark).into_string();
+        assert!(dark.contains("<html lang=\"en\" data-theme=\"dark\">"));
+        assert!(dark.contains("formaction=\"/theme/dark\""));
+        assert!(
+            dark.contains("aria-pressed=\"true\">Dark</button>"),
+            "Dark active"
+        );
+        assert!(
+            !dark.contains("aria-pressed=\"true\">Auto</button>"),
+            "Auto not active in dark"
+        );
     }
 
     #[test]
@@ -570,7 +683,7 @@ mod tests {
 
     #[test]
     fn book_page_has_exact_feed_url_and_qr() {
-        let html = book_page(&detail()).into_string();
+        let html = book_page(&detail(), Theme::System).into_string();
         // The copy input carries the exact working (capability) URL.
         assert!(html.contains("value=\"http://host:8080/feed/Xk9mQ2vP7nR4tB1cY6wZ8a.xml\""));
         assert!(html.contains("12 episodes"));
@@ -587,7 +700,7 @@ mod tests {
 
     #[test]
     fn subscribe_page_has_per_app_deep_links_and_qrs() {
-        let html = subscribe_page(&detail()).into_string();
+        let html = subscribe_page(&detail(), Theme::System).into_string();
         // Apple Podcasts: podcast:// + feed URL WITHOUT the scheme.
         assert!(html.contains("href=\"podcast://host:8080/feed/Xk9mQ2vP7nR4tB1cY6wZ8a.xml\""));
         assert!(html.contains("pktc://subscribe/host:8080/feed/"));
@@ -638,7 +751,7 @@ mod tests {
     #[test]
     fn markup_escapes_untrusted_title() {
         let books = [card("x", "<script>alert(1)</script>", false)];
-        let html = index_page(&books).into_string();
+        let html = index_page(&books, Theme::System).into_string();
         assert!(!html.contains("<script>alert(1)"));
         assert!(html.contains("&lt;script&gt;"));
     }

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -331,7 +331,10 @@ pub fn scanning_page(theme: Theme) -> Markup {
                 style { (PreEscaped(STYLE)) }
             }
             body {
-                header.site { h1 { a href="/" { "Podspine" } } }
+                header.site {
+                    h1 { a href="/" { "Podspine" } }
+                    (theme_picker(theme))
+                }
                 main {
                     p.empty { "Scanning your library…" }
                     p.empty {
@@ -621,6 +624,11 @@ mod tests {
         assert!(!html.contains("No audiobooks found"));
         // ...that reloads itself (no JS) so it flips to the list when the scan ends.
         assert!(html.contains("<meta http-equiv=\"refresh\" content=\"5\">"));
+        // The theme picker is available here too, not only after readiness.
+        assert!(
+            html.contains("themepicker"),
+            "scanning page carries the picker"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

A header **light/dark picker** (Auto / Light / Dark). Default is still to follow the OS (`prefers-color-scheme`); now a visitor can override and the choice **persists**. Backlog item — the manual toggle follow-up to the auto-dark PR.

No JavaScript, no flash of the wrong theme:
- The picker is a small **form of submit buttons** in the header; each button's `formaction` posts to `POST /theme/{mode}`.
- The handler sets a first-party, non-auth **`theme` cookie** and 303-redirects back (PRG), **same-origin-guarded** exactly like `regenerate`. `Auto` clears the cookie (revert to OS).
- The server reads the cookie and renders `<html data-theme="light|dark">`, so the correct theme is present in the first byte (no FOUC) and there's still zero client JS.
- CSS keys the palette off `data-theme`, keeping the OS default via `:root:not([data-theme])`.

## Verification

- `cargo test -p podspine-ui -p podspine-http` green. New tests:
  - ui `theme_picker_reflects_choice` — `data-theme` on `<html>` only when chosen; active button marked.
  - http `theme_cookie_renders_data_theme`, `set_theme_sets_cookie_then_clears_it` (dark sets a year-long cookie; `system` clears it), `set_theme_rejects_cross_site` (CSRF 403).
- Workspace clippy clean, fmt clean.

## Notes

- First cookie the app sets — first-party, non-tracking, cosmetic; `same_origin`'s doc updated to reflect it carries no ambient auth.
- QR SVGs keep their inline white background, so they still scan in dark mode.