### PR TITLE
test: backfill coverage for merged PRs 173 and 174

### DIFF
--- a/crates/http/tests/server.rs
+++ b/crates/http/tests/server.rs
@@ -1964,3 +1964,80 @@ async fn cover_thumb_falls_back_to_the_full_cover_when_absent() {
 
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+#[tokio::test]
+async fn cover_conditional_get_honours_wildcard_and_weak_etag() {
+    if !ffmpeg_available() {
+        eprintln!("skipping: ffmpeg not available");
+        return;
+    }
+    let dir = std::env::temp_dir().join("podspine-http-cover-cond");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let data = dir.join("data");
+
+    let index = Index::open_in_memory().unwrap();
+    let input = synth_with_cover(&dir);
+    let book = scan_book(&input, &data, &index).unwrap();
+    let feed_id = book.feed_id.clone();
+
+    let state = AppState::new(
+        index,
+        "http://test".to_string(),
+        &data,
+        &dir,
+        None,
+        false,
+        None,
+        None,
+    );
+    let app = router(state);
+
+    // Grab the strong ETag from a normal request.
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::get(format!("/cover/{feed_id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let etag = resp
+        .headers()
+        .get(header::ETAG)
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+    let _ = body_bytes(resp).await;
+
+    // A wildcard `If-None-Match: *` revalidates to 304.
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::get(format!("/cover/{feed_id}"))
+                .header(header::IF_NONE_MATCH, "*")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_MODIFIED, "wildcard matches");
+
+    // A weak validator (`W/"…"`) matches the same resource and returns 304.
+    let weak = format!("W/{etag}");
+    let resp = app
+        .oneshot(
+            Request::get(format!("/cover/{feed_id}"))
+                .header(header::IF_NONE_MATCH, weak)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_MODIFIED, "weak etag matches");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/scanner/src/lib.rs
+++ b/crates/scanner/src/lib.rs
@@ -4552,6 +4552,30 @@ mod tests {
     }
 
     #[test]
+    fn watch_filter_ignores_output_under_the_canonical_data_dir() {
+        // The configured data dir can be spelled differently from where it resolves
+        // (a symlinked mount), so the filter also checks the canonical path. A write
+        // under the CANONICAL data dir is still our own split output and must be
+        // ignored even when it doesn't match the raw spelling.
+        let lib = Path::new("/lib");
+        let raw = Path::new("/lib/.podspine"); // as configured
+        let canon = Path::new("/mnt/real/podspine"); // where it resolves to
+        assert!(!watch_path_is_relevant(
+            Path::new("/mnt/real/podspine/BookX/001.m4a"),
+            lib,
+            raw,
+            Some(canon),
+        ));
+        // A real library file (under neither data dir) stays relevant.
+        assert!(watch_path_is_relevant(
+            Path::new("/lib/Author/Title/book.m4b"),
+            lib,
+            raw,
+            Some(canon),
+        ));
+    }
+
+    #[test]
     fn chapterless_file_becomes_a_single_episode() {
         if !ffmpeg_available() {
             skip!("ffmpeg not available");


### PR DESCRIPTION
## What

You flagged that recent PRs left a few lines uncovered on codecov patch coverage. This backfills the **genuinely-testable** branches those PRs added but didn't exercise. (Codecov's API was 503 while I did this, so I audited by reading each merged PR's diff and confirming no existing test hit the branch — the coverage bump will show on this PR's own codecov run.)

- **PR 173 (watcher event filter):** `watch_path_is_relevant` also checks the **canonical** data dir (for a symlinked/differently-spelled mount), but no test passed a `Some(data_canon)`. Added a unit test that a write under the resolved data dir is ignored while a real library file stays relevant.
- **PR 174 (cover cache):** the conditional-GET only tested the exact strong ETag. Added a test that `If-None-Match: *` (wildcard) and `W/"…"` (weak validator) both return `304`.

## Audited but deliberately left

- **PR 178 (parallel split):** the remaining uncovered line is the *catastrophic mid-sequence I/O* cleanup in phase-2 publish (a rename failing for a non-directory reason after the pre-check) — not deterministically reachable in a test, and defensive. Left as-is.
- **PRs 172 / 176 (dark theme / theme picker):** already covered (`referer_path` has unit tests; theme cookie/set paths are exercised).

## Verification

`cargo test -p podspine-scanner -p podspine-http` green; clippy + fmt clean. Test-only — labeled `no-changelog`.