### PR TITLE
docs: reconcile documentation with the code after the 1.7.x changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,10 +17,12 @@ Fixes #(issue number)
 ## Checklist
 
 - [ ] `cargo fmt --all --check` passes
-- [ ] `cargo clippy --all-targets -- -D warnings` passes
+- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes
 - [ ] `cargo test --workspace` passes (with `ffmpeg`/`ffprobe` on PATH)
 - [ ] Added or updated tests for the change
-- [ ] Updated docs (`README.md` / `docs/`) and `CHANGELOG.md` if user-visible
+- [ ] Added a `.changeset/<slug>.md` fragment (or the `no-changelog` label applies)
+      and updated docs (`README.md` / `docs/`) if user-visible — `CHANGELOG.md`
+      itself is generated, never hand-edited
 - [ ] Commits follow Conventional Commits; PR targets `main`
 - [ ] Kept Podspine's invariants (argv-vector ffmpeg calls, opaque ids under the
       data dir, sequential feed `pubDate`s, DRM-free-only)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,8 +32,8 @@ cargo run -- --library ./sample-books   # → http://localhost:8080
 
 ```bash
 cargo fmt --all --check
-cargo clippy --all-targets -- -D warnings
-cargo test --workspace
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace --all-features
 ```
 
 Please run these locally before opening a PR. Tests that need ffmpeg are gated on

