### PR TITLE
chore(changeset): reclassify the cover-thumbnail change as perf

### DIFF
--- a/.changeset/cover-thumbnails.md
+++ b/.changeset/cover-thumbnails.md
@@ -1,5 +1,5 @@
 ---
-default: minor
+default: perf
 ---
 
 Serve a small cover thumbnail to the browse-UI grid instead of full-resolution artwork: the scanner generates a `cover_thumb.jpg` (long edge ≤400px) alongside each cover, and `/cover/{id}/thumb` serves it (falling back to the full cover when it's missing). Existing libraries are backfilled by the reconcile on the next scan — no re-ingest needed. The RSS feed and `/cover` keep the full-size image for podcatchers


### PR DESCRIPTION
One-line change: the cover-thumbnail fragment (from [PR 180](https://github.com/schubydoo/podspine/pull/180)) goes from `default: minor` to `default: perf`.

**Why:** the thumbnail work is a serving-size optimization, not a new capability. As `minor` it forces the pending release to **1.8.0**; as `perf` it bumps patch and lands under the changelog's **Performance** section — same classification as the parallel-chapter-split fragment from [PR 178](https://github.com/schubydoo/podspine/pull/178). With the four patch fragments already on `main`, the next release becomes **1.7.1**.

knope-prepare will refresh the release PR accordingly after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)