### PR TITLE
feat(ui): serve a scanner-generated cover thumbnail to the browse grid

### DIFF
--- a/.changeset/cover-thumbnails.md
+++ b/.changeset/cover-thumbnails.md
@@ -2,4 +2,4 @@
 default: minor
 ---
 
-Serve a small cover thumbnail to the browse-UI grid instead of full-resolution artwork: `/cover/{id}/thumb` generates a `cover_thumb.jpg` (long edge ≤400px) on first request, caches it in the data dir, and regenerates it when the cover changes — so existing books get thumbnails on first view with no re-ingest. The RSS feed and `/cover` keep the full-size image for podcatchers
+Serve a small cover thumbnail to the browse-UI grid instead of full-resolution artwork: the scanner generates a `cover_thumb.jpg` (long edge ≤400px) alongside each cover, and `/cover/{id}/thumb` serves it (falling back to the full cover when it's missing). Existing libraries are backfilled by the reconcile on the next scan — no re-ingest needed. The RSS feed and `/cover` keep the full-size image for podcatchers

--- a/.changeset/cover-thumbnails.md
+++ b/.changeset/cover-thumbnails.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Serve a small cover thumbnail to the browse-UI grid instead of full-resolution artwork: `/cover/{id}/thumb` generates a `cover_thumb.jpg` (long edge ≤400px) on first request, caches it in the data dir, and regenerates it when the cover changes — so existing books get thumbnails on first view with no re-ingest. The RSS feed and `/cover` keep the full-size image for podcatchers

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -504,12 +504,11 @@ async fn cover(
 }
 
 /// `GET /cover/{feed_id}/thumb` — a small `cover_thumb.jpg` for the browse UI grid
-/// (the RSS feed and `/cover` keep the full-res image). The thumbnail is generated
-/// **on demand** from the full cover the first time it's requested and cached in the
-/// data dir, then served as a file thereafter — so existing books get a thumbnail on
-/// first view without a re-ingest, and a re-extracted cover refreshes it (the
-/// generator re-runs when the thumb is missing or older than the cover). If
-/// generation fails, it falls back to the full cover rather than 404ing.
+/// (the RSS feed and `/cover` keep the full-res image). Serving is read-only: the
+/// scanner generates the thumbnail alongside the cover, and this handler just serves
+/// it. If it hasn't been generated yet (the reconcile backfills a missing one on the
+/// next scan) or generation failed, it falls back to the full cover rather than
+/// 404ing.
 async fn cover_thumb(
     State(state): State<AppState>,
     Path(feed_id): Path<String>,

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -49,7 +49,7 @@ use tower_http::trace::TraceLayer;
 
 use podspine_feed::{FeedBook, FeedEpisode, render_checked};
 use podspine_index::{BookRow, Index};
-use podspine_splitter::{ChapterCut, remux_faststart, split_chapter};
+use podspine_splitter::{ChapterCut, extract_cover_thumb, remux_faststart, split_chapter};
 use podspine_ui::{
     BookCard, BookDetail, Theme, book_page, index_page, scanning_page, subscribe_page,
 };
@@ -247,6 +247,7 @@ pub fn router(state: AppState) -> Router {
         .route("/theme/{mode}", post(set_theme))
         .route("/subscribe/{feed_id}", get(subscribe))
         .route("/cover/{feed_id}", get(cover))
+        .route("/cover/{feed_id}/thumb", get(cover_thumb))
         .route("/feed/{feed_id}", get(feed))
         .route("/audio/{feed_id}/{number}", get(audio))
         .layer(TraceLayer::new_for_http())
@@ -497,42 +498,142 @@ async fn cover(
     if !valid_feed_id(&feed_id) {
         return Err(AppError::NotFound);
     }
-    let cover_path = {
-        let index = state.index.lock().map_err(AppError::internal)?;
-        index
-            .get_book_by_feed_id(&feed_id)
-            .map_err(AppError::internal)?
-            .ok_or(AppError::NotFound)?
-            .cover_path
-            .ok_or(AppError::NotFound)?
-    };
+    let cover_path = book_cover_path(&state, &feed_id)?;
+    let canonical = resolve_under_data_dir(&cover_path, &state.data_dir, &feed_id)?;
+    serve_image(&canonical, &headers).await
+}
 
-    let canonical = PathBuf::from(&cover_path)
+/// `GET /cover/{feed_id}/thumb` — a small `cover_thumb.jpg` for the browse UI grid
+/// (the RSS feed and `/cover` keep the full-res image). The thumbnail is generated
+/// **on demand** from the full cover the first time it's requested and cached in the
+/// data dir, then served as a file thereafter — so existing books get a thumbnail on
+/// first view without a re-ingest, and a re-extracted cover refreshes it (the
+/// generator re-runs when the thumb is missing or older than the cover). If
+/// generation fails, it falls back to the full cover rather than 404ing.
+async fn cover_thumb(
+    State(state): State<AppState>,
+    Path(feed_id): Path<String>,
+    headers: HeaderMap,
+) -> Result<Response, AppError> {
+    if !state.is_ready() {
+        return Ok(scanning_unavailable());
+    }
+    if !valid_feed_id(&feed_id) {
+        return Err(AppError::NotFound);
+    }
+    let cover_path = book_cover_path(&state, &feed_id)?;
+    // The full cover is the source of truth (must exist, under the data dir).
+    let cover = resolve_under_data_dir(&cover_path, &state.data_dir, &feed_id)?;
+    let thumb = cover.with_file_name("cover_thumb.jpg");
+
+    match ensure_thumb(&state, &cover, &thumb).await {
+        Ok(()) => serve_image(&thumb, &headers).await,
+        // Generation failed — serve the full cover so a book with art never 404s.
+        Err(_) => serve_image(&cover, &headers).await,
+    }
+}
+
+/// Ensure the cover thumbnail at `thumb` exists and is current, (re)generating it
+/// from `cover` when it's missing or older than the cover — so a re-extracted cover
+/// refreshes the thumbnail on the next view, with no re-ingest and no persisted
+/// thumbnail at scan time. Single-flighted per path like [`ensure_cached`] so
+/// concurrent first-requests run ffmpeg once; the blocking work runs off the async
+/// runtime.
+async fn ensure_thumb(state: &AppState, cover: &FsPath, thumb: &FsPath) -> Result<(), AppError> {
+    let lock = {
+        let mut map = state.inflight.lock().map_err(AppError::internal)?;
+        map.entry(thumb.to_path_buf())
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+            .clone()
+    };
+    let _guard = lock.lock().await;
+
+    let outcome = async {
+        // A concurrent request may have produced a fresh thumb while we waited.
+        if thumb_is_fresh(thumb, cover) {
+            return Ok(());
+        }
+        let cover = cover.to_path_buf();
+        let out_dir = cover
+            .parent()
+            .map(|p| p.to_path_buf())
+            .ok_or(AppError::NotFound)?;
+        tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+            extract_cover_thumb(&cover, &out_dir).map_err(std::io::Error::other)?;
+            Ok(())
+        })
+        .await
+        .map_err(AppError::internal)?
+        .map_err(AppError::internal)?;
+        Ok(())
+    }
+    .await;
+
+    // Drop the single-flight entry (see [`ensure_cached`] for why this is race-free).
+    if let Ok(mut map) = state.inflight.lock() {
+        map.remove(thumb);
+    }
+    outcome
+}
+
+/// Whether the thumbnail exists and is at least as new as the cover it derives from.
+/// A missing thumb, or one older than the cover (a re-extraction bumped the cover's
+/// mtime), is stale and must be regenerated.
+fn thumb_is_fresh(thumb: &FsPath, cover: &FsPath) -> bool {
+    match (
+        std::fs::metadata(thumb).and_then(|m| m.modified()),
+        std::fs::metadata(cover).and_then(|m| m.modified()),
+    ) {
+        (Ok(thumb_mtime), Ok(cover_mtime)) => thumb_mtime >= cover_mtime,
+        _ => false,
+    }
+}
+
+/// The book's stored (full) cover path, or `NotFound` when the book/cover is absent.
+fn book_cover_path(state: &AppState, feed_id: &str) -> Result<String, AppError> {
+    let index = state.index.lock().map_err(AppError::internal)?;
+    index
+        .get_book_by_feed_id(feed_id)
+        .map_err(AppError::internal)?
+        .ok_or(AppError::NotFound)?
+        .cover_path
+        .ok_or(AppError::NotFound)
+}
+
+/// Canonicalize a stored image path and confirm it stays under the data dir (a
+/// resolved path that escapes it is rejected as `NotFound`, never served). Fails
+/// with `NotFound` when the file doesn't exist — which the thumbnail handler relies
+/// on to fall back to the full cover.
+fn resolve_under_data_dir(
+    path: &str,
+    data_dir: &FsPath,
+    feed_id: &str,
+) -> Result<PathBuf, AppError> {
+    let canonical = PathBuf::from(path)
         .canonicalize()
         .map_err(|_| AppError::NotFound)?;
-    if !canonical.starts_with(&state.data_dir) {
+    if !canonical.starts_with(data_dir) {
         tracing::warn!(feed_id, "resolved cover path escaped the data dir");
         return Err(AppError::NotFound);
     }
+    Ok(canonical)
+}
 
-    // Read the bytes first, then derive the ETag from *those exact bytes* (blake3).
-    // A validator built from stat() metadata could advertise the old file's tag
-    // against new bytes if a rescan overwrites the cover between the stat and the
-    // read (TOCTOU), and whole-second mtime wouldn't change for a same-length,
-    // same-second replacement. A content hash matches whatever is served, always.
-    let bytes = tokio::fs::read(&canonical)
+/// Serve an on-disk image with content-addressed caching: an `ETag` (a blake3 hash
+/// of the served bytes) + `Cache-Control`, and a bodyless `304` on a matching
+/// `If-None-Match`, so a browser revalidates cheaply instead of re-downloading the
+/// image on every page refresh. `canonical` is already resolved and confirmed under
+/// the data dir. The ETag is over the exact bytes (not stat metadata), so it can't
+/// advertise a stale validator against a cover that was re-extracted between a stat
+/// and the read.
+async fn serve_image(canonical: &FsPath, headers: &HeaderMap) -> Result<Response, AppError> {
+    let bytes = tokio::fs::read(canonical)
         .await
         .map_err(|_| AppError::NotFound)?;
     let etag = format!("\"{}\"", blake3::hash(&bytes).to_hex());
     let etag_value = HeaderValue::from_str(&etag).map_err(AppError::internal)?;
-    // Short max-age so a refresh burst skips the network entirely, while a covered
-    // book that gets re-extracted goes stale for at most that window.
     let cache_control = HeaderValue::from_static("public, max-age=300");
 
-    // If-None-Match: honour a matching tag (weak `W/` prefix, comma list, or `*`)
-    // with a 304 so the client keeps its cached image and no body is sent. We still
-    // read the file to hash it, but skip re-sending the (multi-MB) body — the
-    // network transfer was the cost over a slow link, not the local disk read.
     let unchanged = headers
         .get(header::IF_NONE_MATCH)
         .and_then(|v| v.to_str().ok())
@@ -549,7 +650,8 @@ async fn cover(
         return Ok(resp);
     }
 
-    let mut resp = ([(header::CONTENT_TYPE, image_mime(&cover_path))], bytes).into_response();
+    let mime = image_mime(&canonical.to_string_lossy());
+    let mut resp = ([(header::CONTENT_TYPE, mime)], bytes).into_response();
     let h = resp.headers_mut();
     h.insert(header::ETAG, etag_value);
     h.insert(header::CACHE_CONTROL, cache_control);

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -529,12 +529,18 @@ async fn cover_thumb(
     // missing one) or generation failed — so a book with art never 404s. Serving is
     // read-only: generation lives in the scanner (single-threaded, atomic), which is
     // what keeps a thumbnail consistent with its cover with no cross-thread race.
+    //
+    // Fall back to the cover when the thumbnail *serve* fails too, not just when it
+    // can't be resolved: a re-ingest deletes the old thumb before regenerating it, so
+    // it can vanish between canonicalize and read — the cover is only ever atomically
+    // replaced (never absent), so serving it is always safe.
     if let Some(dir) = cover.parent() {
         let thumb = cover_thumb_path(dir);
         if let Ok(canonical) =
             resolve_under_data_dir(&thumb.to_string_lossy(), &state.data_dir, &feed_id)
+            && let Ok(resp) = serve_image(&canonical, &headers).await
         {
-            return serve_image(&canonical, &headers).await;
+            return Ok(resp);
         }
     }
     serve_image(&cover, &headers).await

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -49,7 +49,9 @@ use tower_http::trace::TraceLayer;
 
 use podspine_feed::{FeedBook, FeedEpisode, render_checked};
 use podspine_index::{BookRow, Index};
-use podspine_splitter::{ChapterCut, extract_cover_thumb, remux_faststart, split_chapter};
+use podspine_splitter::{
+    ChapterCut, cover_thumb_path, extract_cover_thumb, remux_faststart, split_chapter,
+};
 use podspine_ui::{
     BookCard, BookDetail, Theme, book_page, index_page, scanning_page, subscribe_page,
 };
@@ -524,7 +526,10 @@ async fn cover_thumb(
     let cover_path = book_cover_path(&state, &feed_id)?;
     // The full cover is the source of truth (must exist, under the data dir).
     let cover = resolve_under_data_dir(&cover_path, &state.data_dir, &feed_id)?;
-    let thumb = cover.with_file_name("cover_thumb.jpg");
+    let thumb = cover
+        .parent()
+        .map(cover_thumb_path)
+        .ok_or(AppError::NotFound)?;
 
     match ensure_thumb(&state, &cover, &thumb).await {
         Ok(()) => serve_image(&thumb, &headers).await,
@@ -533,13 +538,20 @@ async fn cover_thumb(
     }
 }
 
-/// Ensure the cover thumbnail at `thumb` exists and is current, (re)generating it
-/// from `cover` when it's missing or older than the cover — so a re-extracted cover
-/// refreshes the thumbnail on the next view, with no re-ingest and no persisted
-/// thumbnail at scan time. Single-flighted per path like [`ensure_cached`] so
-/// concurrent first-requests run ffmpeg once; the blocking work runs off the async
-/// runtime.
+/// Ensure the cover thumbnail at `thumb` exists, generating it from `cover` when
+/// missing. Freshness is handled by explicit invalidation, not mtime: the scanner
+/// deletes the cached thumbnail whenever it re-extracts a cover, so an existing
+/// thumb is always current and a changed cover regenerates here on the next view —
+/// no re-ingest, no persisted thumbnail at scan time, and no dependence on
+/// filesystem timestamp resolution. Single-flighted per path like [`ensure_cached`]
+/// so concurrent first-requests run ffmpeg once; the blocking work runs off the
+/// async runtime.
 async fn ensure_thumb(state: &AppState, cover: &FsPath, thumb: &FsPath) -> Result<(), AppError> {
+    // Fast path: already cached.
+    if thumb.exists() {
+        return Ok(());
+    }
+
     let lock = {
         let mut map = state.inflight.lock().map_err(AppError::internal)?;
         map.entry(thumb.to_path_buf())
@@ -549,8 +561,8 @@ async fn ensure_thumb(state: &AppState, cover: &FsPath, thumb: &FsPath) -> Resul
     let _guard = lock.lock().await;
 
     let outcome = async {
-        // A concurrent request may have produced a fresh thumb while we waited.
-        if thumb_is_fresh(thumb, cover) {
+        // A concurrent request may have produced it while we waited on the lock.
+        if thumb.exists() {
             return Ok(());
         }
         let cover = cover.to_path_buf();
@@ -574,19 +586,6 @@ async fn ensure_thumb(state: &AppState, cover: &FsPath, thumb: &FsPath) -> Resul
         map.remove(thumb);
     }
     outcome
-}
-
-/// Whether the thumbnail exists and is at least as new as the cover it derives from.
-/// A missing thumb, or one older than the cover (a re-extraction bumped the cover's
-/// mtime), is stale and must be regenerated.
-fn thumb_is_fresh(thumb: &FsPath, cover: &FsPath) -> bool {
-    match (
-        std::fs::metadata(thumb).and_then(|m| m.modified()),
-        std::fs::metadata(cover).and_then(|m| m.modified()),
-    ) {
-        (Ok(thumb_mtime), Ok(cover_mtime)) => thumb_mtime >= cover_mtime,
-        _ => false,
-    }
 }
 
 /// The book's stored (full) cover path, or `NotFound` when the book/cover is absent.

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -49,9 +49,7 @@ use tower_http::trace::TraceLayer;
 
 use podspine_feed::{FeedBook, FeedEpisode, render_checked};
 use podspine_index::{BookRow, Index};
-use podspine_splitter::{
-    ChapterCut, cover_thumb_path, extract_cover_thumb, remux_faststart, split_chapter,
-};
+use podspine_splitter::{ChapterCut, cover_thumb_path, remux_faststart, split_chapter};
 use podspine_ui::{
     BookCard, BookDetail, Theme, book_page, index_page, scanning_page, subscribe_page,
 };
@@ -526,66 +524,21 @@ async fn cover_thumb(
     let cover_path = book_cover_path(&state, &feed_id)?;
     // The full cover is the source of truth (must exist, under the data dir).
     let cover = resolve_under_data_dir(&cover_path, &state.data_dir, &feed_id)?;
-    let thumb = cover
-        .parent()
-        .map(cover_thumb_path)
-        .ok_or(AppError::NotFound)?;
 
-    match ensure_thumb(&state, &cover, &thumb).await {
-        Ok(()) => serve_image(&thumb, &headers).await,
-        // Generation failed — serve the full cover so a book with art never 404s.
-        Err(_) => serve_image(&cover, &headers).await,
-    }
-}
-
-/// Ensure the cover thumbnail at `thumb` exists, generating it from `cover` when
-/// missing. Freshness is handled by explicit invalidation, not mtime: the scanner
-/// deletes the cached thumbnail whenever it re-extracts a cover, so an existing
-/// thumb is always current and a changed cover regenerates here on the next view —
-/// no re-ingest, no persisted thumbnail at scan time, and no dependence on
-/// filesystem timestamp resolution. Single-flighted per path like [`ensure_cached`]
-/// so concurrent first-requests run ffmpeg once; the blocking work runs off the
-/// async runtime.
-async fn ensure_thumb(state: &AppState, cover: &FsPath, thumb: &FsPath) -> Result<(), AppError> {
-    // Fast path: already cached.
-    if thumb.exists() {
-        return Ok(());
-    }
-
-    let lock = {
-        let mut map = state.inflight.lock().map_err(AppError::internal)?;
-        map.entry(thumb.to_path_buf())
-            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
-            .clone()
-    };
-    let _guard = lock.lock().await;
-
-    let outcome = async {
-        // A concurrent request may have produced it while we waited on the lock.
-        if thumb.exists() {
-            return Ok(());
+    // Prefer the scanner-generated thumbnail sitting next to the cover; fall back to
+    // the full cover if it hasn't been generated yet (the reconcile backfills a
+    // missing one) or generation failed — so a book with art never 404s. Serving is
+    // read-only: generation lives in the scanner (single-threaded, atomic), which is
+    // what keeps a thumbnail consistent with its cover with no cross-thread race.
+    if let Some(dir) = cover.parent() {
+        let thumb = cover_thumb_path(dir);
+        if let Ok(canonical) =
+            resolve_under_data_dir(&thumb.to_string_lossy(), &state.data_dir, &feed_id)
+        {
+            return serve_image(&canonical, &headers).await;
         }
-        let cover = cover.to_path_buf();
-        let out_dir = cover
-            .parent()
-            .map(|p| p.to_path_buf())
-            .ok_or(AppError::NotFound)?;
-        tokio::task::spawn_blocking(move || -> std::io::Result<()> {
-            extract_cover_thumb(&cover, &out_dir).map_err(std::io::Error::other)?;
-            Ok(())
-        })
-        .await
-        .map_err(AppError::internal)?
-        .map_err(AppError::internal)?;
-        Ok(())
     }
-    .await;
-
-    // Drop the single-flight entry (see [`ensure_cached`] for why this is race-free).
-    if let Ok(mut map) = state.inflight.lock() {
-        map.remove(thumb);
-    }
-    outcome
+    serve_image(&cover, &headers).await
 }
 
 /// The book's stored (full) cover path, or `NotFound` when the book/cover is absent.

--- a/crates/http/tests/server.rs
+++ b/crates/http/tests/server.rs
@@ -1853,7 +1853,7 @@ async fn set_theme_redirects_back_even_when_ui_origin_differs() {
 }
 
 #[tokio::test]
-async fn cover_thumbnail_is_generated_on_demand_and_cached() {
+async fn serves_scanner_generated_thumbnail_with_fallback() {
     if !ffmpeg_available() {
         eprintln!("skipping: ffmpeg not available");
         return;
@@ -1869,11 +1869,8 @@ async fn cover_thumbnail_is_generated_on_demand_and_cached() {
     let feed_id = book.feed_id.clone();
     let cover = PathBuf::from(book.cover_path.clone().expect("cover extracted"));
     let thumb = cover.with_file_name("cover_thumb.jpg");
-    // Thumbnails are made on demand, not at ingest.
-    assert!(
-        !thumb.exists(),
-        "the scan must not pre-generate a thumbnail"
-    );
+    // The scan generates the thumbnail (the http layer only serves it).
+    assert!(thumb.exists(), "the scan should have generated a thumbnail");
 
     let state = AppState::new(
         index,
@@ -1894,7 +1891,7 @@ async fn cover_thumbnail_is_generated_on_demand_and_cached() {
         )
     };
 
-    // First request generates the thumbnail, caches it to disk, and serves JPEG.
+    // The thumb route serves the scanner-made thumbnail (JPEG, cacheable).
     let resp = get_thumb().await.unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
     assert_eq!(
@@ -1906,23 +1903,26 @@ async fn cover_thumbnail_is_generated_on_demand_and_cached() {
         "thumb is cacheable"
     );
     assert!(!body_bytes(resp).await.is_empty(), "thumbnail bytes served");
-    assert!(thumb.exists(), "first request caches the thumbnail to disk");
 
-    // A second request is served from the cached file (freshness is handled by the
-    // scanner deleting the thumb on a cover re-extraction, not by this handler).
+    // Fallback: with no thumbnail on disk (before a reconcile backfills it), the
+    // route serves the full cover instead of 404ing.
+    std::fs::remove_file(&thumb).unwrap();
     let resp = get_thumb().await.unwrap();
-    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "falls back to the full cover"
+    );
     assert!(!body_bytes(resp).await.is_empty());
 
     let _ = std::fs::remove_dir_all(&dir);
 }
 
 #[tokio::test]
-async fn cover_thumb_falls_back_to_the_full_cover_when_generation_fails() {
-    // A book whose "cover" is not a decodable image: thumbnail generation fails, so
-    // `/thumb` must serve the full cover file rather than 404. Exercises the handler
-    // fallback path without depending on ffmpeg (a missing ffmpeg fails generation
-    // just the same, still hitting the fallback).
+async fn cover_thumb_falls_back_to_the_full_cover_when_absent() {
+    // A book with a cover but no generated thumbnail (e.g. before a reconcile
+    // backfills it): `/thumb` must serve the full cover file rather than 404.
+    // ffmpeg-free — the handler only serves, it never generates.
     let dir = std::env::temp_dir().join("podspine-http-thumb-fallback");
     let _ = std::fs::remove_dir_all(&dir);
     let data = dir.join("data");

--- a/crates/http/tests/server.rs
+++ b/crates/http/tests/server.rs
@@ -1853,7 +1853,7 @@ async fn set_theme_redirects_back_even_when_ui_origin_differs() {
 }
 
 #[tokio::test]
-async fn cover_thumbnail_is_generated_on_demand_and_refreshes_when_stale() {
+async fn cover_thumbnail_is_generated_on_demand_and_cached() {
     if !ffmpeg_available() {
         eprintln!("skipping: ffmpeg not available");
         return;
@@ -1886,7 +1886,6 @@ async fn cover_thumbnail_is_generated_on_demand_and_refreshes_when_stale() {
         None,
     );
     let app = router(state);
-
     let get_thumb = || {
         app.clone().oneshot(
             Request::get(format!("/cover/{feed_id}/thumb"))
@@ -1909,24 +1908,11 @@ async fn cover_thumbnail_is_generated_on_demand_and_refreshes_when_stale() {
     assert!(!body_bytes(resp).await.is_empty(), "thumbnail bytes served");
     assert!(thumb.exists(), "first request caches the thumbnail to disk");
 
-    // A re-extracted cover (newer mtime) makes the cached thumb stale — the next
-    // request regenerates it so the thumbnail is at least as new as the cover again.
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-    let cover_bytes = std::fs::read(&cover).unwrap();
-    std::fs::write(&cover, &cover_bytes).unwrap(); // rewrite bumps the cover's mtime
-    let cover_mtime = std::fs::metadata(&cover).unwrap().modified().unwrap();
-    assert!(
-        std::fs::metadata(&thumb).unwrap().modified().unwrap() < cover_mtime,
-        "precondition: the cached thumb is now older than the cover"
-    );
-
+    // A second request is served from the cached file (freshness is handled by the
+    // scanner deleting the thumb on a cover re-extraction, not by this handler).
     let resp = get_thumb().await.unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
-    let _ = body_bytes(resp).await;
-    assert!(
-        std::fs::metadata(&thumb).unwrap().modified().unwrap() >= cover_mtime,
-        "a stale thumbnail is regenerated on the next request"
-    );
+    assert!(!body_bytes(resp).await.is_empty());
 
     let _ = std::fs::remove_dir_all(&dir);
 }

--- a/crates/http/tests/server.rs
+++ b/crates/http/tests/server.rs
@@ -1851,3 +1851,82 @@ async fn set_theme_redirects_back_even_when_ui_origin_differs() {
         "/book/dracula"
     );
 }
+
+#[tokio::test]
+async fn cover_thumbnail_is_generated_on_demand_and_refreshes_when_stale() {
+    if !ffmpeg_available() {
+        eprintln!("skipping: ffmpeg not available");
+        return;
+    }
+    let dir = std::env::temp_dir().join("podspine-http-thumb");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let data = dir.join("data");
+
+    let index = Index::open_in_memory().unwrap();
+    let input = synth_with_cover(&dir);
+    let book = scan_book(&input, &data, &index).unwrap();
+    let feed_id = book.feed_id.clone();
+    let cover = PathBuf::from(book.cover_path.clone().expect("cover extracted"));
+    let thumb = cover.with_file_name("cover_thumb.jpg");
+    // Thumbnails are made on demand, not at ingest.
+    assert!(
+        !thumb.exists(),
+        "the scan must not pre-generate a thumbnail"
+    );
+
+    let state = AppState::new(
+        index,
+        "http://test".to_string(),
+        &data,
+        &dir,
+        None,
+        false,
+        None,
+        None,
+    );
+    let app = router(state);
+
+    let get_thumb = || {
+        app.clone().oneshot(
+            Request::get(format!("/cover/{feed_id}/thumb"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+    };
+
+    // First request generates the thumbnail, caches it to disk, and serves JPEG.
+    let resp = get_thumb().await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        resp.headers().get(header::CONTENT_TYPE).unwrap(),
+        "image/jpeg"
+    );
+    assert!(
+        resp.headers().get(header::ETAG).is_some(),
+        "thumb is cacheable"
+    );
+    assert!(!body_bytes(resp).await.is_empty(), "thumbnail bytes served");
+    assert!(thumb.exists(), "first request caches the thumbnail to disk");
+
+    // A re-extracted cover (newer mtime) makes the cached thumb stale — the next
+    // request regenerates it so the thumbnail is at least as new as the cover again.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    let cover_bytes = std::fs::read(&cover).unwrap();
+    std::fs::write(&cover, &cover_bytes).unwrap(); // rewrite bumps the cover's mtime
+    let cover_mtime = std::fs::metadata(&cover).unwrap().modified().unwrap();
+    assert!(
+        std::fs::metadata(&thumb).unwrap().modified().unwrap() < cover_mtime,
+        "precondition: the cached thumb is now older than the cover"
+    );
+
+    let resp = get_thumb().await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let _ = body_bytes(resp).await;
+    assert!(
+        std::fs::metadata(&thumb).unwrap().modified().unwrap() >= cover_mtime,
+        "a stale thumbnail is regenerated on the next request"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/http/tests/server.rs
+++ b/crates/http/tests/server.rs
@@ -1930,3 +1930,51 @@ async fn cover_thumbnail_is_generated_on_demand_and_refreshes_when_stale() {
 
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+#[tokio::test]
+async fn cover_thumb_falls_back_to_the_full_cover_when_generation_fails() {
+    // A book whose "cover" is not a decodable image: thumbnail generation fails, so
+    // `/thumb` must serve the full cover file rather than 404. Exercises the handler
+    // fallback path without depending on ffmpeg (a missing ffmpeg fails generation
+    // just the same, still hitting the fallback).
+    let dir = std::env::temp_dir().join("podspine-http-thumb-fallback");
+    let _ = std::fs::remove_dir_all(&dir);
+    let data = dir.join("data");
+    let book_dir = data.join("books").join("badcover");
+    std::fs::create_dir_all(&book_dir).unwrap();
+    let cover = book_dir.join("cover.jpg");
+    std::fs::write(&cover, b"this is not an image").unwrap();
+
+    let index = Index::open_in_memory().unwrap();
+    let mut row = book_row("badcover", "Xk9mQ2vP7nR4tB1cY6wZ8a");
+    row.cover_path = Some(cover.to_string_lossy().into_owned());
+    index.upsert_book(&row).unwrap();
+    let feed_id = row.feed_id.clone();
+
+    let state = AppState::new(
+        index,
+        "http://test".to_string(),
+        &data,
+        &dir,
+        None,
+        false,
+        None,
+        None,
+    );
+    let resp = router(state)
+        .oneshot(
+            Request::get(format!("/cover/{feed_id}/thumb"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "falls back to the full cover"
+    );
+    assert_eq!(body_bytes(resp).await, b"this is not an image");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/scanner/src/lib.rs
+++ b/crates/scanner/src/lib.rs
@@ -40,7 +40,8 @@ use podspine_index::{BookRow, EpisodeRow, Index, IndexError};
 use podspine_prober::{ProbeError, needs_faststart, probe};
 use podspine_splitter::{
     ChapterCut, Encoding, SplitEpisode, SplitError, cover_thumb_path, extract_cover,
-    remux_faststart, split_book_encoded, split_chapter_encoded, transcode_whole,
+    extract_cover_thumb, remux_faststart, split_book_encoded, split_chapter_encoded,
+    transcode_whole,
 };
 
 /// Extensions we refuse to ingest (DRM). Matched case-insensitively.
@@ -253,6 +254,16 @@ pub fn scan_book_as(
             && transcode_consistent
             && files_present
         {
+            // The book is up to date, but a browse-UI thumbnail may be missing — an
+            // existing library from before thumbnails, or one deleted from the cache.
+            // Backfill it from the already-extracted cover without a re-split, so the
+            // grid gets thumbnails on the next reconcile rather than a re-index.
+            if let Some(cover) = existing.cover_path.as_deref()
+                && !cover_thumb_path(&book_out).exists()
+                && let Err(err) = extract_cover_thumb(Path::new(cover), &book_out)
+            {
+                tracing::warn!(error = %err, id = %id, "cover thumbnail backfill failed; browse UI will use the full cover");
+            }
             return Ok(existing);
         }
     }
@@ -422,10 +433,14 @@ pub fn scan_book_as(
         let ext = cover_ext(probed.cover_codec.as_deref());
         match extract_cover(input, &book_out, ext) {
             Ok(path) => {
-                // Invalidate any cached browse-UI thumbnail: it was derived from the
-                // previous cover. The `/cover/{id}/thumb` handler regenerates it on
-                // demand from this freshly-extracted cover on the next view.
-                let _ = std::fs::remove_file(cover_thumb_path(&book_out));
+                // Generate the browse-UI thumbnail from the freshly-extracted cover,
+                // in this same (single) scanner thread and atomically, so it always
+                // matches the cover — the http layer only ever *serves* it, which is
+                // what keeps thumbnail and cover consistent with no cross-thread race.
+                // Non-fatal: the serve layer falls back to the full cover if missing.
+                if let Err(err) = extract_cover_thumb(&path, &book_out) {
+                    tracing::warn!(error = %err, id = %id, "cover thumbnail failed; browse UI will use the full cover");
+                }
                 Some(path.to_string_lossy().into_owned())
             }
             Err(err) => {
@@ -4409,58 +4424,36 @@ mod tests {
     }
 
     #[test]
-    fn a_reingest_invalidates_the_cached_cover_thumbnail() {
+    fn scan_generates_a_thumbnail_and_reconcile_backfills_a_missing_one() {
         if !ffmpeg_available() {
             skip!("ffmpeg not available");
         }
-        let dir = scratch("thumb-invalidate");
+        let dir = scratch("thumb-gen");
         let data = dir.join("data");
         let input = synth_with_cover(&dir);
         let index = Index::open_in_memory().unwrap();
-
-        let book = scan_book_as(
-            &input,
-            "coverbook",
-            &data,
-            &index,
-            ScanOptions::default(),
-            &BookOverrides::default(),
-        )
-        .unwrap();
-        let cover = PathBuf::from(book.cover_path.expect("cover extracted"));
-        let book_out = cover.parent().unwrap();
-
-        // Stand in for a thumbnail the /thumb handler cached on demand.
-        let thumb = book_out.join("cover_thumb.jpg");
-        std::fs::write(&thumb, b"stale thumb").unwrap();
-        assert!(thumb.exists());
-
-        // Change the source mtime so the next scan re-ingests (rather than taking
-        // the idempotency early-return) and re-extracts the cover.
-        std::fs::File::options()
-            .write(true)
-            .open(&input)
-            .unwrap()
-            .set_modified(
-                std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_600_000_000),
+        let scan = || {
+            scan_book_as(
+                &input,
+                "coverbook",
+                &data,
+                &index,
+                ScanOptions::default(),
+                &BookOverrides::default(),
             )
-            .unwrap();
+        };
 
-        // The re-ingest re-extracts the cover and must invalidate the thumb, so the
-        // handler regenerates it from the fresh cover on the next view.
-        scan_book_as(
-            &input,
-            "coverbook",
-            &data,
-            &index,
-            ScanOptions::default(),
-            &BookOverrides::default(),
-        )
-        .unwrap();
-        assert!(
-            !thumb.exists(),
-            "re-ingest must delete the stale cached thumbnail"
-        );
+        // A scan generates the thumbnail alongside the cover.
+        let book = scan().unwrap();
+        let cover = PathBuf::from(book.cover_path.expect("cover extracted"));
+        let thumb = cover.parent().unwrap().join("cover_thumb.jpg");
+        assert!(thumb.exists(), "scan generates the thumbnail");
+
+        // Delete it and re-scan (idempotent, unchanged): the reconcile backfills a
+        // missing thumbnail without re-splitting the book.
+        std::fs::remove_file(&thumb).unwrap();
+        scan().unwrap();
+        assert!(thumb.exists(), "reconcile backfills a missing thumbnail");
     }
 
     #[test]

--- a/crates/scanner/src/lib.rs
+++ b/crates/scanner/src/lib.rs
@@ -39,8 +39,8 @@ use podspine_feed::{episode_guid, pubdate_epoch};
 use podspine_index::{BookRow, EpisodeRow, Index, IndexError};
 use podspine_prober::{ProbeError, needs_faststart, probe};
 use podspine_splitter::{
-    ChapterCut, Encoding, SplitEpisode, SplitError, extract_cover, remux_faststart,
-    split_book_encoded, split_chapter_encoded, transcode_whole,
+    ChapterCut, Encoding, SplitEpisode, SplitError, cover_thumb_path, extract_cover,
+    remux_faststart, split_book_encoded, split_chapter_encoded, transcode_whole,
 };
 
 /// Extensions we refuse to ingest (DRM). Matched case-insensitively.
@@ -421,7 +421,13 @@ pub fn scan_book_as(
     let cover_path = if probed.has_cover {
         let ext = cover_ext(probed.cover_codec.as_deref());
         match extract_cover(input, &book_out, ext) {
-            Ok(path) => Some(path.to_string_lossy().into_owned()),
+            Ok(path) => {
+                // Invalidate any cached browse-UI thumbnail: it was derived from the
+                // previous cover. The `/cover/{id}/thumb` handler regenerates it on
+                // demand from this freshly-extracted cover on the next view.
+                let _ = std::fs::remove_file(cover_thumb_path(&book_out));
+                Some(path.to_string_lossy().into_owned())
+            }
             Err(err) => {
                 tracing::warn!(error = %err, id = %id, "cover extraction failed; serving no cover");
                 None
@@ -4400,6 +4406,61 @@ mod tests {
             attrs: Default::default(),
         };
         assert!(watch_event_is_relevant(&hint, lib, data, None));
+    }
+
+    #[test]
+    fn a_reingest_invalidates_the_cached_cover_thumbnail() {
+        if !ffmpeg_available() {
+            skip!("ffmpeg not available");
+        }
+        let dir = scratch("thumb-invalidate");
+        let data = dir.join("data");
+        let input = synth_with_cover(&dir);
+        let index = Index::open_in_memory().unwrap();
+
+        let book = scan_book_as(
+            &input,
+            "coverbook",
+            &data,
+            &index,
+            ScanOptions::default(),
+            &BookOverrides::default(),
+        )
+        .unwrap();
+        let cover = PathBuf::from(book.cover_path.expect("cover extracted"));
+        let book_out = cover.parent().unwrap();
+
+        // Stand in for a thumbnail the /thumb handler cached on demand.
+        let thumb = book_out.join("cover_thumb.jpg");
+        std::fs::write(&thumb, b"stale thumb").unwrap();
+        assert!(thumb.exists());
+
+        // Change the source mtime so the next scan re-ingests (rather than taking
+        // the idempotency early-return) and re-extracts the cover.
+        std::fs::File::options()
+            .write(true)
+            .open(&input)
+            .unwrap()
+            .set_modified(
+                std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_600_000_000),
+            )
+            .unwrap();
+
+        // The re-ingest re-extracts the cover and must invalidate the thumb, so the
+        // handler regenerates it from the fresh cover on the next view.
+        scan_book_as(
+            &input,
+            "coverbook",
+            &data,
+            &index,
+            ScanOptions::default(),
+            &BookOverrides::default(),
+        )
+        .unwrap();
+        assert!(
+            !thumb.exists(),
+            "re-ingest must delete the stale cached thumbnail"
+        );
     }
 
     #[test]

--- a/crates/scanner/src/lib.rs
+++ b/crates/scanner/src/lib.rs
@@ -433,11 +433,16 @@ pub fn scan_book_as(
         let ext = cover_ext(probed.cover_codec.as_deref());
         match extract_cover(input, &book_out, ext) {
             Ok(path) => {
-                // Generate the browse-UI thumbnail from the freshly-extracted cover,
+                // Regenerate the browse-UI thumbnail from the freshly-extracted cover,
                 // in this same (single) scanner thread and atomically, so it always
                 // matches the cover — the http layer only ever *serves* it, which is
                 // what keeps thumbnail and cover consistent with no cross-thread race.
-                // Non-fatal: the serve layer falls back to the full cover if missing.
+                //
+                // Delete the previous thumbnail FIRST: if regeneration then fails, the
+                // book is left with NO thumbnail (the serve layer falls back to the
+                // current full cover, and the next reconcile backfills it) rather than
+                // a stale one derived from the old cover.
+                let _ = std::fs::remove_file(cover_thumb_path(&book_out));
                 if let Err(err) = extract_cover_thumb(&path, &book_out) {
                     tracing::warn!(error = %err, id = %id, "cover thumbnail failed; browse UI will use the full cover");
                 }
@@ -4454,6 +4459,23 @@ mod tests {
         std::fs::remove_file(&thumb).unwrap();
         scan().unwrap();
         assert!(thumb.exists(), "reconcile backfills a missing thumbnail");
+
+        // A re-ingest (mtime changed) deletes the old thumbnail and regenerates it,
+        // so nothing stale from the previous cover survives.
+        let before = std::fs::metadata(&thumb).unwrap().modified().unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        // A clearly-different source mtime forces a re-ingest (not the early-return).
+        std::fs::File::options()
+            .write(true)
+            .open(&input)
+            .unwrap()
+            .set_modified(
+                std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000),
+            )
+            .unwrap();
+        scan().unwrap();
+        let after = std::fs::metadata(&thumb).unwrap().modified().unwrap();
+        assert!(after > before, "a re-ingest regenerates the thumbnail");
     }
 
     #[test]

--- a/crates/scanner/src/lib.rs
+++ b/crates/scanner/src/lib.rs
@@ -449,8 +449,26 @@ pub fn scan_book_as(
                 Some(path.to_string_lossy().into_owned())
             }
             Err(err) => {
-                tracing::warn!(error = %err, id = %id, "cover extraction failed; serving no cover");
-                None
+                // `extract_cover` publishes atomically (writes a `.part` sibling,
+                // renames only on success), so a failed extraction leaves the
+                // previous `cover.jpg` — and its thumbnail — intact on disk. Keep
+                // the stored path rather than dropping it to None and orphaning
+                // that still-valid art: None would 404 both cover routes and block
+                // the reconcile thumbnail backfill, which is gated on a populated
+                // cover_path. `upsert_book` below hasn't run yet, so this still
+                // reads the prior row.
+                let kept = index
+                    .get_book(&id)
+                    .ok()
+                    .flatten()
+                    .and_then(|b| b.cover_path)
+                    .filter(|p| Path::new(p).exists());
+                if kept.is_some() {
+                    tracing::warn!(error = %err, id = %id, "cover extraction failed; keeping the previously extracted cover");
+                } else {
+                    tracing::warn!(error = %err, id = %id, "cover extraction failed; serving no cover");
+                }
+                kept
             }
         }
     } else {
@@ -4476,6 +4494,61 @@ mod tests {
         scan().unwrap();
         let after = std::fs::metadata(&thumb).unwrap().modified().unwrap();
         assert!(after > before, "a re-ingest regenerates the thumbnail");
+    }
+
+    #[test]
+    fn a_failed_cover_re_extraction_keeps_the_previous_cover() {
+        if !ffmpeg_available() {
+            skip!("ffmpeg not available");
+        }
+        let dir = scratch("cover-keep");
+        let data = dir.join("data");
+        let input = synth_with_cover(&dir);
+        let index = Index::open_in_memory().unwrap();
+        let scan = || {
+            scan_book_as(
+                &input,
+                "coverbook",
+                &data,
+                &index,
+                ScanOptions::default(),
+                &BookOverrides::default(),
+            )
+        };
+
+        // A first scan extracts the cover.
+        let book = scan().unwrap();
+        let cover = PathBuf::from(book.cover_path.expect("cover extracted"));
+        assert!(cover.exists(), "cover on disk");
+        let book_out = cover.parent().unwrap().to_path_buf();
+
+        // Block the atomic publish of any *replacement* cover: a directory sitting at
+        // the `.part` target makes ffmpeg's write fail, so `extract_cover` errors while
+        // the previously-published `cover.jpg` stays intact on disk — the exact case
+        // the fallback below must survive.
+        std::fs::create_dir_all(book_out.join("cover.part.jpg")).unwrap();
+
+        // Force a re-ingest (a distinct source mtime, not the idempotent early return).
+        std::fs::File::options()
+            .write(true)
+            .open(&input)
+            .unwrap()
+            .set_modified(
+                std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_700_000_000),
+            )
+            .unwrap();
+
+        // The re-ingest keeps the still-present cover instead of orphaning it to None —
+        // otherwise both cover routes 404 and the thumbnail backfill can't recover it.
+        let reingested = scan().unwrap();
+        assert_eq!(
+            reingested.cover_path.as_deref(),
+            cover.to_str(),
+            "a failed cover re-extraction keeps the previous cover, not None"
+        );
+        assert!(cover.exists(), "the previous cover survives on disk");
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/crates/splitter/src/lib.rs
+++ b/crates/splitter/src/lib.rs
@@ -1260,6 +1260,43 @@ mod tests {
     }
 
     #[test]
+    fn cover_extraction_reports_publish_when_a_directory_blocks_the_target() {
+        if !have_ffmpeg() {
+            skip!("ffmpeg not available");
+        }
+        // ffmpeg produces the `.part` fine, but a directory sitting at the final path
+        // blocks the atomic rename → CoverError::Publish (the image is never
+        // half-published; the blocker is left as-is).
+        let dir = std::env::temp_dir().join("podspine-cover-publish");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let cover = dir.join("cover.png");
+        let ok = Command::new("ffmpeg")
+            .args([
+                "-y",
+                "-loglevel",
+                "error",
+                "-f",
+                "lavfi",
+                "-i",
+                "color=c=red:s=64x64:d=0.1",
+                "-frames:v",
+                "1",
+            ])
+            .arg(&cover)
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        assert!(ok, "ffmpeg cover synth failed");
+
+        std::fs::create_dir_all(cover_thumb_path(&dir)).unwrap(); // a dir at the target
+        let err = extract_cover_thumb(&cover, &dir).expect_err("blocked rename must fail");
+        assert!(matches!(err, CoverError::Publish { .. }), "{err:?}");
+        assert!(cover_thumb_path(&dir).is_dir(), "the blocker is left as-is");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
     fn semaphore_bounds_and_releases_permits() {
         let sem = Semaphore {
             permits: Mutex::new(1),

--- a/crates/splitter/src/lib.rs
+++ b/crates/splitter/src/lib.rs
@@ -221,6 +221,15 @@ pub enum CoverError {
         /// Where the cover was expected.
         path: PathBuf,
     },
+    /// The finished image could not be moved into place (the atomic publish).
+    #[error("could not publish cover to {path:?}: {source}")]
+    Publish {
+        /// The final path the image was being moved to.
+        path: PathBuf,
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
     /// Could not create the output directory.
     #[error("could not create output directory {path:?}: {source}")]
     CreateDir {
@@ -350,32 +359,12 @@ fn run_ffmpeg_within(args: &[OsString], timeout: Duration) -> Result<(), RunErro
 /// **stream copy** (no re-encode), returning the written path. `ext` should match
 /// the cover codec (`"jpg"` for mjpeg, `"png"` for png). The source is only read.
 ///
-/// Maps only the first video (attached-picture) stream, so no audio is written.
+/// Maps only the first video (attached-picture) stream, so no audio is written. The
+/// write is atomic ([`extract_image`]), so a `/cover` or `/thumb` reader never sees
+/// a half-written cover while a rescan re-extracts it.
 pub fn extract_cover(input: &Path, out_dir: &Path, ext: &str) -> Result<PathBuf, CoverError> {
-    fs::create_dir_all(out_dir).map_err(|source| CoverError::CreateDir {
-        path: out_dir.to_path_buf(),
-        source,
-    })?;
-
     let out_path = out_dir.join(format!("cover.{ext}"));
-    let args = build_cover_args(input, &out_path);
-
-    match run_ffmpeg(&args) {
-        Ok(()) => {}
-        Err(RunError::Spawn(e)) => return Err(CoverError::Spawn(e)),
-        Err(RunError::Failed { code, stderr }) => {
-            return Err(CoverError::Ffmpeg { code, stderr });
-        }
-        Err(RunError::TimedOut) => return Err(CoverError::TimedOut),
-    }
-
-    let ok = fs::metadata(&out_path)
-        .map(|m| m.len() > 0)
-        .unwrap_or(false);
-    if !ok {
-        return Err(CoverError::OutputMissing { path: out_path });
-    }
-    Ok(out_path)
+    extract_image(out_path, |part| build_cover_args(input, part))
 }
 
 /// Long-edge cap (px) for the cover thumbnail. 400 covers every browse-UI use —
@@ -384,35 +373,60 @@ pub fn extract_cover(input: &Path, out_dir: &Path, ext: &str) -> Result<PathBuf,
 /// podcatcher artwork.
 const COVER_THUMB_PX: u32 = 400;
 
-/// Downscale an already-extracted cover into a small `cover_thumb.jpg` for the
-/// browse UI (the RSS feed keeps the full-res `/cover`). Re-encodes to JPEG, bounded
-/// to [`COVER_THUMB_PX`] on the long edge and never upscaled; the source cover file
-/// is only read. A failure is non-fatal to ingest — the serve layer falls back to
-/// the full cover.
+/// The path of a book's browse-UI cover thumbnail under `out_dir`. Centralized so
+/// the generator, the serve layer, and the scanner's invalidation all agree on it.
+pub fn cover_thumb_path(out_dir: &Path) -> PathBuf {
+    out_dir.join("cover_thumb.jpg")
+}
+
+/// Downscale an already-extracted cover into a small [`cover_thumb_path`] JPEG for
+/// the browse UI (the RSS feed keeps the full-res `/cover`). Bounded to
+/// [`COVER_THUMB_PX`] on the long edge and never upscaled; the source cover file is
+/// only read, and the write is atomic ([`extract_image`]).
 pub fn extract_cover_thumb(cover: &Path, out_dir: &Path) -> Result<PathBuf, CoverError> {
-    fs::create_dir_all(out_dir).map_err(|source| CoverError::CreateDir {
-        path: out_dir.to_path_buf(),
-        source,
-    })?;
+    let out_path = cover_thumb_path(out_dir);
+    extract_image(out_path, |part| build_cover_thumb_args(cover, part))
+}
 
-    let out_path = out_dir.join("cover_thumb.jpg");
-    let args = build_cover_thumb_args(cover, &out_path);
+/// Run ffmpeg to produce an image at `out_path` **atomically**: create the parent
+/// dir, write to a `.part` sibling, validate it's non-empty, then rename into place.
+/// A concurrent reader sees the old file or the new one, never a half-written one —
+/// which is what lets a rescan re-extract a cover while `/cover` and `/thumb` serve.
+fn extract_image(
+    out_path: PathBuf,
+    args_for: impl FnOnce(&Path) -> Vec<OsString>,
+) -> Result<PathBuf, CoverError> {
+    if let Some(dir) = out_path.parent() {
+        fs::create_dir_all(dir).map_err(|source| CoverError::CreateDir {
+            path: dir.to_path_buf(),
+            source,
+        })?;
+    }
 
+    let part = part_path(&out_path);
+    let args = args_for(&part);
     match run_ffmpeg(&args) {
         Ok(()) => {}
         Err(RunError::Spawn(e)) => return Err(CoverError::Spawn(e)),
         Err(RunError::Failed { code, stderr }) => {
+            let _ = fs::remove_file(&part);
             return Err(CoverError::Ffmpeg { code, stderr });
         }
-        Err(RunError::TimedOut) => return Err(CoverError::TimedOut),
+        Err(RunError::TimedOut) => {
+            let _ = fs::remove_file(&part);
+            return Err(CoverError::TimedOut);
+        }
     }
 
-    let ok = fs::metadata(&out_path)
-        .map(|m| m.len() > 0)
-        .unwrap_or(false);
+    let ok = fs::metadata(&part).map(|m| m.len() > 0).unwrap_or(false);
     if !ok {
+        let _ = fs::remove_file(&part);
         return Err(CoverError::OutputMissing { path: out_path });
     }
+    fs::rename(&part, &out_path).map_err(|source| CoverError::Publish {
+        path: out_path.clone(),
+        source,
+    })?;
     Ok(out_path)
 }
 

--- a/crates/splitter/src/lib.rs
+++ b/crates/splitter/src/lib.rs
@@ -378,6 +378,44 @@ pub fn extract_cover(input: &Path, out_dir: &Path, ext: &str) -> Result<PathBuf,
     Ok(out_path)
 }
 
+/// Long-edge cap (px) for the cover thumbnail. 400 covers every browse-UI use —
+/// the grid (~150px), the detail cover (~200px) and the subscribe subcover (~96px)
+/// — at 2× density, while the full-res `/cover` is what the RSS feed advertises for
+/// podcatcher artwork.
+const COVER_THUMB_PX: u32 = 400;
+
+/// Downscale an already-extracted cover into a small `cover_thumb.jpg` for the
+/// browse UI (the RSS feed keeps the full-res `/cover`). Re-encodes to JPEG, bounded
+/// to [`COVER_THUMB_PX`] on the long edge and never upscaled; the source cover file
+/// is only read. A failure is non-fatal to ingest — the serve layer falls back to
+/// the full cover.
+pub fn extract_cover_thumb(cover: &Path, out_dir: &Path) -> Result<PathBuf, CoverError> {
+    fs::create_dir_all(out_dir).map_err(|source| CoverError::CreateDir {
+        path: out_dir.to_path_buf(),
+        source,
+    })?;
+
+    let out_path = out_dir.join("cover_thumb.jpg");
+    let args = build_cover_thumb_args(cover, &out_path);
+
+    match run_ffmpeg(&args) {
+        Ok(()) => {}
+        Err(RunError::Spawn(e)) => return Err(CoverError::Spawn(e)),
+        Err(RunError::Failed { code, stderr }) => {
+            return Err(CoverError::Ffmpeg { code, stderr });
+        }
+        Err(RunError::TimedOut) => return Err(CoverError::TimedOut),
+    }
+
+    let ok = fs::metadata(&out_path)
+        .map(|m| m.len() > 0)
+        .unwrap_or(false);
+    if !ok {
+        return Err(CoverError::OutputMissing { path: out_path });
+    }
+    Ok(out_path)
+}
+
 /// Build the ffmpeg argv for a stream-copy cover extraction (argv vector, never a
 /// shell string). Factored out for a hermetic unit test.
 fn build_cover_args(input: &Path, output: &Path) -> Vec<OsString> {
@@ -395,6 +433,34 @@ fn build_cover_args(input: &Path, output: &Path) -> Vec<OsString> {
         "1".into(),
         "-c".into(),
         "copy".into(),
+        output.as_os_str().to_os_string(),
+    ]
+}
+
+/// Build the ffmpeg argv for the cover thumbnail: read the cover image, one frame,
+/// scale so the long edge is at most [`COVER_THUMB_PX`] (aspect preserved, never
+/// upscaled — `min(px, iw/ih)`), re-encode as JPEG. Argv vector, never a shell
+/// string. Factored out for a hermetic unit test.
+fn build_cover_thumb_args(input: &Path, output: &Path) -> Vec<OsString> {
+    vec![
+        "-nostdin".into(),
+        "-y".into(),
+        "-loglevel".into(),
+        "error".into(),
+        "-i".into(),
+        input.as_os_str().to_os_string(),
+        "-frames:v".into(),
+        "1".into(),
+        "-vf".into(),
+        format!(
+            "scale=w='min({px},iw)':h='min({px},ih)':force_original_aspect_ratio=decrease",
+            px = COVER_THUMB_PX
+        )
+        .into(),
+        "-c:v".into(),
+        "mjpeg".into(),
+        "-q:v".into(),
+        "4".into(),
         output.as_os_str().to_os_string(),
     ]
 }
@@ -1101,6 +1167,82 @@ mod tests {
         assert!(pair("-frames:v", "1"), "one frame only");
         assert!(!args.iter().any(|a| a == "-to"));
         assert_eq!(args.last().unwrap(), "out/cover.jpg", "output path is last");
+    }
+
+    #[test]
+    fn cover_thumb_args_scale_and_reencode_to_jpeg() {
+        let args: Vec<String> =
+            build_cover_thumb_args(Path::new("cover.png"), Path::new("out/cover_thumb.jpg"))
+                .iter()
+                .map(|a| a.to_string_lossy().into_owned())
+                .collect();
+        let pair = |a: &str, b: &str| args.windows(2).any(|w| w[0] == a && w[1] == b);
+        assert!(pair("-c:v", "mjpeg"), "re-encode to JPEG");
+        assert!(pair("-frames:v", "1"), "one frame only");
+        // The scale filter caps the long edge and never upscales.
+        assert!(
+            args.iter()
+                .any(|a| a.contains("scale=") && a.contains("min(400,iw)")),
+            "must cap the long edge at 400px: {args:?}"
+        );
+        assert_eq!(args.last().unwrap(), "out/cover_thumb.jpg");
+    }
+
+    #[test]
+    fn cover_thumb_downscales_a_large_cover() {
+        if !have_ffmpeg() {
+            skip!("ffmpeg not available");
+        }
+        let dir = std::env::temp_dir().join("podspine-cover-thumb");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        // A large cover to downscale.
+        let cover = dir.join("cover.png");
+        let ok = Command::new("ffmpeg")
+            .args([
+                "-y",
+                "-loglevel",
+                "error",
+                "-f",
+                "lavfi",
+                "-i",
+                "color=c=blue:s=800x800:d=0.1",
+                "-frames:v",
+                "1",
+            ])
+            .arg(&cover)
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        assert!(ok, "ffmpeg cover synth failed");
+
+        let thumb = extract_cover_thumb(&cover, &dir).expect("thumbnail");
+        assert_eq!(thumb, dir.join("cover_thumb.jpg"));
+        assert!(std::fs::metadata(&thumb).unwrap().len() > 0);
+
+        // Downscaled: the thumbnail's width is capped at 400 (the source is 800).
+        let width = Command::new("ffprobe")
+            .args([
+                "-v",
+                "error",
+                "-select_streams",
+                "v:0",
+                "-show_entries",
+                "stream=width",
+                "-of",
+                "csv=p=0",
+            ])
+            .arg(&thumb)
+            .output()
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .and_then(|s| s.trim().parse::<u32>().ok())
+            .expect("ffprobe the thumbnail width");
+        assert!(
+            width <= 400 && width > 0,
+            "thumbnail width {width} must be <= 400"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/crates/splitter/src/lib.rs
+++ b/crates/splitter/src/lib.rs
@@ -1869,6 +1869,29 @@ mod tests {
     }
 
     #[test]
+    fn extract_cover_thumb_maps_a_bad_input_to_a_cover_error() {
+        if !have_ffmpeg() {
+            skip!("ffmpeg not available");
+        }
+        // A non-image input -> ffmpeg can't decode it -> CoverError (Ffmpeg or the
+        // empty-output guard), never a panic.
+        let dir = std::env::temp_dir().join("podspine-thumb-fail");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let bad = dir.join("notanimage.png");
+        std::fs::write(&bad, b"definitely not an image").unwrap();
+        let err = extract_cover_thumb(&bad, &dir.join("out")).expect_err("bad input must fail");
+        assert!(
+            matches!(
+                err,
+                CoverError::Ffmpeg { .. } | CoverError::OutputMissing { .. }
+            ),
+            "{err:?}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
     fn extract_cover_reports_create_dir_when_out_dir_is_a_file() {
         // out_dir is an existing regular file -> create_dir_all fails BEFORE any
         // ffmpeg spawn -> CoverError::CreateDir. ffmpeg-free, so it runs everywhere.

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -277,7 +277,7 @@ fn cover(id: &str, title: &str, has_cover: bool, class: &str) -> Markup {
         .to_string();
     html! {
         @if has_cover {
-            img class=(class) src=(format!("/cover/{id}")) alt=(format!("Cover of {title}")) loading="lazy";
+            img class=(class) src=(format!("/cover/{id}/thumb")) alt=(format!("Cover of {title}")) loading="lazy";
         } @else {
             div class=(format!("{class} placeholder")) role="img" aria-label=(format!("No cover art for {title}")) {
                 span aria-hidden="true" { (initial) }
@@ -610,8 +610,8 @@ mod tests {
         assert!(html.contains("href=\"/book/dracula\""));
         assert!(html.contains("href=\"/book/solaris\""));
         // Cover present -> img with alt; absent -> labelled placeholder.
-        // Covers are served by capability id, not the slug.
-        assert!(html.contains("src=\"/cover/cap-dracula\""));
+        // The grid uses the small thumbnail, keyed by capability id (not the slug).
+        assert!(html.contains("src=\"/cover/cap-dracula/thumb\""));
         assert!(html.contains("alt=\"Cover of Dracula\""));
         assert!(html.contains("aria-label=\"No cover art for Solaris\""));
     }


### PR DESCRIPTION
## What (backlog: cover thumbnails)

The browse grid loaded **full-resolution** cover art (often 1500px+, MBs each) to fill ~150px cells, so a page pulled megabytes of images. This serves a small thumbnail instead.

- **Generated in the scanner:** right after extracting the cover, in the same single scanner thread and atomically (`.part` → rename), the scanner writes a `cover_thumb.jpg` (re-encoded JPEG, long edge ≤400px, never upscaled). Because one thread writes cover-then-thumbnail, a thumbnail is always consistent with its cover — no cross-thread race.
- **Existing libraries:** reconcile **backfills** a missing thumbnail from the already-extracted cover (no re-split) on the next scan/restart, so no full re-index is needed. Renders the full cover until then.
- **Served read-only:** `GET /cover/{id}/thumb` serves the thumbnail if present, else **falls back to the full cover** (never 404s a book with art). Same content-addressed caching as `/cover` (blake3 `ETag` + `Cache-Control` + `304`) via a shared `serve_image` helper.
- **UI:** grid/detail/subscribe covers use the thumb.
- **Feed unchanged:** the RSS `itunes:image` and `/cover` keep the **full-res** artwork (podcatchers want 1400–3000px).
- **Atomic cover writes:** `extract_cover` is now atomic too (fixes a pre-existing `/cover` partial-read while a rescan re-extracts a cover).

## Design note

An earlier iteration generated thumbnails on demand in the http handler; Greptile (correctly) found races between handler-side generation and the scanner's concurrent cover replacement. Moving generation into the single-threaded scanner removes that race class entirely, and the reconcile backfill preserves the "no re-index for existing books" benefit.

## Verification

`splitter`: downscale (800px → ffprobe ≤400), atomic-rename (`Publish`) failure, hermetic args. `scanner`: scan generates + reconcile backfills a missing thumbnail. `http`: serves the thumb, falls back to the full cover when absent. All crate suites + workspace clippy + fmt clean.

## Follow-up (backlogged)

A per-book **"Refresh / re-index"** button in the web UI — noted in `scratch/backlog.md`.