--- a/README.md
+++ b/README.md
@@ -139,7 +139,8 @@ override settings — `storage_mode`, `title`/`author`, `disabled`, and more —
 just that book. See **[per-book overrides](docs/DEPLOYMENT.md#per-book-overrides-podspinetoml)**.
 
 Each book's feed lives at an unguessable **capability URL** — `/feed/{feed_id}.xml`,
-with `/audio/{feed_id}/{n}` (episode audio, HTTP Range) and `/cover/{feed_id}`. The
+with `/audio/{feed_id}/{n}` (episode audio, HTTP Range), `/cover/{feed_id}`, and
+`/subscribe/{feed_id}` (the add-to-app helper page the QR opens). The
 browse UI (`/`, `/book/{slug}`) enumerates your library, so keep it on the LAN or
 behind proxy-auth while the capability routes are safe to expose — see
 **[exposing Podspine safely](docs/DEPLOYMENT.md#exposing-podspine-safely)**.

--- a/README.md
+++ b/README.md
@@ -87,8 +87,9 @@ Windows (PowerShell):
 irm https://raw.githubusercontent.com/schubydoo/podspine/main/install.ps1 | iex
 ```
 
-Or a package manager — `brew install schubydoo/podspine/podspine`, `scoop install
-podspine`, `nix profile install github:schubydoo/podspine`,
+Or a package manager — `brew install schubydoo/podspine/podspine`,
+`scoop bucket add podspine https://github.com/schubydoo/scoop-podspine && scoop install podspine`,
+`nix profile install github:schubydoo/podspine`,
 or `cargo binstall --git https://github.com/schubydoo/podspine podspine`.
 `ffmpeg`/`ffprobe` must be on your `PATH`. Full matrix,
 version pinning, uninstall, and signature verification: **[Installing](https://schubydoo.github.io/podspine/latest/installation/)**.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,8 +14,8 @@ disclosure and credit you, if you'd like.
 
 ## Supported versions
 
-Podspine is pre-1.0 and under active development; only the latest release
-receives security fixes.
+Podspine is under active development; only the latest release receives
+security fixes.
 
 ## Scope & threat model
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -37,14 +37,15 @@ The crates are described below; the pipeline runs left to right, with the SQLite
 | `prober` | Thin `ffprobe` wrapper → `ProbedBook` (duration, audio codec, cover presence/codec, track/title tags, embedded chapters). Parsing is separated from the subprocess call so it's unit-testable. |
 | `chapters` | Resolve the chapter source: a sibling `.cue` (75 fps `INDEX 01`) or `.ffmeta` sidecar wins over embedded markers (priority `.cue` > `.ffmeta` > embedded). `.opf`/`.nfo`/`.odm` are never chapter sources. |
 | `splitter` | `ffmpeg` wrapper: stream-copy each chapter into a codec-matching container (no re-encode). Bounds concurrency with a semaphore and enforces a per-child timeout/kill. Also extracts cover art. |
-| `index` | `rusqlite` (bundled SQLite) store for `book`, `episode`, and `feed_token` rows, with idempotent upserts keyed on stable ids. |
+| `index` | `rusqlite` (bundled SQLite) store for `book` and `episode` rows (the per-book `feed_id` capability token is a column on `book`), with idempotent upserts keyed on stable ids. |
 | `feed` | Build one RSS 2.0 channel (itunes + podcast namespaces) per book, and a self-check that refuses to serve a malformed feed. |
 | `http` | Axum router: UI, feed, cover, and Range audio routes, plus the security/DoS middleware. |
 | `ui` | `maud` server-rendered pages: book grid, per-book copy-URL + QR + regenerate, and the per-book **subscribe page** (one-tap "Open in…" deep links + per-app QRs). Pure presentation — no DB or HTTP dependency. |
 | `metrics` | Optional Prometheus instrumentation: metric names, the recorder, the helpers other crates record through, and a standalone `/metrics` listener bound separately from the feed server. A no-op unless `--metrics-bind` is set. |
 
 Plus the `podspine` server binary (`src/main.rs`, wiring config → scan → watch →
-serve).
+serve) and a dev-only `test-support` crate (shared test fixtures: ffmpeg skip
+gates, synthetic-audio generation, scratch-dir guards — never shipped).
 
 ## Ingest data flow
 
@@ -116,7 +117,7 @@ details.
 
 ```
 <data_dir>/
-├── podspine.db              # SQLite index (book, episode, feed_token)
+├── podspine.db              # SQLite index (book, episode)
 └── books/
     └── <slug>/
         ├── 001.m4a          # per-chapter episode files (NNN.<ext>)
@@ -125,9 +126,11 @@ details.
         └── cover.jpg        # extracted cover, if present
 ```
 
-Everything the HTTP layer serves lives under `<data_dir>` — a single trusted root
-that the path-safety check enforces. `book` and `episode` rows carry the on-disk
-`file_path` written at scan time; the server never builds a path from request input.
+Everything the HTTP layer serves lives under one of two trusted roots — `<data_dir>`
+(extracted chapters, covers) or the read-only library (whole-file episodes served in
+place) — and the path-safety check asserts containment in whichever root the row
+recorded. `book` and `episode` rows carry the on-disk `file_path` written at scan
+time; the server never builds a path from request input.
 
 ## HTTP surface
 
@@ -145,7 +148,9 @@ safe to expose externally (a guessed id 404s); see
 | `GET /subscribe/{feed_id}` | capability | "Add to a podcast app" helper page: one-tap "Open in…" deep links + per-app QRs. |
 | `GET /feed/{feed_id}.xml` | capability | The podcast feed (built from the index, passed through the self-check); always `itunes:block` + `X-Robots-Tag: noindex`. |
 | `GET /audio/{feed_id}/{n}` | capability | Episode audio with HTTP Range (206 / `Content-Range` / 416) via `axum-range`. |
-| `GET /cover/{feed_id}` | capability | Book cover image. |
+| `GET /cover/{feed_id}` | capability | Book cover image (full resolution — this is what feeds embed). |
+| `GET /cover/{feed_id}/thumb` | capability | Small scanner-generated cover thumbnail for the browse grid; falls back to the full cover. |
+| `POST /theme/{mode}` | UI (slug) | Set the light/dark/system theme cookie; same-origin-guarded. |
 | `GET /healthz` | — | Liveness. |
 
 `GET /metrics` is deliberately **not** in this table: when enabled it lives on a
@@ -170,13 +175,16 @@ split the way they are.
   the above is violated.
 
 **Audio fidelity:**
-- Never re-encoded: chapters are extracted by stream copy and whole files are served
-  untouched, so there's no quality loss.
+- Never re-encoded by default: chapters are extracted by stream copy and whole files
+  are served untouched, so there's no quality loss. The one exception is opt-in —
+  `PODSPINE_TRANSCODE=aac|mp3` re-encodes sources no podcatcher can play (FLAC,
+  Vorbis, Opus, ALAC) once at ingest; everything else stays stream-copied.
 
 **Security (see [SECURITY.md](https://github.com/schubydoo/podspine/blob/main/SECURITY.md) for the threat model):**
 - Book/episode ids are **opaque index keys**. Slugs are validated against an
   allow-list charset and rejected with 404; the resolved audio path is canonicalized
-  and asserted to stay under `<data_dir>`. A path is never built from user input.
+  and asserted to stay under a trusted root (`<data_dir>` or the read-only library).
+  A path is never built from user input.
 - `ffmpeg`/`ffprobe` are invoked with an **argv vector, never a shell string** —
   chapter titles and filenames are untrusted.
 - Bounded `ffmpeg` concurrency (a semaphore sized to the CPU count) with a per-child

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -236,8 +236,8 @@ Podspine has two kinds of routes, and they want different exposure:
 
 | Surface | Routes | Keyed by | Expose to the internet? |
 |---|---|---|---|
-| **Capability** | `GET /feed/{id}.xml`, `/audio/{id}/{n}`, `/cover/{id}`, `/healthz` | a random, unguessable per-book `feed_id` | **Yes** — a guessed id just 404s, and feeds carry `itunes:block` + `X-Robots-Tag: noindex` so they aren't listed or crawled |
-| **Browse UI** | `GET /`, `/book/{slug}`, `POST /book/{slug}/regenerate` | the human `slug` | **No** — `GET /` lists every book, handing out the "unguessable" URLs. Keep it on the LAN or behind proxy-auth |
+| **Capability** | `GET /feed/{id}.xml`, `/audio/{id}/{n}`, `/cover/{id}`, `/cover/{id}/thumb`, `/subscribe/{id}`, `/healthz` | a random, unguessable per-book `feed_id` | **Yes** — a guessed id just 404s, and feeds carry `itunes:block` + `X-Robots-Tag: noindex` so they aren't listed or crawled. (The proxy snippets below deliberately don't publish `/subscribe` — it's used from the LAN book page.) |
+| **Browse UI** | `GET /`, `/book/{slug}`, `POST /book/{slug}/regenerate`, `POST /theme/{mode}` | the human `slug` | **No** — `GET /` lists every book, handing out the "unguessable" URLs. Keep it on the LAN or behind proxy-auth |
 
 This is what lets you subscribe to a book and stream it **on the road without a VPN**:
 you copy the capability feed URL (or scan its QR) from the book page **on your LAN**,

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -5,8 +5,9 @@ is enough; this page covers the production details: persistence, exposing it saf
 and running it as a service.
 
 > **Podspine has no built-in login.** It splits into two surfaces (see
-> [Exposing Podspine safely](#exposing-podspine-safely) below): the **feed/audio/cover**
-> routes are protected by an unguessable per-book **capability URL** and are safe to
+> [Exposing Podspine safely](#exposing-podspine-safely) below): the
+> **feed/audio/cover/subscribe** routes are protected by an unguessable per-book
+> **capability URL** and are safe to
 > expose to the internet, while the **browse UI** enumerates your whole library and
 > must stay on your LAN or behind proxy-auth. See [SECURITY.md](https://github.com/schubydoo/podspine/blob/main/SECURITY.md).
 
@@ -358,8 +359,8 @@ the browse UI private. Two hard requirements:
    Range to seek/scrub; stripping it breaks playback.
 2. Set `PODSPINE_BASE_URL` to the **public** URL so generated feed/audio links match.
 
-The configs below publish `/feed`, `/audio`, `/cover`, `/healthz` and refuse the
-browse UI (`/`, `/book/*`) — you use the UI over the LAN. (Prefer one authenticated
+The configs below publish `/feed`, `/audio`, `/cover`, `/subscribe`, `/healthz` and
+refuse the browse UI (`/`, `/book/*`) — you use the UI over the LAN. (Prefer one authenticated
 hostname instead? Drop the `@ui`/`location /` blocks and put `basicauth`/`auth_basic`
 on the whole server — just never require auth on `/feed`,`/audio`,`/cover`,
 `/subscribe`, since podcast apps (and a phone that just scanned a QR) can't log in.)

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -236,7 +236,7 @@ Podspine has two kinds of routes, and they want different exposure:
 
 | Surface | Routes | Keyed by | Expose to the internet? |
 |---|---|---|---|
-| **Capability** | `GET /feed/{id}.xml`, `/audio/{id}/{n}`, `/cover/{id}`, `/cover/{id}/thumb`, `/subscribe/{id}`, `/healthz` | a random, unguessable per-book `feed_id` | **Yes** — a guessed id just 404s, and feeds carry `itunes:block` + `X-Robots-Tag: noindex` so they aren't listed or crawled. (The proxy snippets below deliberately don't publish `/subscribe` — it's used from the LAN book page.) |
+| **Capability** | `GET /feed/{id}.xml`, `/audio/{id}/{n}`, `/cover/{id}`, `/cover/{id}/thumb`, `/subscribe/{id}`, `/healthz` | a random, unguessable per-book `feed_id` | **Yes** — a guessed id just 404s, and feeds carry `itunes:block` + `X-Robots-Tag: noindex` so they aren't listed or crawled. `/subscribe` must be public in a split deployment: the QR on the (LAN-only) book page points your phone at `base_url/subscribe/{feed_id}`, and it exposes only that one book's links |
 | **Browse UI** | `GET /`, `/book/{slug}`, `POST /book/{slug}/regenerate`, `POST /theme/{mode}` | the human `slug` | **No** — `GET /` lists every book, handing out the "unguessable" URLs. Keep it on the LAN or behind proxy-auth |
 
 This is what lets you subscribe to a book and stream it **on the road without a VPN**:
@@ -361,15 +361,15 @@ the browse UI private. Two hard requirements:
 The configs below publish `/feed`, `/audio`, `/cover`, `/healthz` and refuse the
 browse UI (`/`, `/book/*`) — you use the UI over the LAN. (Prefer one authenticated
 hostname instead? Drop the `@ui`/`location /` blocks and put `basicauth`/`auth_basic`
-on the whole server — just never require auth on `/feed`,`/audio`,`/cover`, since
-podcast apps can't log in.)
+on the whole server — just never require auth on `/feed`,`/audio`,`/cover`,
+`/subscribe`, since podcast apps (and a phone that just scanned a QR) can't log in.)
 
 **Caddy** (Range passes through automatically):
 
 ```caddy
 podspine.example.com {
     # Public: the capability surface only (unguessable per-book URLs).
-    @capability path /feed/* /audio/* /cover/* /healthz
+    @capability path /feed/* /audio/* /cover/* /subscribe/* /healthz
     handle @capability {
         reverse_proxy 127.0.0.1:8080
     }
@@ -386,8 +386,8 @@ podspine.example.com {
 server {
     server_name podspine.example.com;
 
-    # Public capability surface: feeds, cover, and audio (with Range).
-    location ~ ^/(feed|audio|cover)/ {
+    # Public capability surface: feeds, cover, audio (with Range), and subscribe.
+    location ~ ^/(feed|audio|cover|subscribe)/ {
         proxy_pass http://127.0.0.1:8080;
         proxy_set_header Host $host;
         proxy_set_header Range $http_range;               # forward seek requests

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -29,7 +29,9 @@ crates/
 ├── index             # rusqlite (bundled) store
 ├── feed              # RSS 2.0 + itunes/podcast + self-check
 ├── http              # Axum router + middleware
-└── ui                # maud pages
+├── ui                # maud pages
+├── metrics           # optional Prometheus instrumentation (--metrics-bind)
+└── test-support      # dev-only test fixtures (skip! macros, ffmpeg synthesis)
 ```
 
 ## Common commands
@@ -38,7 +40,7 @@ crates/
 cargo build                                   # build the workspace
 cargo run -- --library ./sample-books         # run the server → http://localhost:8080
 cargo test --workspace                        # run all tests
-cargo clippy --all-targets -- -D warnings     # lint (warnings are errors)
+cargo clippy --workspace --all-targets --all-features -- -D warnings  # lint (matches CI's gate)
 cargo fmt                                      # format
 ```
 
@@ -55,6 +57,10 @@ audiobooks.)
   the pipeline. These are gated on tool availability: if `ffmpeg`/`ffprobe` — or a
   specific encoder — isn't present, the test prints a skip notice and returns rather
   than failing. Encoders used include `aac`, `libmp3lame`, `flac`, and `libopus`.
+  The shared machinery (the `skip!`/`skip_unless_ffmpeg!` macros, fixture synthesis,
+  scratch-dir guards) lives in the dev-only `crates/test-support` crate. CI runs the
+  suite through `cargo nextest run`; plain `cargo test` and local `cargo nextest run`
+  both work.
 
 Run with logs to see scan/serve behavior:
 
@@ -100,12 +106,17 @@ produces the per-arch binaries and lays them out under `dist/` — see
 ## Hooks & CI
 
 - **Pre-commit** (`.pre-commit-config.yaml`) runs `cargo fmt --check`, `clippy -D
-  warnings`, and the lib unit tests before a commit lands, plus hygiene checks
-  (trailing whitespace, large files, secret/private-key detection). Install with
-  `pre-commit install`.
-- **CI** (`.github/workflows/ci.yml`): a `quality` job (fmt · clippy · test with
-  ffmpeg installed) and a `supply-chain` job (`cargo audit` + `cargo deny`) on every
-  push/PR. Releases run separately on `v*` tags.
+  warnings`, the lib unit tests, and the changeset lint before a commit lands, plus
+  hygiene checks (trailing whitespace, large files, secret/private-key detection).
+  A **pre-push** stage additionally runs the full workspace suite plus `cargo audit`
+  and `cargo deny` — both binaries must be on `PATH` or the push hook fails. Install
+  with `pre-commit install --install-hooks -t pre-commit -t pre-push`.
+- **CI** (`.github/workflows/ci.yml`), on PRs and pushes to `main`: `lint`
+  (fmt · clippy), a `test` matrix (ubuntu + macos, `cargo nextest` emitting JUnit
+  that uploads to Codecov Test Analytics), an informational non-blocking Windows
+  leg, `coverage` (cargo-llvm-cov with a **90% line floor** + Codecov upload),
+  `supply-chain` (`cargo audit` + `cargo deny`), and a required-checks aggregator.
+  Releases run separately on `v*` tags.
 
-Please make sure `fmt`, `clippy -D warnings`, and `test --workspace` all pass before
-opening a PR — CI enforces the same gates.
+Please make sure `fmt`, `clippy` (with `--workspace --all-features`), and
+`test --workspace` all pass before opening a PR — CI enforces the same gates.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -7,9 +7,11 @@ This is the measurement half of the Sprint 5 performance-validation work — it
 checks Podspine against the four performance targets in the [table below](#targets)
 (ingest time, feed render p95, audio time-to-first-byte, and idle memory).
 The point is not to publish a leaderboard — it is to answer one question before
-any v2 efficiency work (on-the-fly splitting, transcoding) is built: **are the
-NFR targets already met, or is there a real bottleneck to fix?** Run the harness
-on the box you actually deploy to and let the numbers decide.
+any further efficiency work is built: **are the NFR targets already met, or is
+there a real bottleneck to fix?** (Opt-in transcoding — `PODSPINE_TRANSCODE` —
+and `saver` mode's regenerate-on-demand chapter cache have since shipped; what
+remains hypothetical is byte-range chapter serving with no split files at all.)
+Run the harness on the box you actually deploy to and let the numbers decide.
 
 ## Targets
 
@@ -67,30 +69,35 @@ DURATION_SEC=3600 CHAPTERS=40 N_FEED=500 scripts/bench.sh
 
 ## Reference run
 
-Illustrative only — captured in a Linux x86_64 CI-class sandbox, loopback, with a
-synthetic 300s / 8-chapter book. **Your hardware will differ**; re-run locally.
+Illustrative only — captured 2026-08-19 on a Linux x86_64 host, loopback, with a
+synthetic 300s / 8-chapter book, after the parallel chapter split (v1.7.0).
+**Your hardware will differ**; re-run locally.
 
 | NFR | Metric                   | Measured           | Target      | Result |
 |-----|--------------------------|--------------------|-------------|--------|
-| P1  | Ingest (this book, 300s) | 0.91 s             | —           | —      |
-| P1  | Ingest → 10h (extrap.)   | ~109 s             | ≤ 120 s     | PASS   |
-| P2  | Feed p50/p95/p99         | 2.0 / 2.2 / 2.4 ms | p95 < 200ms | PASS   |
-| P3  | Audio TTFB p50/p95/p99   | 2.4 / 2.7 / 2.8 ms | p95 < 300ms | PASS   |
-| P4  | Idle RSS                 | 8.3 MB             | < 50 MB     | PASS   |
+| P1  | Ingest (this book, 300s) | 0.24 s             | —           | —      |
+| P1  | Ingest → 10h (extrap.)   | ~29 s              | ≤ 120 s     | PASS   |
+| P2  | Feed p50/p95/p99         | 1.3 / 2.3 / 2.5 ms | p95 < 200ms | PASS   |
+| P3  | Audio TTFB p50/p95/p99   | 0.7 / 0.8 / 0.9 ms | p95 < 300ms | PASS   |
+| P4  | Idle RSS                 | 9.5 MB             | < 50 MB     | PASS   |
 
 ### Reading the reference run
 
 All four targets clear with wide margins — feed render and audio TTFB sit ~100×
-under budget, and idle memory is ~6× under. The only figure worth watching is
-**P1**: pre-split ingest is I/O-bound (`ffmpeg -c copy` per chapter), so on slow
-storage or a many-chapter book it will rise. This applies only to **chaptered**
-books — whole-file episodes (MP3-folder tracks, chapterless singles) are served in
-place from the library and skip the split entirely (Sprint 6.2). Because the
-extrapolation folds in fixed startup cost it is pessimistic, but if a real 10h
-chaptered book on your disk lands near the 2-minute ceiling, that is the signal
-that avoiding the pre-split for chaptered books too (on-the-fly byte-range chapter
-serving, no duplicate split files) is worth the complexity — otherwise premature.
+under budget, and idle memory is ~5× under. **P1** used to be the figure to
+watch, and it improved substantially in v1.7.0: chapters are now split in
+parallel, bounded by a CPU-sized ffmpeg gate (measured ~9× on a 20-core host for
+a 40-chapter book), so many-chapter books scale far better than a linear
+per-chapter model suggests. Pre-split ingest remains I/O-bound on slow storage.
+This applies only to **chaptered** books — whole-file episodes (MP3-folder
+tracks, chapterless singles) are served in place from the library and skip the
+split entirely (Sprint 6.2), and `saver` mode trades the persistent split set
+for a regenerate-on-demand cache. Because the extrapolation folds in fixed
+startup cost it is pessimistic, but if a real 10h chaptered book on your disk
+still lands near the 2-minute ceiling, that is the signal that on-the-fly
+byte-range chapter serving (no split files at all) is worth the complexity —
+otherwise premature.
 
-The optional `/metrics` endpoint (Prometheus counters/histograms) is intentionally
-not part of this harness; it adds a runtime dependency and an opt-in config flag,
-which is a separate change.
+The optional `/metrics` endpoint (Prometheus counters/histograms, enabled with
+`--metrics-bind` on its own listener) is intentionally not part of this harness —
+the harness measures the serving path, not the exporter.


### PR DESCRIPTION
A whole-repo documentation audit (17 docs, claim-by-claim against `main`) found 18 stale claims across 8 docs; 9 docs verified fully current. This PR fixes all 18. No behavior changes — docs only.

## Highlights

- **ARCHITECTURE.md** had the security model wrong in two places: it claimed a `feed_token` table that has never existed (the capability token is a `feed_id` column on `book`), and said everything served lives under `<data_dir>` — untrue since serve-in-place: whole-file episodes stream from the read-only library, and the containment check asserts against both roots. Also: "never re-encoded" now carries the opt-in `PODSPINE_TRANSCODE` exception, and the route table gains `/cover/{id}/thumb` + `/theme/{mode}`.
- **DEVELOPMENT.md** described a CI `quality` job that doesn't exist — replaced with the actual layout (lint · nextest→JUnit→Codecov test matrix · informational Windows leg · 90% coverage floor · supply-chain · aggregator), documented the pre-push hook stage, and added the `metrics` and `test-support` crates to the workspace tree.
- **benchmarks.md** framed shipped features (transcoding, saver mode, `/metrics`) as future v2 work, and its reference numbers predated the parallel chapter split. Fresh reference run captured 2026-08-19: ingest **0.91s → 0.24s** for the 300s/8-chapter book, 10h extrapolation **~109s → ~29s**; the "watch P1" discussion rewritten around the parallel split.
- **PR template** asked contributors to hand-edit the knope-generated `CHANGELOG.md` — now asks for a `.changeset/*.md` fragment (or the `no-changelog` label), matching CONTRIBUTING.
- Mechanical: clippy/test commands in CONTRIBUTING/DEVELOPMENT/template now match CI's actual gate (`--workspace --all-features`); DEPLOYMENT's surface-split table gains the three newer routes; README's scoop one-liner includes the required bucket-add; SECURITY drops "pre-1.0".

Docs-only → `no-changelog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)