### PR TITLE
chore: rewrite all code comments in ASD-STE100 style and lint comments in CI

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,10 +1,11 @@
-# ClusterFuzzLite build image. The OSS-Fuzz Rust base ships a nightly toolchain
-# + cargo-fuzz + the sanitizer runtimes; we only add the source and the build
-# script. https://google.github.io/clusterfuzzlite/build-integration/rust/
+# ClusterFuzzLite build image. The OSS-Fuzz Rust base ships a nightly
+# toolchain + cargo-fuzz + the sanitizer runtimes; this file only adds the
+# source and the build script.
+# https://google.github.io/clusterfuzzlite/build-integration/rust/
 FROM gcr.io/oss-fuzz-base/base-builder-rust@sha256:433319ea1a6bbea6c1db1915a5d385021908cc62026d9f0efda2270ef6060de3
 
 # ffmpeg/ffprobe are NOT needed here: the harnesses fuzz pure parsers
-# (crates/chapters, crates/prober::parse_probe_json), no subprocess.
+# (crates/chapters, crates/prober::parse_probe_json), with no subprocess.
 COPY . $SRC/podspine
 WORKDIR $SRC/podspine
 COPY .clusterfuzzlite/build.sh $SRC/build.sh

--- a/.clusterfuzzlite/Dockerfile.dockerignore
+++ b/.clusterfuzzlite/Dockerfile.dockerignore
@@ -1,10 +1,11 @@
-# Per-Dockerfile ignore for the ClusterFuzzLite build. It OVERRIDES the repo-root
-# .dockerignore (which keeps only dist/ for the lean runtime image) — without this,
-# the root ignore excludes the source, so `COPY .clusterfuzzlite/build.sh` fails
-# "not found" and no fuzzers build. Here we keep the whole Rust workspace and
-# exclude only what cargo-fuzz doesn't need. rust-toolchain.toml is excluded on
-# purpose: its `channel = "stable"` would override base-builder-rust's nightly and
-# break `cargo fuzz build`.
+# The per-Dockerfile ignore for the ClusterFuzzLite build. It OVERRIDES the
+# repo-root .dockerignore (which keeps only dist/ for the lean runtime
+# image). Without this file, the root ignore excludes the source, so
+# `COPY .clusterfuzzlite/build.sh` fails with "not found" and no fuzzers
+# build. This file keeps the whole Rust workspace and excludes only what
+# cargo-fuzz does not need. rust-toolchain.toml is excluded on purpose: its
+# `channel = "stable"` would override base-builder-rust's nightly and break
+# `cargo fuzz build`.
 .git
 target
 dist

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,6 +1,6 @@
 # cargo-nextest configuration. Only the `ci` profile is customized: it emits
-# JUnit XML (the only format Codecov's Test Analytics ingests — same reason
-# claustrum runs gotestsum) at target/nextest/ci/junit.xml. Local
+# JUnit XML (the only format Codecov's Test Analytics ingests; claustrum runs
+# gotestsum for the same reason) at target/nextest/ci/junit.xml. Local
 # `cargo nextest run` uses the default profile and is unaffected.
 [profile.ci.junit]
 path = "junit.xml"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 # No contact_links, deliberately:
-#   - Discussions is not enabled for this repo, so a link to /discussions 404s.
-#     Usage questions belong in Issues (Bug Report / Feature Request).
+#   - Discussions is not enabled for this repo, so a link to /discussions
+#     404s. Usage questions belong in Issues (Bug Report / Feature Request).
 #   - Private vulnerability reporting IS enabled, so GitHub renders its own
 #     "Report a security vulnerability" entry in the chooser. The hand-written
-#     link to /security/advisories/new duplicated it — the same option appeared
+#     link to /security/advisories/new duplicated it: the same option appeared
 #     twice, with two different descriptions.

--- a/.github/actions/setup-ffmpeg/action.yml
+++ b/.github/actions/setup-ffmpeg/action.yml
@@ -6,21 +6,21 @@ description: >-
   informational Windows job fall back to their package managers. ffmpeg stays
   real, so the split/probe/scan correctness tests are unaffected.
 
-# Why a local composite action rather than a published one (e.g.
-# AnimMouse/setup-ffmpeg): the repo ruleset requires every action — including
-# ones nested inside a composite action — to be pinned to a full commit SHA.
+# Why a local composite action, not a published one (e.g.
+# AnimMouse/setup-ffmpeg): the repo ruleset requires every action, including
+# ones nested inside a composite action, to be pinned to a full commit SHA.
 # Published setup-ffmpeg actions call actions/cache and tool-cache by version
-# tag internally, which we can't pin, so they're rejected. Vendoring the logic
-# here keeps every ref under our control.
+# tag internally, which this repo cannot pin, so they are rejected. The
+# vendored logic here keeps every ref under the repo's control.
 #
-# Why ffmpeg 6.0.1 (not the newest 8.x): it's a deliberate *minimum-version
-# floor*. John Van Sickle's old-releases archive is the only source that is both
-# permanent AND immutable (BtbN's dated builds get pruned; its `latest` tag is
-# mutable, so a pinned hash would drift). Every ffmpeg flag Podspine uses is
-# stable across 4→8, and distro users (Debian/Ubuntu LTS) often run older
-# ffmpeg — proving it works on 6.0.1 covers them, and newer ffmpeg is
-# backward-compatible for this flag surface. Bump the version + FFMPEG_SHA256 +
-# cache key together to move the floor.
+# Why ffmpeg 6.0.1 (not the newest 8.x): it is a deliberate *minimum-version
+# floor*. John Van Sickle's old-releases archive is the only source that is
+# both permanent AND immutable (BtbN's dated builds get pruned, and its
+# `latest` tag is mutable, so a pinned hash would drift). Every ffmpeg flag
+# Podspine uses is stable across 4→8, and distro users (Debian/Ubuntu LTS)
+# often run older ffmpeg. Proof that it works on 6.0.1 covers them, and newer
+# ffmpeg is backward-compatible for this flag surface. Bump the version,
+# FFMPEG_SHA256, and cache key together to move the floor.
 
 runs:
   using: composite
@@ -54,8 +54,8 @@ runs:
     - name: Add ffmpeg to PATH (Linux)
       if: runner.os == 'Linux'
       shell: bash
-      # $dest is a hardcoded constant (no untrusted input), so this GITHUB_PATH
-      # write can't be influenced by an attacker. Podspine runs `ffmpeg` via a
+      # $dest is a hardcoded constant (no untrusted input), so an attacker
+      # cannot influence this GITHUB_PATH write. Podspine runs `ffmpeg` via a
       # PATH lookup, and GITHUB_PATH is the sanctioned way to extend PATH.
       run: | # zizmor: ignore[github-env]
         set -euo pipefail

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -1,14 +1,16 @@
-# ClusterFuzzLite — scheduled BATCH fuzzing (the deep counterpart to cflite_pr).
-# Runs EVERY harness in fuzz/ on a schedule (`mode: batch`), so unchanged code is
-# re-fuzzed regularly and each target gets a longer run. A reproducible crash
-# surfaces here + as SARIF. NOT a required check — it signals, never gates.
+# ClusterFuzzLite: scheduled BATCH fuzzing (the deep counterpart to
+# cflite_pr). It runs EVERY harness in fuzz/ on a schedule (`mode: batch`),
+# so unchanged code is re-fuzzed regularly and each target gets a longer run.
+# A reproducible crash surfaces here and as SARIF. NOT a required check: it
+# signals, never gates.
 #
-# Corpus persistence (optional): clones a private storage-repo, fuzzes, and pushes
-# the grown corpus back so coverage compounds across runs. Needs a
-# `schubydoo/podspine-fuzz-corpus` repo + a `FUZZ_STORAGE_TOKEN` PAT (write) — see
-# the publish checklist. The PR job deliberately carries no such secret. If the
-# secret is unset the job still runs (fuzzing from seed), it just won't accumulate.
-# `fuzz-seconds` is PER target → wall-clock ≈ fuzz-seconds × harness count + build.
+# Corpus persistence (optional): the job clones a private storage-repo,
+# fuzzes, and pushes the grown corpus back, so coverage compounds across
+# runs. This needs a `schubydoo/podspine-fuzz-corpus` repo and a
+# `FUZZ_STORAGE_TOKEN` PAT (write); see the publish checklist. The PR job
+# deliberately carries no such secret. If the secret is unset, the job still
+# runs (it fuzzes from seed); it only does not accumulate. `fuzz-seconds` is
+# PER target, so wall-clock ≈ fuzz-seconds × harness count + build.
 # Docs: https://google.github.io/clusterfuzzlite/
 name: ClusterFuzzLite batch fuzzing
 

--- a/.github/workflows/cflite_cron.yml
+++ b/.github/workflows/cflite_cron.yml
@@ -1,9 +1,10 @@
-# ClusterFuzzLite — weekly corpus PRUNE + COVERAGE report (maintenance for the
-# daily cflite_batch). Prune minimizes the persisted corpus (drops inputs adding
-# no coverage); coverage replays the whole corpus and pushes an HTML line-coverage
-# report to the corpus repo's gh-pages branch — showing exactly which parser code
-# the fuzzers reach (0% = a harness is owed). Both reuse the storage-repo +
-# FUZZ_STORAGE_TOKEN. NOT required checks. Docs: https://google.github.io/clusterfuzzlite/
+# ClusterFuzzLite: the weekly corpus PRUNE + COVERAGE report (maintenance
+# for the daily cflite_batch). Prune minimizes the persisted corpus (it drops
+# inputs that add no coverage). Coverage replays the whole corpus and pushes
+# an HTML line-coverage report to the corpus repo's gh-pages branch, which
+# shows exactly which parser code the fuzzers reach (0% means a harness is
+# owed). Both reuse the storage-repo + FUZZ_STORAGE_TOKEN. NOT required
+# checks. Docs: https://google.github.io/clusterfuzzlite/
 name: ClusterFuzzLite cron (prune + coverage)
 
 on:

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,16 +1,18 @@
-# ClusterFuzzLite — fuzz code changed by each PR (cargo-fuzz harnesses in fuzz/).
-# Informational / Phase-1: a short per-PR run on the address sanitizer; NOT a
-# required check, so a flaky finding never blocks a merge, but a reproducible
-# crash surfaces here (and as SARIF in the Security tab). Deeper runs live in the
-# scheduled cflite_batch.yml. No corpus secret here (fork-PR-safe).
+# ClusterFuzzLite: fuzz the code that each PR changes (cargo-fuzz harnesses
+# in fuzz/). Informational / Phase-1: a short per-PR run on the address
+# sanitizer. It is NOT a required check, so a flaky finding never blocks a
+# merge, but a reproducible crash surfaces here (and as SARIF in the Security
+# tab). Deeper runs live in the scheduled cflite_batch.yml. No corpus secret
+# lives here (fork-PR-safe).
 # Docs: https://google.github.io/clusterfuzzlite/
 name: ClusterFuzzLite PR fuzzing
 
 on:
   pull_request:
     branches: [main]
-    # Fuzz only when fuzz-relevant code changes, and only on open/reopen/ready
-    # (not every `synchronize` push). The nightly batch is the deep fuzzer.
+    # Fuzz only when fuzz-relevant code changes, and only on
+    # open/reopen/ready (not on every `synchronize` push). The nightly batch
+    # is the deep fuzzer.
     types: [opened, reopened, ready_for_review]
     paths:
       - "src/**"

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -1,11 +1,11 @@
 name: Changeset check
 
-# Advisory, NON-BLOCKING nudge for the changesets-only release model. A PR that
-# changes product code (crates/ or src/) but adds no `.changeset/*.md` fragment
-# gets a sticky comment + a warning annotation — it never fails the job, so it
-# can't block a merge. Opt out per-PR with the `no-changelog` label (CI /
-# refactor / tests / non-user-facing docs). Gated on KNOPE_ENABLED with the rest
-# of the release flow.
+# An advisory, NON-BLOCKING nudge for the changesets-only release model. A
+# PR that changes product code (crates/ or src/) but adds no
+# `.changeset/*.md` fragment gets a sticky comment and a warning annotation.
+# It never fails the job, so it cannot block a merge. Opt out per-PR with the
+# `no-changelog` label (CI / refactor / tests / non-user-facing docs). Gated
+# on KNOPE_ENABLED with the rest of the release flow.
 
 on:
   pull_request:
@@ -21,9 +21,9 @@ concurrency:
 
 jobs:
   changeset:
-    # Same-repo PRs only (fork PRs get a read-only token and can't comment), never
-    # on knope's own release PR (it deletes changesets as it prepares), and only
-    # once the changesets flow is enabled.
+    # Same-repo PRs only (fork PRs get a read-only token and cannot
+    # comment); never on knope's own release PR (it deletes changesets as it
+    # prepares); and only once the changesets flow is enabled.
     if: >-
       ${{ vars.KNOPE_ENABLED == 'true'
           && github.event.pull_request.head.repo.full_name == github.repository
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      # Optional podspine-ci App token for a larger API budget; soft-fail so a
-      # missing/rotated App degrades to GITHUB_TOKEN rather than redding an
-      # advisory check.
+      # An optional podspine-ci App token for a larger API budget. Soft-fail,
+      # so that a missing or rotated App degrades to GITHUB_TOKEN and does not
+      # red an advisory check.
       - name: Mint podspine-ci App token
         id: app-token
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: CI
 
-# fmt + clippy, the full test suite across platforms, coverage (with a line
-# floor), and supply-chain audit. A single aggregator job — `ci required checks
-# passed` — is what branch protection should require; extend it by adding jobs to
-# its `needs`.
+# fmt + clippy + rustdoc + typos, the full test suite across platforms, coverage
+# (with a line floor), and supply-chain audit. A single aggregator job — `ci
+# required checks passed` — is what branch protection should require; extend it
+# by adding jobs to its `needs`.
 
 on:
   push:
@@ -24,12 +24,16 @@ env:
 
 jobs:
   lint:
-    name: fmt · clippy
+    name: fmt · clippy · docs · typos
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      # Spell-check all text in the repository (code comments included).
+      # False positives go in `typos.toml` at the repository root.
+      - name: Typos
+        uses: crate-ci/typos@8a48f81b6c64dcfea44b3633223084c4be58ac5f # v1.49.0
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           components: rustfmt, clippy
@@ -38,6 +42,13 @@ jobs:
         run: cargo fmt --all --check
       - name: Clippy (deny warnings)
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+      # The only step that fires `rustdoc::` lints (broken intra-doc links, bad
+      # code-block attributes). `--document-private-items` because this workspace
+      # is a binary: almost all doc comments sit on private or internal items.
+      - name: Docs (deny warnings)
+        run: cargo doc --workspace --no-deps --all-features --document-private-items
+        env:
+          RUSTDOCFLAGS: -D warnings
 
   test:
     name: test (${{ matrix.os }})
@@ -54,14 +65,16 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
-      # Real ffmpeg, cached static build on Linux (seconds vs. apt pulling the
-      # whole libav* tree); see .github/actions/setup-ffmpeg for the why.
+      # Real ffmpeg, from a cached static build on Linux (seconds, vs. apt
+      # that pulls the whole libav* tree); see .github/actions/setup-ffmpeg
+      # for the why.
       - name: Set up ffmpeg
         uses: ./.github/actions/setup-ffmpeg
-      # nextest instead of `cargo test`: same tests, same gate (non-zero exit on
-      # failure), but a junit.xml falls out (.config/nextest.toml `ci` profile) —
-      # the only format Codecov's Test Analytics ingests. Prebuilt binary via
-      # install-action, matching the coverage/supply-chain jobs.
+      # nextest instead of `cargo test`: same tests, same gate (non-zero exit
+      # on failure), but a junit.xml falls out (.config/nextest.toml `ci`
+      # profile): the only format Codecov's Test Analytics ingests. Prebuilt
+      # binary via install-action, which matches the coverage/supply-chain
+      # jobs.
       - uses: taiki-e/install-action@5b4d68e2e660441203ab128a23676f1e4faf1532 # v2.86.3
         with:
           tool: cargo-nextest
@@ -71,18 +84,19 @@ jobs:
       # the day one appears, and reuses the build cache so it costs seconds.
       - name: Doctests
         run: cargo test --workspace --all-features --doc
-      # Upload from every leg, tagged with its OS as a Codecov flag, so Test
-      # Analytics (flaky/slow tests) breaks out per platform. Tokenless (public
-      # repo), non-blocking, and `!cancelled()` so a FAILED run still uploads —
-      # nextest writes junit.xml before exiting non-zero, and a failing suite is
-      # exactly when the analytics matter. (Pattern lifted from claustrum's CI.)
+      # Upload from every leg, tagged with its OS as a Codecov flag, so that
+      # Test Analytics (flaky/slow tests) breaks out per platform. Tokenless
+      # (public repo), non-blocking, and `!cancelled()`, so a FAILED run still
+      # uploads: nextest writes junit.xml before it exits non-zero, and a
+      # failing suite is exactly when the analytics matter. (The pattern is
+      # lifted from claustrum's CI.)
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           files: target/nextest/ci/junit.xml
-          # `files` is additive, not exclusive — without this the CLI still walks
-          # the checkout looking for more report-shaped files.
+          # `files` is additive, not exclusive. Without this, the CLI still
+          # walks the checkout in search of more report-shaped files.
           disable_search: true
           flags: ${{ runner.os }}
           report_type: test_results
@@ -98,10 +112,11 @@ jobs:
           retention-days: 7
 
   test-windows:
-    # Informational: Podspine has no Windows release target and its tests have
-    # never run there. This surfaces the status honestly (green/red) but is
-    # deliberately NOT in the required-checks aggregator, so it can't block
-    # merges. Promote it into the `test` matrix once it's reliably green.
+    # Informational: Podspine has no Windows release target, and its tests
+    # have never run there. This surfaces the status honestly (green/red) but
+    # is deliberately NOT in the required-checks aggregator, so it cannot
+    # block merges. Promote it into the `test` matrix once it is reliably
+    # green.
     name: test (windows, informational)
     runs-on: windows-latest
     steps:
@@ -154,9 +169,10 @@ jobs:
           tool: cargo-llvm-cov
       - name: Set up ffmpeg
         uses: ./.github/actions/setup-ffmpeg
-      # Enforce the line floor (the real gate; baseline ~94%) and emit lcov.
-      # cargo-llvm-cov writes lcov.info before the threshold check, so the upload
-      # below still runs on a floor failure — surfacing a drop when it matters.
+      # Enforce the line floor (the real gate; the baseline is ~94%) and emit
+      # lcov. cargo-llvm-cov writes lcov.info before the threshold check, so
+      # the upload below still runs on a floor failure, and a drop surfaces
+      # when it matters.
       - name: Coverage (lcov + line floor)
         run: cargo llvm-cov --workspace --lcov --output-path lcov.info --fail-under-lines 90
       # Codecov is informational (see codecov.yml); tokenless for public repos,
@@ -175,10 +191,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      # Prebuilt binaries (seconds) instead of `cargo install`, which compiled both
-      # tools from source — by far the slowest step in CI. cargo-audit/deny only read
-      # Cargo.toml/lock, so no project toolchain is needed (the runner's cargo
-      # dispatches the subcommands).
+      # Prebuilt binaries (seconds) instead of `cargo install`, which
+      # compiled both tools from source: by far the slowest step in CI.
+      # cargo-audit/deny only read Cargo.toml/lock, so no project toolchain is
+      # needed (the runner's cargo dispatches the subcommands).
       - uses: taiki-e/install-action@5b4d68e2e660441203ab128a23676f1e4faf1532 # v2.86.3
         with:
           tool: cargo-audit,cargo-deny

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,13 +1,14 @@
 name: CodeQL
 
-# Static analysis (SAST) for Rust via CodeQL — results land in the Security tab
-# (Code scanning). The `main` ruleset makes CodeQL a REQUIRED code-scanning tool,
-# so coverage must survive the "stuck PR" class: the `push` trigger binds a result
-# to each branch's STABLE head SHA (GitHub maps it onto open PRs and honours it
-# across base moves that recompute the merge ref), while `pull_request` adds the
-# merge-ref, PR-diff-aware analysis. Analysing every branch head — not just main —
-# is what keeps a PR off mergeStateStatus=BLOCKED after an unrelated merge moves
-# main. CodeQL uploads via the built-in GITHUB_TOKEN (App tokens are rejected by
+# Static analysis (SAST) for Rust via CodeQL; results land in the Security
+# tab (Code scanning). The `main` ruleset makes CodeQL a REQUIRED
+# code-scanning tool, so coverage must survive the "stuck PR" class. The
+# `push` trigger binds a result to each branch's STABLE head SHA (GitHub maps
+# it onto open PRs and honours it across base moves that recompute the merge
+# ref), while `pull_request` adds the merge-ref, PR-diff-aware analysis. The
+# analysis of every branch head (not just main) is what keeps a PR off
+# mergeStateStatus=BLOCKED after an unrelated merge moves main. CodeQL
+# uploads via the built-in GITHUB_TOKEN (App tokens are rejected by
 # upload-sarif, github/codeql-action#2719).
 #
 # NOTE: action refs are pinned to full commit SHAs (the repo's Actions policy
@@ -45,13 +46,15 @@ jobs:
         uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: rust
-          # Rust ONLY supports `build-mode: none` (CodeQL 2.25.x). `manual`/`autobuild`
-          # fail at `database init` with "Rust does not support the manual build mode",
-          # so there's no cargo-build-under-tracer option. Extraction is therefore
+          # Rust ONLY supports `build-mode: none` (CodeQL 2.25.x).
+          # `manual`/`autobuild` fail at `database init` with "Rust does not
+          # support the manual build mode", so there is no
+          # cargo-build-under-tracer option. Extraction is therefore
           # source-only: some files report "extracted with errors" (unresolved
-          # dependency/macro types) — a known limitation of the experimental Rust
-          # extractor, NOT fixable via build mode. Deeper Rust coverage comes from
-          # clippy (-D warnings), cargo audit/deny, and security.yml.
+          # dependency/macro types), a known limitation of the experimental
+          # Rust extractor, and NOT fixable via build mode. Deeper Rust
+          # coverage comes from clippy (-D warnings), cargo audit/deny, and
+          # security.yml.
           build-mode: none
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,20 +3,20 @@ name: Docs
 # Build the MkDocs (Material) site and publish it to GitHub Pages via `mike`,
 # which keeps a version selector on the gh-pages branch:
 #   - every push to main updates the rolling `dev` snapshot (unreleased docs)
-#   - every release tag (vX.Y.Z) publishes an immutable `X.Y` snapshot AND moves
-#     the `latest` alias (the site default) to it, so visitors land on the newest
-#     release — the version they can actually install. `dev` is opt-in via the
-#     selector and carries a version-warning banner.
+#   - every release tag (vX.Y.Z) publishes an immutable `X.Y` snapshot AND
+#     moves the `latest` alias (the site default) to it, so visitors land on
+#     the newest release: the version they can actually install. `dev` is
+#     opt-in via the selector and carries a version-warning banner.
 # Pull requests only build with --strict (link/config validation), never deploy.
 #
-# NOTE: action refs are pinned to full commit SHAs (repo Actions policy + Scorecard);
-# pip caching is deliberately NOT used (cache-poisoning vector in a publishing
-# workflow — zizmor), and the deploy job pushes via an explicit tokened remote
-# rather than persisted checkout credentials (zizmor artipacked). Python deps are
-# hash-pinned: docs/requirements.txt is a pip-compile lockfile installed with
-# --require-hashes, so every transitive package is verified (Scorecard
-# Pinned-Dependencies). Bump via docs/requirements.in + pip-compile (Renovate
-# regenerates it).
+# NOTE: action refs are pinned to full commit SHAs (repo Actions policy +
+# Scorecard). pip caching is deliberately NOT used (a cache-poisoning vector
+# in a publishing workflow; zizmor). The deploy job pushes via an explicit
+# tokened remote, not persisted checkout credentials (zizmor artipacked).
+# Python deps are hash-pinned: docs/requirements.txt is a pip-compile lockfile
+# installed with --require-hashes, so every transitive package is verified
+# (Scorecard Pinned-Dependencies). Bump via docs/requirements.in + pip-compile
+# (Renovate regenerates it).
 
 on:
   push:
@@ -39,7 +39,8 @@ permissions:
   contents: read
 
 concurrency:
-  # Serialize deploys (they push to gh-pages); don't cancel a push mid-deploy.
+  # Serialize deploys (they push to gh-pages); do not cancel a push
+  # mid-deploy.
   group: docs-${{ github.ref }}
   cancel-in-progress: false
 
@@ -61,9 +62,10 @@ jobs:
   deploy:
     name: deploy (mike)
     needs: build
-    # Never on PRs (fork tokens are read-only anyway); same-repo only; and only
-    # for main or a release tag — otherwise a manual workflow_dispatch from a
-    # feature branch would fall through and overwrite `latest` with branch docs.
+    # Never on PRs (fork tokens are read-only anyway); same-repo only; and
+    # only for main or a release tag. Otherwise a manual workflow_dispatch
+    # from a feature branch would fall through and overwrite `latest` with
+    # branch docs.
     if: >-
       github.event_name != 'pull_request'
       && github.repository == 'schubydoo/podspine'
@@ -98,16 +100,18 @@ jobs:
           set -euo pipefail
           if [ -n "${PROMOTE:-}" ]; then
             # One-time migration / manual re-point: make an already-deployed
-            # release the site default under the `latest` alias. Used once when
-            # switching from "latest tracks main" to the release-default model —
-            # it removes the legacy version literally named `latest` (the old main
-            # snapshot) so `latest` can become an alias on the release. `|| true`
-            # because on a healthy tree there's no such version to delete.
+            # release the site default under the `latest` alias. This was used
+            # once for the switch from "latest tracks main" to the
+            # release-default model. It removes the legacy version literally
+            # named `latest` (the old main snapshot), so that `latest` can
+            # become an alias on the release. `|| true` because on a healthy
+            # tree there is no such version to delete.
             #
-            # Use `mike alias` (NOT `mike deploy`): we're only re-pointing the
-            # alias at an already-published snapshot. `mike deploy $PROMOTE` would
-            # rebuild the docs from the current checkout (main) into the $PROMOTE
-            # dir, clobbering the immutable release snapshot with main's content.
+            # Use `mike alias` (NOT `mike deploy`): this only re-points the
+            # alias at an already-published snapshot. `mike deploy $PROMOTE`
+            # would rebuild the docs from the current checkout (main) into the
+            # $PROMOTE dir, and that would clobber the immutable release
+            # snapshot with main's content.
             case "$PROMOTE" in
               [0-9]*.[0-9]*) ;;
               *) echo "::error::promote_to_latest must be an X.Y version (e.g. 1.2)"; exit 1 ;;
@@ -116,17 +120,18 @@ jobs:
             mike alias --push --update-aliases "$PROMOTE" latest
             mike set-default --push --template mike/redirect.html latest
           elif [ "$REF_TYPE" = "tag" ]; then
-            # Release vX.Y.Z -> immutable "X.Y" snapshot, and move `latest` (the
-            # site default) onto it: the newest release is what visitors land on.
-            # Assumes linear releases (a backport to an old line would wrongly
-            # claim `latest` — re-point manually via promote_to_latest if so).
+            # A release vX.Y.Z publishes an immutable "X.Y" snapshot and
+            # moves `latest` (the site default) onto it: the newest release is
+            # what visitors land on. This assumes linear releases (a backport
+            # to an old line would wrongly claim `latest`; re-point manually
+            # via promote_to_latest in that case).
             version="${REF_NAME#v}"
             mike deploy --push --update-aliases "${version%.*}" latest
             mike set-default --push --template mike/redirect.html latest
           else
-            # Push to main -> rolling `dev` snapshot. Deliberately never touches
-            # `latest`/default, so unreleased changes aren't what users see by
-            # default; Material's version-warning banner flags `dev` as ahead of
-            # the release.
+            # A push to main updates the rolling `dev` snapshot. It
+            # deliberately never touches `latest`/default, so unreleased
+            # changes are not what users see by default. Material's
+            # version-warning banner flags `dev` as ahead of the release.
             mike deploy --push --update-aliases dev
           fi

--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -1,13 +1,13 @@
 name: Installer smoke
 
-# Smoke-test every install method on real runners (the cross-OS / package-manager
-# coverage the dev host can't provide): the one-line installers install.sh (Linux +
-# macOS) and install.ps1 (Windows), their uninstall counterparts, the Homebrew
-# formula (macOS), the Nix flake (Linux), and `cargo install` (Linux + macOS). The
-# script/brew jobs install the
-# published RELEASE binary and verify it runs via `--help` (the `--version` flag
-# ships in this PR, so the current release doesn't have it yet); the Nix job builds
-# THIS PR's source and so checks `--version`. Non-required signal job.
+# Smoke-test every install method on real runners (the cross-OS /
+# package-manager coverage the dev host cannot provide): the one-line
+# installers install.sh (Linux + macOS) and install.ps1 (Windows), their
+# uninstall counterparts, the Homebrew formula (macOS), the Nix flake (Linux),
+# and `cargo install` (Linux + macOS). The script/brew jobs install the
+# published RELEASE binary and verify that it runs via `--help`. The Nix and
+# cargo jobs build THIS checkout's source, so they check `--version`. This is
+# a non-required signal job.
 on:
   workflow_dispatch:
   pull_request:
@@ -65,9 +65,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      # install.ps1 runs under a function + try/catch (no `exit`, for iex safety); it
-      # signals failure via $global:LASTEXITCODE, so verify the OUTCOME (binary present
-      # + runnable) rather than trusting the script's exit status.
+      # install.ps1 runs under a function + try/catch (no `exit`, for iex
+      # safety); it signals failure via $global:LASTEXITCODE. So verify the
+      # OUTCOME (the binary is present and runnable); do not trust the
+      # script's exit status.
       - name: install.ps1 + verify + uninstall.ps1
         shell: pwsh
         run: |
@@ -95,9 +96,10 @@ jobs:
       - name: brew install via a local tap + verify
         run: |
           set -euo pipefail
-          # Modern Homebrew refuses a bare local formula path — it must live in a tap.
-          # Stage our formula into an ephemeral local tap (mirrors real consumption via
-          # the homebrew-podspine repo) and install from there.
+          # Modern Homebrew refuses a bare local formula path: the formula
+          # must live in a tap. Stage the formula into an ephemeral local tap
+          # (this mirrors real consumption via the homebrew-podspine repo) and
+          # install from there.
           brew tap-new schubydoo/local --no-git
           tap_dir="$(brew --repository schubydoo/local)"
           mkdir -p "$tap_dir/Formula"
@@ -123,7 +125,7 @@ jobs:
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes
-      # Builds THIS PR's source, so the freshly-added --version flag is present.
+      # This builds THIS checkout's source, so the --version flag is present.
       - name: Build + run the flake
         run: |
           set -euo pipefail
@@ -143,10 +145,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      # `cargo install --path` from THIS PR's checkout exercises the cargo route
-      # (and the source carries the new --version). The Rust toolchain is preinstalled
-      # on GitHub runners. The [package.metadata.binstall] block is separately
-      # validated end-to-end by `cargo binstall --git` once it lands on main.
+      # `cargo install --path` from THIS checkout exercises the cargo route
+      # (the source carries --version). The Rust toolchain is preinstalled on
+      # GitHub runners. The [package.metadata.binstall] block is separately
+      # validated end-to-end by `cargo binstall --git` from main.
       - name: cargo install + verify
         run: |
           set -euo pipefail

--- a/.github/workflows/knope-prepare.yml
+++ b/.github/workflows/knope-prepare.yml
@@ -1,14 +1,15 @@
 name: Prepare Release
 
-# knope's "release PR" half. On push to main, if the Conventional-Commit history
-# since the last tag warrants a release, knope bumps the version + CHANGELOG,
-# resyncs Cargo.lock, force-pushes the `release` branch, and opens/refreshes a
-# `chore: prepare release X.Y.Z` PR. Merging that PR is the approval gate; the
-# merge triggers knope-release.yml.
+# knope's "release PR" half. On push to main, if pending changeset fragments
+# warrant a release, knope bumps the version + CHANGELOG, resyncs Cargo.lock,
+# force-pushes the `release` branch, and opens/refreshes a
+# `chore: prepare release X.Y.Z` PR. The merge of that PR is the approval
+# gate; the merge triggers knope-release.yml.
 #
-# Gated on the `KNOPE_ENABLED` repo variable (now 'true'). Needs the `podspine-ci`
-# GitHub App INSTALLED on the repo (PODSPINE_CI_APP_ID / PODSPINE_CI_APP_PRIVATE_KEY
-# secrets) — only for release-driving pushes; see the changeset-first ordering below.
+# Gated on the `KNOPE_ENABLED` repo variable (now 'true'). This needs the
+# `podspine-ci` GitHub App INSTALLED on the repo (PODSPINE_CI_APP_ID /
+# PODSPINE_CI_APP_PRIVATE_KEY secrets). The App is needed only for
+# release-driving pushes; see the changeset-first ordering below.
 
 on:
   push:
@@ -29,10 +30,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      # Detect a pending changeset FIRST, with a credential-less checkout, so a
-      # routine push with no fragment is a clean no-op that never touches the
-      # podspine-ci App. Only a release-driving push mints the token below — this
-      # decouples ordinary merges (docs/CI/no-changelog) from the App entirely.
+      # Detect a pending changeset FIRST, with a credential-less checkout, so
+      # that a routine push with no fragment is a clean no-op that never
+      # touches the podspine-ci App. Only a release-driving push mints the
+      # token below. This decouples ordinary merges (docs/CI/no-changelog)
+      # from the App entirely.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
@@ -48,9 +50,10 @@ jobs:
           echo "has=$([ "$count" -gt 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
           echo "pending changeset fragments: $count"
       # Everything below runs ONLY when a fragment is pending. Short-lived
-      # podspine-ci App token: its identity is what lets the release PR's eventual
-      # merge tag trigger release.yml (a GITHUB_TOKEN-pushed tag would not, by
-      # GitHub's recursion suppression) and lets CI run on the release PR.
+      # podspine-ci App token: its identity is what lets the release PR's
+      # eventual merge tag trigger release.yml (a GITHUB_TOKEN-pushed tag
+      # would not, because of GitHub's recursion suppression), and it lets CI
+      # run on the release PR.
       - name: Mint podspine-ci App token
         id: app-token
         if: ${{ steps.changesets.outputs.has == 'true' }}
@@ -65,9 +68,9 @@ jobs:
         run: |
           echo "::error::podspine-ci App token mint produced an empty token; check the PODSPINE_CI_APP_ID / PODSPINE_CI_APP_PRIVATE_KEY secrets and the App installation."
           exit 1
-      # Re-checkout with the App token persisted so knope's `git push` of the
-      # release branch + the PR it opens run as the App identity. Full history +
-      # tags so knope can find the last release tag.
+      # Re-checkout with the App token persisted, so that knope's `git push`
+      # of the release branch, and the PR it opens, run as the App identity.
+      # Full history and tags, so that knope can find the last release tag.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: ${{ steps.changesets.outputs.has == 'true' }}
         with:

--- a/.github/workflows/knope-release.yml
+++ b/.github/workflows/knope-release.yml
@@ -1,15 +1,16 @@
 name: Knope Release
 
-# knope's "publish" half. When the `chore: prepare release X.Y.Z` PR (opened by
-# knope-prepare.yml from the `release` branch) merges, knope creates the GitHub
-# Release + tag from the CHANGELOG notes. Because the tag is pushed as the
-# podspine-ci App (not GITHUB_TOKEN), it triggers release.yml — which does the
-# actual signed build (binaries + SLSA provenance + SBOM + GHCR image). So this
-# workflow deliberately does NOT build or sign anything.
+# knope's "publish" half. When the `chore: prepare release X.Y.Z` PR (opened
+# by knope-prepare.yml from the `release` branch) merges, knope creates the
+# GitHub Release + tag from the CHANGELOG notes. The tag is pushed as the
+# podspine-ci App (not GITHUB_TOKEN), so it triggers release.yml, which does
+# the actual signed build (binaries + SLSA provenance + SBOM + GHCR image).
+# So this workflow deliberately does NOT build or sign anything.
 #
-# GATED OFF behind the `KNOPE_ENABLED` repo variable. Triggered on the release PR
-# MERGING (head branch `release`), not a commit-message marker (squash subjects
-# are editable). Tags the squash commit that actually landed on main.
+# GATED behind the `KNOPE_ENABLED` repo variable. It triggers on the MERGE of
+# the release PR (head branch `release`), not on a commit-message marker
+# (squash subjects are editable). It tags the squash commit that actually
+# landed on main.
 
 on:
   pull_request:
@@ -51,7 +52,8 @@ jobs:
           echo "::error::podspine-ci App token mint produced an empty token; check the PODSPINE_CI_APP_ID / PODSPINE_CI_APP_PRIVATE_KEY secrets and the App installation."
           exit 1
       # Tag the squash commit that landed on main (merge_commit_sha), not the
-      # orphaned PR head. Full history + tags for knope's version comparison.
+      # orphaned PR head. Full history and tags, for knope's version
+      # comparison.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
@@ -61,8 +63,9 @@ jobs:
         uses: knope-dev/action@19617851f9f13ab2f27a05989c55efb18aca3675 # v2.1.2
         with:
           version: 0.23.0
-      # knope creates the GitHub Release + tag as the App token, which triggers
-      # release.yml (the signed build). No-op if the version already has a release.
+      # knope creates the GitHub Release + tag as the App token, which
+      # triggers release.yml (the signed build). This is a no-op when the
+      # version already has a release.
       - name: Create the tag + GitHub Release
         run: knope release --verbose
         env:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,11 +1,12 @@
 name: Nightly
 
-# Build the two Linux musl binaries from the tip of `main` and push a multi-arch
-# image to GHCR as `:nightly` (plus `:nightly-<shortsha>` for traceability). This
-# is a throwaway TEST image for trying merged-but-unreleased changes on a real
-# deployment before cutting a `v*` release — it NEVER moves `:latest` and publishes
-# no GitHub Release or binary assets. Run it on demand (workflow_dispatch) or let
-# the daily schedule refresh it.
+# Build the two Linux musl binaries from the tip of `main` and push a
+# multi-arch image to GHCR as `:nightly` (plus `:nightly-<shortsha>` for
+# traceability). This is a throwaway TEST image, used to try
+# merged-but-unreleased changes on a real deployment before a `v*` release is
+# cut. It NEVER moves `:latest`, and it publishes no GitHub Release and no
+# binary assets. Run it on demand (workflow_dispatch), or let the daily
+# schedule refresh it.
 #
 # Mirrors release.yml's `binaries` + `image` jobs, trimmed to Linux (the image
 # consumes only the musl binaries). Action refs are pinned to full commit SHAs
@@ -17,7 +18,7 @@ name: Nightly
 on:
   workflow_dispatch:
   schedule:
-    # 07:00 UTC daily — after the day's merges land, before a morning test.
+    # 07:00 UTC daily: after the day's merges land, before a morning test.
     - cron: "0 7 * * *"
 
 # Least privilege by default; the image job elevates explicitly.
@@ -25,25 +26,26 @@ permissions:
   contents: read
 
 concurrency:
-  # Scope by ref, not a bare "nightly": concurrency is evaluated BEFORE the job's
-  # ref guard, so a shared group would let an off-main dispatch cancel a running
-  # main nightly and then skip — killing the image with nothing to replace it.
-  # Per-ref, a newer main build still supersedes an in-flight main build.
+  # Scope by ref, not a bare "nightly": concurrency is evaluated BEFORE the
+  # job's ref guard, so a shared group would let an off-main dispatch cancel a
+  # running main nightly and then skip. That would kill the image with nothing
+  # to replace it. Per-ref, a newer main build still supersedes an in-flight
+  # main build.
   group: nightly-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   binaries:
-    # Canonical repo AND the `main` ref only. `:nightly` is contracted to be the tip
-    # of main, so a dispatch on a feature branch or tag (workflow_dispatch lets you
-    # pick any ref) must not publish its build under that tag; a scheduled run's ref
-    # is already refs/heads/main. This also keeps forks from building nightlies on a
-    # cron they never asked for.
+    # Canonical repo AND the `main` ref only. `:nightly` is contracted to be
+    # the tip of main, so a dispatch on a feature branch or tag
+    # (workflow_dispatch permits any ref) must not publish its build under
+    # that tag. A scheduled run's ref is already refs/heads/main. This also
+    # keeps forks from nightly builds on a cron they never asked for.
     if: ${{ github.repository == 'schubydoo/podspine' && github.ref == 'refs/heads/main' }}
     name: Build ${{ matrix.name }} binary (musl)
     runs-on: ubuntu-latest
     strategy:
-      # One arch failing shouldn't hide the other's result.
+      # A failure on one arch must not hide the other's result.
       fail-fast: false
       matrix:
         include:
@@ -122,7 +124,8 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           # `:nightly` always points at the newest main build; `:nightly-<shortsha>`
-          # pins a specific one. Never `:latest` — that is stable-release only.
+          # pins a specific one. Never `:latest`: that tag is stable-release
+          # only.
           tags: |
             type=raw,value=nightly
             type=sha,prefix=nightly-,format=short

--- a/.github/workflows/packaging-bump.yml
+++ b/.github/workflows/packaging-bump.yml
@@ -1,18 +1,20 @@
 name: Packaging manifest bump
 
-# Keep the in-repo package-manager manifests — Homebrew (Formula/podspine.rb), Scoop
-# (packaging/scoop/podspine.json), and the Nix flake's version — in lockstep with
-# published releases. Nothing auto-updates them
-# otherwise, so `brew`/`scoop`/`nix` would keep serving whatever the committed
-# manifests pin, frozen until someone bumps them by hand.
+# Keep the in-repo package-manager manifests (Homebrew Formula/podspine.rb,
+# Scoop packaging/scoop/podspine.json, and the Nix flake's version) in
+# lockstep with published releases. Nothing auto-updates them otherwise, so
+# `brew`/`scoop`/`nix` would keep serving whatever the committed manifests
+# pin, frozen until someone bumps them by hand.
 #
-# On every published release we regenerate each manifest's version/url/hash from the
-# release's authoritative checksums.txt (via scripts/bump_packaging.py) and open a PR.
-# We DON'T push to main: main is branch-protected and the bump is reviewable. A manifest
-# not yet on main is skipped, so this can merge ahead of packaging landing.
+# On every published release, this workflow regenerates each manifest's
+# version/url/hash from the release's authoritative checksums.txt (via
+# scripts/bump_packaging.py) and opens a PR. It does NOT push to main: main is
+# branch-protected, and the bump is reviewable. A manifest not yet on main is
+# skipped, so this can merge before packaging lands.
 #
-# Trust root: the checksums.txt asset, fetched over GitHub TLS from our own just-published
-# release — the same trust model install.sh/install.ps1 use.
+# Trust root: the checksums.txt asset, fetched over GitHub TLS from this
+# repo's own just-published release. install.sh/install.ps1 use the same trust
+# model.
 on:
   release:
     types: [published]
@@ -33,19 +35,22 @@ concurrency:
 jobs:
   bump:
     name: Sync packaging manifests to the release
-    # workflow_dispatch restricted to the default branch so a dispatch from an arbitrary
-    # ref can't run this write-capable job. (release events use the default branch anyway.)
+    # workflow_dispatch is restricted to the default branch, so that a
+    # dispatch from an arbitrary ref cannot run this write-capable job.
+    # (release events use the default branch anyway.)
     if: ${{ github.event_name == 'release' || github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
-    # Must exceed the checksums.txt wait budget below (~20 min) plus the download +
-    # bump + PR work, or Actions kills the job mid-wait for a slow release build.
+    # This must exceed the checksums.txt wait budget below (~20 min) plus
+    # the download + bump + PR work. Otherwise Actions kills the job mid-wait
+    # for a slow release build.
     timeout-minutes: 25
     permissions:
       contents: read
       pull-requests: read
     steps:
-      # App token (NOT the default GITHUB_TOKEN): a PR opened by the default token would
-      # not trigger downstream CI, and it can't push a branch under branch protection.
+      # App token (NOT the default GITHUB_TOKEN): a PR opened by the default
+      # token would not trigger downstream CI, and that token cannot push a
+      # branch under branch protection.
       - name: Mint GitHub App token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -68,8 +73,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      # Resolve + STRICTLY validate the tag before it reaches a shell (passed via env,
-      # never inlined) — a malformed/hostile tag can't inject.
+      # Resolve and STRICTLY validate the tag before it reaches a shell
+      # (passed via env, never inlined), so that a malformed or hostile tag
+      # cannot inject.
       - name: Resolve target release tag
         id: tag
         env:
@@ -94,8 +100,9 @@ jobs:
           echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
           echo "Target tag: $tag"
 
-      # Regenerate version/url/hash for every present manifest from checksums.txt. The
-      # helper fails closed if an asset is missing or a stale version would survive.
+      # Regenerate version/url/hash for every present manifest from
+      # checksums.txt. The helper fails closed when an asset is missing or a
+      # stale version would survive.
       - name: Regenerate packaging manifests
         id: regen
         env:
@@ -105,15 +112,17 @@ jobs:
         run: |
           set -euo pipefail
           tmp="$(mktemp -d)"
-          # release.yml publishes the release before its 5-platform matrix finishes
-          # uploading assets, so `release: published` can fire before checksums.txt
-          # exists. Wait for it (up to ~20 min) instead of racing to a hard failure.
+          # release.yml publishes the release before its 5-platform matrix
+          # finishes the asset uploads, so `release: published` can fire
+          # before checksums.txt exists. Wait for it (up to ~20 min); do not
+          # race to a hard failure.
           #
-          # `any(...)` yields a literal `true`/`false` and never an empty string, so a
-          # "not present yet" result can't be misread as "present". The previous
-          # `index(...) != "null"` check broke on attempt 1 because `gh --jq` prints
-          # "" (not "null") for a JSON null, which passed the `!= "null"` test.
-          # `|| have=retry` additionally keeps waiting through a transient gh/API error.
+          # `any(...)` yields a literal `true`/`false` and never an empty
+          # string, so a "not present yet" result cannot be misread as
+          # "present". The previous `index(...) != "null"` check broke on
+          # attempt 1: `gh --jq` prints "" (not "null") for a JSON null, and
+          # "" passed the `!= "null"` test. `|| have=retry` additionally keeps
+          # the wait alive through a transient gh/API error.
           for i in $(seq 1 40); do
             have="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
                     --json assets --jq 'any(.assets[].name; . == "checksums.txt")')" \
@@ -174,10 +183,12 @@ jobs:
             echo "PR already open for $branch — pushed the updated manifests to it."
           fi
 
-          # Enable native auto-merge (squash) so the deterministic, CI-verified bump lands
-          # once required checks pass — no manual merge per release. The bump is machine-
-          # generated from the release's signed checksums.txt (fails closed), not hand
-          # logic. Best-effort: a disabled "Allow auto-merge" setting just leaves it manual.
+          # Enable native auto-merge (squash), so that the deterministic,
+          # CI-verified bump lands once required checks pass: no manual merge
+          # per release. The bump is machine-generated from the release's
+          # signed checksums.txt (it fails closed), not hand logic.
+          # Best-effort: a disabled "Allow auto-merge" setting only leaves it
+          # manual.
           if ! gh pr merge --repo "$GITHUB_REPOSITORY" --auto --squash "$branch"; then
             echo "::warning::could not enable auto-merge on $branch — merge it manually"
           fi

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,11 +1,12 @@
 name: PR Title
 
-# Validate that the pull-request title follows Conventional Commits. The repo
-# squash-merges, so the PR title becomes the squashed commit subject — keeping a
-# clean, conventional history that Knope can drive releases/CHANGELOG from later.
+# Validate that the pull-request title follows Conventional Commits. The
+# repo squash-merges, so the PR title becomes the squashed commit subject.
+# That keeps a clean, conventional history.
 #
-# Keep `synchronize` in the triggers: if this is made a REQUIRED check, required
-# checks are evaluated per head-SHA, so a fixup push needs a fresh check run.
+# Keep `synchronize` in the triggers: if this becomes a REQUIRED check,
+# required checks are evaluated per head-SHA, so a fixup push needs a fresh
+# check run.
 
 on:
   pull_request:
@@ -26,12 +27,13 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      # Mint a short-lived podspine-ci App installation token (≥5,000 REST req/hr,
-      # vs the 1,000/hr github-actions[bot] pool that fails spuriously under
-      # multi-PR bursts). Same-repo PRs only — fork PRs can't read the App secrets,
-      # so the step is skipped there and the action falls back to GITHUB_TOKEN.
-      # Soft-fail: until the App secrets exist the mint yields an empty token and
-      # this required check still runs under GITHUB_TOKEN instead of erroring.
+      # Mint a short-lived podspine-ci App installation token (≥5,000 REST
+      # req/hr, vs the 1,000/hr github-actions[bot] pool that fails spuriously
+      # under multi-PR bursts). Same-repo PRs only: fork PRs cannot read the
+      # App secrets, so the step is skipped there, and the action falls back
+      # to GITHUB_TOKEN. Soft-fail: until the App secrets exist, the mint
+      # yields an empty token, and this check still runs under GITHUB_TOKEN;
+      # it does not error.
       - name: Mint podspine-ci App token
         id: app-token
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,14 @@
 name: Release
 
-# On a `v*` tag: build release binaries for Linux (static musl amd64+arm64, via
-# zig), macOS (Intel + Apple Silicon), and Windows (x86_64), generate SBOMs, sign
-# the checksums with keyless cosign, attach a SLSA build-provenance file, publish a
-# GitHub Release, and push a multi-arch (Linux) image to GHCR (with provenance +
-# SBOM, and a cosign signature). TAD §6.4.
+# On a `v*` tag: build release binaries for Linux (static musl amd64+arm64,
+# via zig), macOS (Intel + Apple Silicon), and Windows (x86_64). Generate
+# SBOMs. Sign the checksums with keyless cosign. Attach a SLSA
+# build-provenance file. Publish a GitHub Release. Push a multi-arch (Linux)
+# image to GHCR (with provenance, SBOM, and a cosign signature). TAD §6.4.
 #
-# OpenSSF Scorecard: Signed-Releases — cosign `.sigstore.json` signatures plus a
-# `*.intoto.jsonl` SLSA provenance file; SBOM — CycloneDX SBOMs as release assets.
+# OpenSSF Scorecard: Signed-Releases needs the cosign `.sigstore.json`
+# signatures plus a `*.intoto.jsonl` SLSA provenance file; SBOM needs the
+# CycloneDX SBOMs as release assets.
 #
 # Cut a release: `git tag v1.0.0 && git push origin v1.0.0`.
 #
@@ -23,8 +24,8 @@ permissions:
   contents: read
 
 concurrency:
-  # Releases must not cancel each other — a half-published release is worse than
-  # letting two runs serialize.
+  # Releases must not cancel each other: a half-published release is worse
+  # than two serialized runs.
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
@@ -33,8 +34,8 @@ jobs:
     name: Build ${{ matrix.name }} binary
     runs-on: ${{ matrix.os }}
     strategy:
-      # Don't let one platform's failure cancel the others — we want to see every
-      # target's result on a release run.
+      # Do not let one platform's failure cancel the others: a release run
+      # must show every target's result.
       fail-fast: false
       matrix:
         include:
@@ -47,12 +48,13 @@ jobs:
             os: ubuntu-latest
             name: linux-arm64
             build: zig
-          # macOS + Windows: use the platform's native toolchain (cargo build), not
-          # zig — native is exactly what CI already exercises (green macos + windows
-          # test jobs), and rusqlite's bundled SQLite C compiles with clang / MSVC
-          # cl.exe. Both darwin arches build on one Apple-Silicon runner: the macOS
-          # SDK is universal, so x86_64-apple-darwin cross-compiles cleanly there
-          # (macos-13, the old Intel runner, has been retired by GitHub).
+          # macOS + Windows: use the platform's native toolchain (cargo
+          # build), not zig. Native is exactly what CI already exercises
+          # (green macos + windows test jobs), and rusqlite's bundled SQLite C
+          # compiles with clang / MSVC cl.exe. Both darwin arches build on one
+          # Apple-Silicon runner: the macOS SDK is universal, so
+          # x86_64-apple-darwin cross-compiles cleanly there (macos-13, the
+          # old Intel runner, has been retired by GitHub).
           - target: aarch64-apple-darwin
             os: macos-14
             name: darwin-arm64
@@ -142,15 +144,17 @@ jobs:
             fi
           done
           cd release
-          # One SBOM per binary (skip any SBOM already present so we never SBOM a SBOM).
+          # One SBOM per binary (skip any SBOM already present, so that the
+          # loop never SBOMs a SBOM).
           for f in podspine-${TAG}-*; do
             case "$f" in *.sbom.cdx.json) continue ;; esac
             syft "$f" -o "cyclonedx-json=${f}.sbom.cdx.json"
           done
-          # One checksums file over binaries + SBOMs, each listed exactly once; cosign
-          # signs it, so a verifier trusts every artifact transitively through its hash.
-          # (A single podspine-${TAG}-* glob now covers binaries AND their SBOMs — the
-          # old two-glob form double-counted the SBOMs.)
+          # One checksums file over binaries + SBOMs, each listed exactly
+          # once; cosign signs it, so a verifier trusts every artifact
+          # transitively through its hash. (A single podspine-${TAG}-* glob
+          # now covers binaries AND their SBOMs: the old two-glob form
+          # double-counted the SBOMs.)
           sha256sum podspine-${TAG}-* > checksums.txt
           cosign sign-blob --bundle checksums.txt.sigstore.json checksums.txt --yes
       - name: SLSA build provenance
@@ -183,8 +187,9 @@ jobs:
             release/checksums.txt.sigstore.json
             release/podspine.intoto.jsonl
           )
-          # A tag with a hyphen (v1.0.0-rc.1, -beta …) is a pre-release: mark it so it
-          # doesn't become the repo's "Latest release". SemVer build/pre-release marker.
+          # A tag with a hyphen (v1.0.0-rc.1, -beta …) is a pre-release: mark
+          # it, so that it does not become the repo's "Latest release". This
+          # is the SemVer pre-release marker.
           prerelease=""
           case "$TAG" in *-*) prerelease="--prerelease" ;; esac
           if gh release view "$TAG" >/dev/null 2>&1; then

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,11 +1,12 @@
 name: Scorecard
 
-# OpenSSF Scorecard — repository-level security best-practices audit. Runs on
-# branch_protection_rule (so ruleset changes trigger a re-evaluation), a weekly
-# schedule, and pushes to main. Intentionally NOT a required check: it never runs
-# on pull_request, so requiring it would leave every PR perpetually pending. The
-# signal lives in the Security tab (Code scanning → Scorecard) and at
-# scorecard.dev once publish_results is enabled.
+# OpenSSF Scorecard: a repository-level security best-practices audit. It
+# runs on branch_protection_rule (ruleset changes then trigger a
+# re-evaluation), on a weekly schedule, and on pushes to main. It is
+# intentionally NOT a required check: it never runs on pull_request, so a
+# requirement on it would leave every PR perpetually pending. The signal
+# lives in the Security tab (Code scanning → Scorecard) and at scorecard.dev
+# once publish_results is enabled.
 #
 # NOTE: action refs are pinned to full commit SHAs (the repo's Actions policy
 # requires it; also satisfies Scorecard Pinned-Dependencies); Renovate keeps them current.
@@ -38,13 +39,14 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      # podspine-ci App token as Scorecard's repo_token: the Branch-Protection check
-      # needs administration:read (the default GITHUB_TOKEN can't read branch rules,
-      # so that check scores 0 / inconclusive). Sourcing it from the App also lifts
-      # the API budget to >=5,000/hr. Requires the App to be granted
-      # `administration: read`. Soft-fail: until the App secrets exist the mint
-      # yields an empty token and Scorecard falls back to GITHUB_TOKEN (Branch-
-      # Protection stays inconclusive, as it is today) rather than failing the run.
+      # podspine-ci App token as Scorecard's repo_token: the Branch-Protection
+      # check needs administration:read (the default GITHUB_TOKEN cannot read
+      # branch rules, so that check scores 0 / inconclusive). The App source
+      # also lifts the API budget to >=5,000/hr. This requires the App to be
+      # granted `administration: read`. Soft-fail: until the App secrets
+      # exist, the mint yields an empty token, and Scorecard falls back to
+      # GITHUB_TOKEN (Branch-Protection stays inconclusive, as it is today);
+      # the run does not fail.
       - name: Mint podspine-ci App token
         id: app-token
         continue-on-error: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,9 +2,10 @@ name: Security
 
 # Podspine's extra security scanners in one file: secret scanning (gitleaks), a
 # container-image CVE scan (trivy), and a GitHub Actions workflow audit (zizmor).
-# Each is its own JOB so they run in parallel and surface individually in the
-# code-scanning Security tab. Rust SAST lives in codeql.yml and Rust supply-chain
-# (cargo audit/deny) in ci.yml — this file deliberately does not duplicate them.
+# Each is its own JOB, so they run in parallel and surface individually in
+# the code-scanning Security tab. Rust SAST lives in codeql.yml, and Rust
+# supply-chain (cargo audit/deny) lives in ci.yml; this file deliberately does
+# not duplicate them.
 #
 # NOTE: all action refs are pinned to full commit SHAs (the repo's Actions policy
 # requires it; also satisfies Scorecard Pinned-Dependencies); Renovate keeps them current.
@@ -35,11 +36,12 @@ jobs:
         with:
           fetch-depth: 0 # full history so the scan covers every commit
           persist-credentials: false
-      # podspine-ci App token (>=5,000 REST req/hr) so the action's GitHub API calls
-      # don't exhaust the 1,000/hr github-actions[bot] pool. Same-repo runs only;
-      # fork PRs can't read the App secrets, so the mint is skipped (soft-fail) and
-      # the token falls back to GITHUB_TOKEN below. gitleaks-action is free for
-      # public repos / individual accounts — no GITLEAKS_LICENSE needed.
+      # podspine-ci App token (>=5,000 REST req/hr), so that the action's
+      # GitHub API calls do not exhaust the 1,000/hr github-actions[bot] pool.
+      # Same-repo runs only: fork PRs cannot read the App secrets, so the mint
+      # is skipped (soft-fail) and the token falls back to GITHUB_TOKEN below.
+      # gitleaks-action is free for public repos / individual accounts; no
+      # GITLEAKS_LICENSE is needed.
       - name: Mint podspine-ci App token
         id: app-token
         if: >-
@@ -58,9 +60,10 @@ jobs:
 
   trivy-image:
     name: trivy image scan
-    # Compiling the musl binary + building the image just to scan it is the long
-    # pole; skip it on PRs (report-only there anyway). Runs on the main push + weekly
-    # cron, which catch Alpine/ffmpeg CVEs and a broken Dockerfile before any release.
+    # The musl-binary compile plus the image build, only for a scan, is the
+    # long pole; skip it on PRs (it is report-only there anyway). It runs on
+    # the main push and the weekly cron, which catch Alpine/ffmpeg CVEs and a
+    # broken Dockerfile before any release.
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -71,9 +74,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      # The runtime-only Dockerfile COPYs a prebuilt dist/<arch>/podspine, so build
-      # the amd64 static musl binary first. Single-arch on an amd64 runner, so plain
-      # musl-gcc (links rusqlite's bundled SQLite C) is enough — no cross toolchain.
+      # The runtime-only Dockerfile COPYs a prebuilt dist/<arch>/podspine, so
+      # build the amd64 static musl binary first. This is single-arch on an
+      # amd64 runner, so plain musl-gcc (it links rusqlite's bundled SQLite C)
+      # is enough; no cross toolchain is needed.
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           targets: x86_64-unknown-linux-musl
@@ -106,9 +110,10 @@ jobs:
           output: trivy-image.sarif
           severity: CRITICAL,HIGH,MEDIUM
           ignore-unfixed: true # only fixable CVEs are actionable
-          # Report-only: findings surface in the Security tab (like scorecard) rather
-          # than red-X'ing main every time upstream discloses an ffmpeg/Alpine CVE.
-          # Flip to "1" to make it a hard gate once you want to enforce.
+          # Report-only: findings surface in the Security tab (like
+          # scorecard); they do not red-X main every time upstream discloses
+          # an ffmpeg/Alpine CVE. Flip to "1" to make it a hard gate when you
+          # want to enforce.
           exit-code: "0"
       - name: Upload SARIF
         if: always()
@@ -129,8 +134,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      # podspine-ci App token so zizmor's advisory API lookups don't 403 against the
-      # 1,000/hr github-actions[bot] pool. Same-repo only; fork PRs fall back.
+      # podspine-ci App token, so that zizmor's advisory API lookups do not
+      # 403 against the 1,000/hr github-actions[bot] pool. Same-repo only;
+      # fork PRs fall back.
       - name: Mint podspine-ci App token
         id: app-token
         if: >-
@@ -146,9 +152,10 @@ jobs:
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       - name: Install zizmor
         run: uv tool install zizmor
-      # Advisory: `|| true` keeps the SARIF flowing to the Security tab without gating
-      # merges while we confirm zizmor runs clean on these workflows. Drop `|| true` to
-      # make it enforcing once a run shows no findings we don't intend to accept.
+      # Advisory: `|| true` keeps the SARIF flowing to the Security tab
+      # without a merge gate, while zizmor's cleanliness on these workflows is
+      # confirmed. Drop `|| true` to make it enforcing once a run shows no
+      # findings that are not deliberately accepted.
       - name: Run zizmor
         run: zizmor --format sarif . > results.sarif || true
         env:

--- a/.github/workflows/tap-sync-trigger.yml
+++ b/.github/workflows/tap-sync-trigger.yml
@@ -1,18 +1,21 @@
 name: tap-sync-trigger
 
-# When a packaging-bump PR merges (the Homebrew formula + Scoop manifest sources on
-# `main` have just changed), trigger the tap's and bucket's syncs IMMEDIATELY instead
-# of waiting for their daily cron. Best-effort: a dispatch failure just leaves the cron
-# as the safety net, so this never blocks or fails the release path.
+# When a packaging-bump PR merges (the Homebrew formula + Scoop manifest
+# sources on `main` have just changed), trigger the tap's and bucket's syncs
+# IMMEDIATELY; do not wait for their daily cron. Best-effort: a dispatch
+# failure only leaves the cron as the safety net, so this never blocks or
+# fails the release path.
 #
-# WHY this trigger point (not `release: published`): at publish time the bumped manifests
-# are NOT yet on `main` — packaging-bump opens a PR; it doesn't push main. So we fire on
-# the packaging-bump PR MERGE, detected by the head-branch prefix.
+# WHY this trigger point (not `release: published`): at publish time the
+# bumped manifests are NOT yet on `main`. packaging-bump opens a PR; it does
+# not push main. So this fires on the packaging-bump PR MERGE, detected by
+# the head-branch prefix.
 #
-# SECURITY: same-repo, merged `packaging-bump/*` PR only (a fork can't reach this even by
-# naming its head that; `pull_request`, not _target). Mints a tap/bucket-scoped
-# podspine-ci App token with `actions:write` ONLY (never contents:write) — the minimal
-# cross-repo surface `workflow run` needs. Workflow-level permissions stay read-only.
+# SECURITY: same-repo, merged `packaging-bump/*` PR only (a fork cannot reach
+# this even with that head name; `pull_request`, not _target). It mints a
+# tap/bucket-scoped podspine-ci App token with `actions:write` ONLY (never
+# contents:write): the minimal cross-repo surface that `workflow run` needs.
+# Workflow-level permissions stay read-only.
 on:
   pull_request:
     types: [closed]
@@ -48,8 +51,9 @@ jobs:
           echo "::error::podspine-ci App token was empty; refusing to dispatch. Confirm the \
           App is installed on schubydoo/homebrew-podspine and scoop-podspine with Actions: write."
           exit 1
-      # Best-effort per repo: each downstream sync no-ops when the manifest is unchanged,
-      # and its daily cron stays the fallback, so a dispatch failure must not fail the job.
+      # Best-effort per repo: each downstream sync no-ops when the manifest
+      # is unchanged, and its daily cron stays the fallback, so a dispatch
+      # failure must not fail the job.
       - name: Trigger the Homebrew tap + Scoop bucket syncs
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
-# Rust build artifacts (Cargo.lock IS committed — this is a binary/app)
+# Rust build artifacts (Cargo.lock IS committed: this is a binary/app)
 /target/
 **/*.rs.bk
 
-# Scratch space — uncommitted docs, data, and scratch files
+# Scratch space: uncommitted docs, data, and scratch files
 /scratch/
 
 # Source planning docs (kept local, not committed for now)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,15 @@
-# Podspine pre-commit — shift-left quality gate for the Rust/Cargo workspace.
+# Podspine pre-commit: the shift-left quality gate for the Rust/Cargo
+# workspace.
 #
 #   commit stage : fast hygiene + fmt --check + clippy (-D warnings) + lib unit tests   (~seconds)
 #   push  stage  : full workspace test suite (incl. ffmpeg-backed integration tests)
 #
-# cargo audit / cargo deny also run at the PUSH stage locally (see below) — they need the
-# online advisory DB, and `language: system` means both binaries must be on PATH:
-# `cargo install cargo-audit cargo-deny`. Without them the pre-push hook fails.
-# Hook commands mirror .github/workflows/ci.yml exactly so the local gate and CI never
-# drift. Bypass a hook deliberately with SKIP=<id> or --no-verify.
+# cargo audit / cargo deny also run at the PUSH stage locally (see below).
+# They need the online advisory DB, and `language: system` means both
+# binaries must be on PATH: `cargo install cargo-audit cargo-deny`. Without
+# them the pre-push hook fails. Hook commands mirror
+# .github/workflows/ci.yml exactly, so the local gate and CI never drift.
+# Bypass a hook deliberately with SKIP=<id> or --no-verify.
 minimum_pre_commit_version: "3.2.0"
 default_install_hook_types: [pre-commit, pre-push]
 
@@ -20,8 +22,9 @@ repos:
       - id: end-of-file-fixer
         exclude: '^LICENSE$'
       - id: check-yaml
-        # mkdocs.yml uses the `!!python/name:` tag (Material Mermaid fence); the
-        # safe loader can't resolve it. Everything else stays safe-loaded.
+        # mkdocs.yml uses the `!!python/name:` tag (Material Mermaid fence);
+        # the safe loader cannot resolve it. Everything else stays
+        # safe-loaded.
         exclude: '^mkdocs\.yml$'
       - id: check-toml
       - id: check-merge-conflict
@@ -33,16 +36,18 @@ repos:
 
   - repo: local
     hooks:
-      # Guard: audiobook media must never be committed (fixtures live outside the repo).
+      # Guard: audiobook media must never be committed (fixtures live outside
+      # the repo).
       - id: no-audio-fixtures
         name: block audio media files
         entry: "Audio media must not be committed — keep fixtures outside the repo (e.g. /home/claude/audiobooks). Override with: git add -f + SKIP=no-audio-fixtures."
         language: fail
         files: '\.(m4b|m4a|mp3|flac|ogg|opus|aax|aaxc|aa)$'
 
-      # Guard: knope changeset fragments must have front matter + a SINGLE-line body,
-      # else the release fails ("missing front matter") or the changelog renders a
-      # `#### heading` mid-list instead of a bullet. Runs when a fragment changes.
+      # Guard: knope changeset fragments must have front matter and a
+      # SINGLE-line body. Otherwise the release fails ("missing front matter"),
+      # or the changelog renders a `#### heading` mid-list instead of a
+      # bullet. This runs when a fragment changes.
       - id: changeset-lint
         name: changeset fragment lint (knope one-line body)
         entry: sh scripts/lint_changesets.sh
@@ -81,8 +86,9 @@ repos:
         pass_filenames: false
         stages: [pre-push]
 
-      # Supply-chain checks — mirror CI's supply-chain job. No `types` filter:
-      # advisories/licenses can change independent of your source files. Need network.
+      # Supply-chain checks mirror CI's supply-chain job. No `types` filter:
+      # advisories/licenses can change independent of the source files. They
+      # need network access.
       - id: cargo-audit
         name: cargo audit (RustSec advisories)
         entry: cargo audit
@@ -97,7 +103,7 @@ repos:
         pass_filenames: false
         stages: [pre-push]
 
-      # ---- push stage: CLI end-to-end (uncomment once podspine-cli lands — Task 1.6) ----
+      # ---- push stage: CLI end-to-end (uncomment once podspine-cli lands; Task 1.6) ----
       # - id: e2e-cli
       #   name: CLI end-to-end smoke tests
       #   entry: bash scripts/e2e_test.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,24 @@ license = "AGPL-3.0-only"
 repository = "https://github.com/schubydoo/podspine"
 authors = ["schubydoo"]
 
+# Comment and doc lints. Each member crate opts in with `[lints] workspace = true`.
+# CI runs clippy with `-D warnings`, so "warn" here blocks CI but not local builds.
+[workspace.lints.clippy]
+# Identifiers in doc comments must have backticks.
+doc_markdown = "warn"
+# Each `unsafe` block must have a `// SAFETY:` comment. The workspace has no
+# `unsafe` today; this lint guards the first one.
+undocumented_unsafe_blocks = "warn"
+
+[workspace.lints.rustdoc]
+# Each [`item`] link in doc comments must resolve. Fires only under `cargo doc`
+# (the "Docs (deny warnings)" CI step), not under clippy.
+broken_intra_doc_links = "deny"
+# The CI doc step passes `--document-private-items` because this workspace is a
+# binary, not a library. Links from public items to private items are therefore
+# valid and stay clickable.
+private_intra_doc_links = "allow"
+
 # Pinned per TAD §3 (verified 2026-07-03). Member crates opt in as each pipeline
 # stage lands (`axum.workspace = true`, etc.); unreferenced entries stay inert.
 [workspace.dependencies]
@@ -44,13 +62,13 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # Metrics facade; a no-op unless a recorder is installed (`--metrics-bind`).
 metrics = "0.24.6"
 # `default-features = false` drops the crate's own hyper listener and the
-# rustls/aws-lc-rs push-gateway stack: we render from the handle and serve it
-# on our own axum listener, so none of that is reachable.
+# rustls/aws-lc-rs push-gateway stack: Podspine renders from the handle and
+# serves it on its own axum listener, so none of that is reachable.
 metrics-exporter-prometheus = { version = "0.18.3", default-features = false }
 # errors
 thiserror = "2"
 anyhow = "1"
-# process control (sync per-child timeout+kill for ffmpeg — the splitter is sync)
+# process control (sync per-child timeout+kill for ffmpeg; the splitter is sync)
 wait-timeout = "0.2"
 
 [package]
@@ -103,3 +121,6 @@ tokio = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+
+[lints]
+workspace = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,23 @@
 # syntax=docker/dockerfile:1@sha256:ecfaec9ed6d810b56388c508f4121597bfbba70d41a6dfeee4d8cad5f295fc32
 #
-# Runtime-only image: it COPYs a prebuilt static (musl) binary — no Rust toolchain
-# in the build, so `docker buildx` stays fast across linux/amd64 + linux/arm64
-# (TAD §6.4). The release pipeline (Task 3.7) builds the per-arch binaries into
-# dist/<arch>/podspine; `docker buildx build --platform ...` selects by TARGETARCH.
+# Runtime-only image: it COPYs a prebuilt static (musl) binary. There is no
+# Rust toolchain in the build, so `docker buildx` stays fast across
+# linux/amd64 + linux/arm64 (TAD §6.4). The release pipeline (Task 3.7)
+# builds the per-arch binaries into dist/<arch>/podspine;
+# `docker buildx build --platform ...` selects by TARGETARCH.
 #
-# Base is Alpine: the binary is static musl, so no glibc is needed, and Alpine's
-# ffmpeg keeps the image ~1/3 the size of debian-slim (TAD sanctions this "if size
-# matters" — it does; the ≤180MB target rules out debian's full ffmpeg).
+# The base is Alpine: the binary is static musl, so no glibc is needed, and
+# Alpine's ffmpeg keeps the image ~1/3 the size of debian-slim (the TAD
+# sanctions this "if size matters", and it does: the ≤180MB target rules out
+# debian's full ffmpeg).
 FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 
 # ffmpeg is the one runtime dependency; ca-certificates for outbound TLS if needed.
 RUN apk add --no-cache ffmpeg ca-certificates
 
-# Non-root system user; own /data before VOLUME so the anonymous volume Docker
-# creates at runtime inherits podspine ownership (else it can't write the DB).
+# A non-root system user. Own /data before VOLUME, so that the anonymous
+# volume Docker creates at runtime inherits podspine ownership (otherwise it
+# cannot write the DB).
 RUN adduser -D -H -u 10001 -s /sbin/nologin podspine \
  && mkdir -p /app /data \
  && chown podspine:podspine /app /data

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,3 @@
+# Words that `clippy::doc_markdown` must not flag as unbackticked code.
+# ".." keeps clippy's built-in list; add only real words/acronyms here.
+doc-valid-idents = ["DoS", "SQLite", "OverDrive", ".."]

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,26 +1,28 @@
-# Codecov config. Coverage is REPORTED here for visibility (PR comment + trend
-# graphs + per-crate breakdown); the REAL gate is the CI line floor in
+# Codecov config. Coverage is REPORTED here for visibility (PR comment, trend
+# graphs, per-crate breakdown). The REAL gate is the CI line floor in
 # .github/workflows/ci.yml (the `coverage (>= 90% lines)` job runs
-# `cargo llvm-cov --fail-under-lines 90`). The `project` status is informational
-# (a nudge, never a block); `patch` is a real pass/fail traffic light on new-code
-# coverage — but neither is a *required* check unless it's added to branch
-# protection. Coverage uploads from ONE Linux cell, so flags / carryforward /
-# report-merging aren't needed.
+# `cargo llvm-cov --fail-under-lines 90`). The `project` status is
+# informational (a nudge, never a block). `patch` is a real pass/fail traffic
+# light on new-code coverage. Neither is a *required* check unless it is added
+# to branch protection. Coverage uploads from ONE Linux cell, so flags,
+# carryforward, and report-merging are not needed.
 #
-# Rust note: Codecov ingests the lcov that `cargo llvm-cov --lcov` emits directly
-# — no cobertura conversion step.
+# Rust note: Codecov ingests the lcov that `cargo llvm-cov --lcov` emits
+# directly; no cobertura conversion step is needed.
 #
-# Baseline: ~94% lines excluding src/main.rs (feed/selfcheck/ui/prober/chapters/
-# index all ≥98%; splitter/cli the lowest; src/main.rs is 0% — the live server
-# wiring, not unit-testable — and is excluded from the report via `ignore` below).
+# Baseline: ~94% lines excluding src/main.rs (feed/selfcheck/ui/prober/
+# chapters/index are all ≥98%; splitter is the lowest). src/main.rs is 0% (the
+# live server wiring, not unit-testable) and is excluded from the report via
+# `ignore` below.
 #
 # Validate before deploying changes:
 #   curl -X POST --data-binary @codecov.yml https://api.codecov.io/validate
 
 codecov:
-  # ci.yml uploads coverage even when the floor step FAILS (the `!cancelled()`
-  # guard), on purpose: a coverage drop should surface exactly when a change
-  # breaks the floor. So don't gate the Codecov status on CI passing.
+  # ci.yml uploads coverage even when the floor step FAILS (the
+  # `!cancelled()` guard), on purpose: a coverage drop must surface exactly
+  # when a change breaks the floor. So do not gate the Codecov status on CI
+  # passing.
   require_ci_to_pass: false
   notify:
     wait_for_ci: false
@@ -29,32 +31,34 @@ codecov:
 coverage:
   precision: 2
   round: down # a strict floor rounds down, matching the CI --fail-under-lines gate
-  range: "88...96" # red->green band around the ~94% baseline
+  range: "88...96" # the red-to-green band around the ~94% baseline
   status:
     project:
       default:
         target: 90% # mirror the ci.yml line floor
         threshold: 1% # tolerate sub-1% drift before flagging
-        informational: true # nudge, never block — ci.yml is the source of truth
+        informational: true # a nudge, never a block; ci.yml is the source of truth
     patch:
       default:
-        # New-code (diff) coverage gate. 80% sits below the repo's ~91% overall
-        # so it flags under-tested new code without chronic red; raise it if new
-        # PRs comfortably clear a higher bar.
+        # New-code (diff) coverage gate. 80% sits below the repo's ~91%
+        # overall, so it flags under-tested new code without chronic red.
+        # Raise it when new PRs comfortably clear a higher bar.
         target: 80%
-        threshold: 0% # no slack — new code meets the target or the status goes red
+        threshold: 0% # no slack: new code meets the target, or the status goes red
         informational: false # a real pass/fail traffic light (still a non-required check)
-        if_not_found: success # docs-only PRs upload no diff → don't block them
+        if_not_found: success # docs-only PRs upload no diff; do not block them
 
-# src/main.rs is the server's live wiring (resolve config, open the index, scan,
-# bind the socket, serve) — exercised by running the app, not by unit tests. It
-# can't be meaningfully unit-tested, so exclude it from the REPORTED coverage so
-# the dashboard reflects testable code. (The CI line floor still measures the full
-# tree; it carries enough headroom to absorb this ~0.8% of lines.)
+# src/main.rs is the server's live wiring (resolve config, open the index,
+# scan, bind the socket, serve). A run of the app exercises it, not unit
+# tests. It cannot be meaningfully unit-tested, so it is excluded from the
+# REPORTED coverage, and the dashboard then reflects testable code. (The CI
+# line floor still measures the full tree; it carries enough headroom to
+# absorb this ~0.8% of lines.)
 ignore:
   - "src/main.rs"
-  # Dev-only test scaffolding (skip!/scratch/ffmpeg synths) — it only ever runs
-  # inside tests, so "coverage" of it is noise, same reasoning as src/main.rs.
+  # Dev-only test scaffolding (skip!/scratch/ffmpeg synths): it only ever
+  # runs inside tests, so "coverage" of it is noise, for the same reason as
+  # src/main.rs.
   - "crates/test-support/src/lib.rs"
 
 # The per-line PR annotations are mostly visual clutter; the comment + dashboard
@@ -76,8 +80,8 @@ comment:
 # component matcher silently does NOT pick up a `**` glob here (the component
 # renders empty even at 100% coverage), whereas explicit file paths DO match.
 # (Same quirk clauster's codecov.yml hit with its `db/**` / `hooks/**` components.)
-# So when a crate gains a module, add its `.rs` file here — a glob will look fine
-# and quietly track nothing.
+# So when a crate gains a module, add its `.rs` file here; a glob would look
+# fine and quietly track nothing.
 component_management:
   individual_components:
     - component_id: scanner

--- a/crates/chapters/Cargo.toml
+++ b/crates/chapters/Cargo.toml
@@ -14,3 +14,6 @@ podspine-prober = { path = "../prober" }
 
 [dev-dependencies]
 podspine-test-support = { path = "../test-support" }
+
+[lints]
+workspace = true

--- a/crates/chapters/src/lib.rs
+++ b/crates/chapters/src/lib.rs
@@ -3,17 +3,18 @@
 //! A companion **sidecar** beside the audio file takes precedence over embedded
 //! chapters (PRD §3.0, Task 3.8). v1 supports two sidecar formats, in priority
 //! order:
-//! 1. **`.cue`** — `INDEX 01 mm:ss:ff` timestamps at **75 frames/sec** (the
+//! 1. **`.cue`**: `INDEX 01 mm:ss:ff` timestamps at **75 frames/sec** (the
 //!    default when present).
-//! 2. **`.ffmeta` / `.ffmetadata`** — ffmpeg's metadata format (`[CHAPTER]`
+//! 2. **`.ffmeta` / `.ffmetadata`**: ffmpeg's metadata format (`[CHAPTER]`
 //!    blocks with `TIMEBASE`/`START`/`END`/`title`).
-//! 3. **Embedded** chapters (from `ffprobe`) — the fallback.
+//! 3. **Embedded** chapters (from `ffprobe`): the fallback.
 //!
 //! `.opf` / `.nfo` / OverDrive `.odm` are metadata/manifest files and are
 //! **never** treated as chapter sources. A config override can force embedded
 //! chapters even when a sidecar exists.
 //!
-//! Parsing is pure (string in, chapters out) so it is unit-tested without files.
+//! Parsing is pure (string in, chapters out), so it is unit-tested without
+//! files.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -93,8 +94,9 @@ fn sidecar(audio: &Path, exts: &[&str]) -> Option<String> {
     None
 }
 
-/// Renumber chapters' `idx` to 0-based file order (parsers build order; embedded
-/// already is, but this keeps the contract uniform).
+/// Renumber chapters' `idx` to 0-based file order (parsers build in order,
+/// and embedded chapters already are ordered, but this keeps the contract
+/// uniform).
 fn renumber(mut chapters: Vec<Chapter>) -> Vec<Chapter> {
     for (i, c) in chapters.iter_mut().enumerate() {
         c.idx = i;
@@ -330,11 +332,11 @@ FILE "book.m4b" WAVE
         let audio = dir.join("book.m4b");
         std::fs::write(&audio, b"not real audio").unwrap();
 
-        // No sidecar -> embedded.
+        // No sidecar gives embedded.
         let r = resolve(&audio, &embedded(), 100.0, false);
         assert_eq!(r.source, ChapterSource::Embedded);
 
-        // .ffmeta present -> ffmeta.
+        // A present .ffmeta gives ffmeta.
         std::fs::write(
             dir.join("book.ffmeta"),
             ";FFMETADATA1\n[CHAPTER]\nTIMEBASE=1/1000\nSTART=0\nEND=5000\ntitle=A\n",
@@ -343,7 +345,7 @@ FILE "book.m4b" WAVE
         let r = resolve(&audio, &embedded(), 100.0, false);
         assert_eq!(r.source, ChapterSource::Ffmeta);
 
-        // .cue present -> cue wins over ffmeta (higher priority).
+        // A present .cue wins over ffmeta (higher priority).
         std::fs::write(
             dir.join("book.cue"),
             "TRACK 01 AUDIO\n  TITLE \"C\"\n  INDEX 01 00:00:00\n",
@@ -367,7 +369,8 @@ FILE "book.m4b" WAVE
         for ext in ["opf", "nfo", "odm"] {
             std::fs::write(dir.join(format!("book.{ext}")), b"<metadata/>").unwrap();
         }
-        // Only metadata/manifest siblings exist -> falls back to embedded.
+        // Only metadata/manifest siblings exist, so resolve falls back to
+        // embedded.
         let r = resolve(&audio, &embedded(), 100.0, false);
         assert_eq!(r.source, ChapterSource::Embedded);
     }
@@ -385,7 +388,7 @@ FILE "book.m4b" WAVE
         let ch = parse_ffmeta(meta);
         assert_eq!(ch.len(), 2, "the END-less chapter is dropped");
         assert_eq!(ch[0].end_sec, 2.0);
-        assert_eq!(ch[1].start_sec, 2.0); // TIMEBASE 0/0 rejected -> 1/1000 default
+        assert_eq!(ch[1].start_sec, 2.0); // TIMEBASE 0/0 is rejected; 1/1000 stays.
         assert_eq!(ch[1].end_sec, 6.0);
     }
 
@@ -394,7 +397,8 @@ FILE "book.m4b" WAVE
         let dir = scratch("chapters-fallthrough");
         let audio = dir.join("book.m4b");
         std::fs::write(&audio, b"x").unwrap();
-        // A .cue with no INDEX parses to zero chapters -> fall through to .ffmeta.
+        // A .cue with no INDEX parses to zero chapters, so resolve falls
+        // through to .ffmeta.
         std::fs::write(dir.join("book.cue"), "REM nothing usable here\n").unwrap();
         std::fs::write(
             dir.join("book.ffmeta"),

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -17,3 +17,6 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 podspine-test-support = { path = "../test-support" }
+
+[lints]
+workspace = true

--- a/crates/config/src/book_overrides.rs
+++ b/crates/config/src/book_overrides.rs
@@ -205,9 +205,10 @@ mod tests {
         std::fs::write(&audio, b"x").unwrap();
         assert_eq!(load(&audio, &lib).unwrap(), None, "no sidecar → Ok(None)");
 
-        // An unknown key (typo) is a parse error → per-book warning, not fatal.
-        std::fs::write(lib.join("Book.podspine.toml"), b"stroage_mode = \"saver\"").unwrap();
-        assert!(load(&audio, &lib).is_err(), "unknown key → Err");
+        // An unknown key (a typo, here a stray plural) is a parse error: a
+        // per-book warning, not fatal.
+        std::fs::write(lib.join("Book.podspine.toml"), b"storage_modes = \"saver\"").unwrap();
+        assert!(load(&audio, &lib).is_err(), "an unknown key must give Err");
         let _ = std::fs::remove_dir_all(&lib);
     }
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -3,8 +3,8 @@
 //!
 //! The library path is the only required input; everything else has a default,
 //! so `podspine --library ./books` just works. Failures (missing library,
-//! unparseable bind address, absent ffmpeg/ffprobe) surface as a clear fatal
-//! error at startup — never mid-request. See TAD §4.
+//! unparsable bind address, absent ffmpeg/ffprobe) surface as a clear fatal
+//! error at startup, never mid-request. See TAD §4.
 
 use std::net::{IpAddr, SocketAddr};
 use std::path::{Path, PathBuf};
@@ -23,8 +23,9 @@ const DEFAULT_DATA_DIR: &str = "./data";
 const DEFAULT_CACHE_SIZE_BYTES: u64 = 2 * 1024 * 1024 * 1024;
 
 /// How a **chaptered** book's per-chapter episodes are produced and stored.
-/// Whole-file episodes (MP3-folder tracks, chapterless single files) ignore this
-/// — they are streamed in place from the library, never extracted (Sprint 6.2).
+/// Whole-file episodes (MP3-folder tracks, chapterless single files) ignore
+/// this: they are streamed in place from the library, never extracted
+/// (Sprint 6.2).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, ValueEnum, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum StorageMode {
@@ -38,7 +39,7 @@ pub enum StorageMode {
 }
 
 impl StorageMode {
-    /// The canonical label for this mode (`"full"`/`"saver"`) — the TOML/CLI
+    /// The canonical label for this mode (`"full"`/`"saver"`): the TOML/CLI
     /// spelling, and the TEXT the index persists in `book.storage_mode`.
     #[must_use]
     pub fn label(self) -> &'static str {
@@ -59,27 +60,30 @@ impl StorageMode {
     }
 }
 
-/// Whether to re-encode sources no podcatcher can play, and to what (Task 5.2).
+/// Whether to re-encode sources that no podcatcher can play, and to what
+/// (Task 5.2).
 ///
 /// Off by default: Podspine is copy-first, and a re-encode both costs CPU at
-/// ingest and loses quality. Turn it on for a library of FLAC/Ogg/Opus/ALAC books
-/// that clients refuse to play. Podcast-safe sources (MP3, AAC) are never
-/// re-encoded, whatever this is set to.
+/// ingest and loses quality. Turn it on for a library of FLAC/Ogg/Opus/ALAC
+/// books that clients refuse to play. Podcast-safe sources (MP3, AAC) are
+/// never re-encoded, independent of this setting.
 ///
-/// A transcoded book is always stored `full`, even under `storage_mode = "saver"`:
-/// a re-encode is not byte-reproducible across ffmpeg builds, so regenerating a
-/// chapter on demand could serve bytes whose length no longer matches the
-/// `enclosure length` already published in the feed.
+/// A transcoded book is always stored `full`, even under
+/// `storage_mode = "saver"`: a re-encode is not byte-reproducible across
+/// ffmpeg builds, so a chapter regenerated on demand could serve bytes whose
+/// length no longer matches the `enclosure length` already published in the
+/// feed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, ValueEnum, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum TranscodeMode {
-    /// Never re-encode — serve every source stream-copied (the default).
+    /// Never re-encode: serve every source stream-copied (the default).
     #[default]
     Off,
     /// Re-encode non-podcast-safe sources to AAC 128 kbps (`.m4a`).
     Aac,
-    /// Re-encode non-podcast-safe sources to MP3 128 kbps — the fallback for
-    /// clients that still choke on AAC. Needs an ffmpeg built with `libmp3lame`.
+    /// Re-encode non-podcast-safe sources to MP3 128 kbps: the fallback for
+    /// clients that still do not play AAC. This needs an ffmpeg built with
+    /// `libmp3lame`.
     Mp3,
 }
 
@@ -90,7 +94,7 @@ impl TranscodeMode {
         !matches!(self, TranscodeMode::Off)
     }
 
-    /// The canonical label for this mode (`"off"`/`"aac"`/`"mp3"`) — the
+    /// The canonical label for this mode (`"off"`/`"aac"`/`"mp3"`): the
     /// TOML/CLI spelling, and the TEXT the index persists in `book.transcode`.
     #[must_use]
     pub fn label(self) -> &'static str {
@@ -140,10 +144,11 @@ pub struct Cli {
     /// Force embedded chapters, ignoring any `.cue`/`.ffmeta` sidecar.
     #[arg(long, env = "PODSPINE_FORCE_EMBEDDED_CHAPTERS")]
     pub force_embedded_chapters: bool,
-    /// Remux a non-faststart whole-file mp4 (`moov` after `mdat`) to faststart on
-    /// demand so podcast clients seek quickly, instead of serving it in place. The
-    /// remux is stream-copied and cache-managed (counts against the `saver` cache
-    /// cap), never a pinned duplicate. Default off: serve in place + log a callout.
+    /// Remux a non-faststart whole-file mp4 (`moov` after `mdat`) to faststart
+    /// on demand, so that podcast clients seek quickly, instead of serving it
+    /// in place. The remux is stream-copied and cache-managed (it counts
+    /// against the `saver` cache cap), never a pinned duplicate. Default off:
+    /// serve in place and log a notice.
     #[arg(long, env = "PODSPINE_REMUX_NON_FASTSTART")]
     pub remux_non_faststart: bool,
     /// Chapter storage strategy for **chaptered** books: `full` pre-splits every
@@ -153,10 +158,11 @@ pub struct Cli {
     /// chapterless singles), which are served in place from the library.
     #[arg(long, env = "PODSPINE_STORAGE_MODE")]
     pub storage_mode: Option<StorageMode>,
-    /// Re-encode sources podcatchers can't play (FLAC/Ogg/Opus/ALAC) to `aac`
-    /// 128k or `mp3` 128k; `off` (default) serves every source stream-copied.
-    /// MP3/AAC sources are never re-encoded. A transcoded book is always stored
-    /// `full` (a re-encode can't be regenerated byte-for-byte on demand).
+    /// Re-encode sources that podcatchers cannot play (FLAC/Ogg/Opus/ALAC) to
+    /// `aac` 128k or `mp3` 128k; `off` (default) serves every source
+    /// stream-copied. MP3/AAC sources are never re-encoded. A transcoded book
+    /// is always stored `full` (a re-encode cannot be regenerated
+    /// byte-for-byte on demand).
     #[arg(long, env = "PODSPINE_TRANSCODE")]
     pub transcode: Option<TranscodeMode>,
     /// Max disk for the on-demand chapter cache in `saver` mode (e.g. `2GB`,
@@ -167,11 +173,12 @@ pub struct Cli {
     /// size-only eviction). Ignored in `full` mode.
     #[arg(long, env = "PODSPINE_CACHE_TTL")]
     pub cache_ttl: Option<String>,
-    /// Serve Prometheus metrics on this address, e.g. `127.0.0.1:9090`. Unset =
-    /// no metrics endpoint and no recorder (the instrumentation compiles to
-    /// no-ops). Deliberately a *separate* listener from `--bind`: metrics expose
-    /// operator data — library size, error counts — that has no business on the
-    /// same surface as internet-facing feeds. Bind it to loopback or the LAN.
+    /// Serve Prometheus metrics on this address, e.g. `127.0.0.1:9090`. Unset
+    /// means no metrics endpoint and no recorder (the instrumentation compiles
+    /// to no-ops). This is deliberately a *separate* listener from `--bind`:
+    /// metrics expose operator data (library size, error counts) that has no
+    /// business on the same surface as internet-facing feeds. Bind it to
+    /// loopback or the LAN.
     #[arg(long, env = "PODSPINE_METRICS_BIND")]
     pub metrics_bind: Option<String>,
     /// Optional TOML config file.
@@ -225,35 +232,38 @@ pub struct Config {
     pub default_cover_url: Option<String>,
     /// Ignore `.cue`/`.ffmeta` sidecars and always use embedded chapters.
     pub force_embedded_chapters: bool,
-    /// Remux a non-faststart whole-file mp4 (`moov` after `mdat`) to faststart on
-    /// demand rather than serving it in place — so podcast clients seek quickly.
-    /// The remuxed copy is stream-copied and cache-managed (evicted under the
-    /// `saver` cap, regenerated on demand), never a pinned duplicate. Default off:
-    /// such books serve in place and a one-line callout is logged at ingest. No
-    /// effect on faststart mp4, MP3/OGG/FLAC, or chaptered books (Sprint 6.3).
+    /// Remux a non-faststart whole-file mp4 (`moov` after `mdat`) to faststart
+    /// on demand, instead of serving it in place, so that podcast clients seek
+    /// quickly. The remuxed copy is stream-copied and cache-managed (evicted
+    /// under the `saver` cap, regenerated on demand), never a pinned
+    /// duplicate. Default off: such books serve in place, and the ingest logs
+    /// a one-line notice. There is no effect on faststart mp4, MP3/OGG/FLAC,
+    /// or chaptered books (Sprint 6.3).
     pub remux_non_faststart: bool,
     /// How **chaptered** books are produced/stored: `full` (pre-split every
-    /// chapter to disk) or `saver` (split at ingest, then cache regenerations on
-    /// demand). Applies library-wide to chaptered books, which materialize under
-    /// `data_dir`. Whole-file episodes (MP3-folder tracks, chapterless single
-    /// files) are unaffected — they stream in place from the library (Sprint 6.2).
+    /// chapter to disk) or `saver` (split at ingest, then cache regenerations
+    /// on demand). This applies library-wide to chaptered books, which
+    /// materialize under `data_dir`. Whole-file episodes (MP3-folder tracks,
+    /// chapterless single files) are unaffected: they stream in place from the
+    /// library (Sprint 6.2).
     pub storage_mode: StorageMode,
-    /// Whether non-podcast-safe sources (FLAC/Vorbis/Opus/ALAC) are re-encoded at
-    /// ingest, and to what (Task 5.2). `Off` by default — Podspine is copy-first.
-    /// MP3/AAC sources are never re-encoded. A transcoded book is materialized
-    /// `full` regardless of `storage_mode`; see [`TranscodeMode`].
+    /// Whether non-podcast-safe sources (FLAC/Vorbis/Opus/ALAC) are re-encoded
+    /// at ingest, and to what (Task 5.2). `Off` by default: Podspine is
+    /// copy-first. MP3/AAC sources are never re-encoded. A transcoded book is
+    /// materialized `full`, independent of `storage_mode`; see
+    /// [`TranscodeMode`].
     pub transcode: TranscodeMode,
     /// Cache size cap in bytes for `saver` mode (`None` = unbounded).
     pub cache_size_bytes: Option<u64>,
     /// TTL for cached chapters in `saver` mode (`None` = size-only eviction).
     pub cache_ttl: Option<Duration>,
     /// Address for the Prometheus metrics listener (`None` = metrics disabled,
-    /// no recorder installed). Always a second listener, never `bind` — see the
+    /// no recorder installed). Always a second listener, never `bind`; see the
     /// `Cli::metrics_bind` note on why this surface is kept separate.
     pub metrics_bind: Option<SocketAddr>,
 }
 
-/// Configuration failures — all fatal, all reported at startup.
+/// Configuration failures: all fatal, all reported at startup.
 #[derive(Debug, thiserror::Error)]
 pub enum ConfigError {
     /// No library path from any source.
@@ -332,7 +342,7 @@ pub enum ConfigError {
     ParseConfig {
         /// The path.
         path: PathBuf,
-        /// TOML error (boxed — `toml::de::Error` is large, keeping
+        /// TOML error (boxed: `toml::de::Error` is large, and the box keeps
         /// `ConfigError`/`Result` small; see clippy `result_large_err`).
         source: Box<toml::de::Error>,
     },
@@ -350,7 +360,7 @@ impl Config {
         Ok(config)
     }
 
-    /// Merge CLI/env over TOML over defaults (pure — no filesystem or process
+    /// Merge CLI/env over TOML over defaults (pure: no filesystem or process
     /// checks). `validate`/`preflight` do the environment-touching work.
     pub fn resolve(cli: &Cli, file: &FileConfig) -> Result<Self, ConfigError> {
         let library = cli
@@ -447,8 +457,9 @@ impl Config {
         if !self.library.is_dir() {
             return Err(ConfigError::LibraryNotDir(self.library.clone()));
         }
-        // Catch the metrics/feed surface collision here rather than as an opaque
-        // "address in use" from the second listener half a second into startup.
+        // Catch the metrics/feed surface collision here, not as an opaque
+        // "address in use" from the second listener half a second into
+        // startup.
         if let Some(metrics) = self.metrics_bind
             && binds_collide(metrics, self.bind)
         {
@@ -465,8 +476,8 @@ impl Config {
     }
 }
 
-/// Load a TOML config file. `None` yields an empty config; an explicit path that
-/// can't be read or parsed is a fatal error.
+/// Load a TOML config file. `None` yields an empty config; an explicit path
+/// that cannot be read or parsed is a fatal error.
 fn load_file(path: Option<&Path>) -> Result<FileConfig, ConfigError> {
     let Some(path) = path else {
         return Ok(FileConfig::default());
@@ -483,7 +494,7 @@ fn load_file(path: Option<&Path>) -> Result<FileConfig, ConfigError> {
 
 /// Whether two listeners would fight over the same port.
 ///
-/// Equality isn't enough on two counts:
+/// Equality is not enough, for two reasons:
 ///
 /// - A wildcard bind claims every interface, so `0.0.0.0:8080` and
 ///   `127.0.0.1:8080` collide even though the addresses differ.
@@ -511,8 +522,9 @@ fn canonical_ip(ip: IpAddr) -> IpAddr {
     }
 }
 
-/// Verify `ffmpeg` and `ffprobe` are on PATH by execing `-version`. Fails fast so
-/// a missing toolchain is a startup error, not a mid-request surprise.
+/// Verify that `ffmpeg` and `ffprobe` are on PATH: exec `-version`. This
+/// fails fast, so a missing toolchain is a startup error, not a mid-request
+/// surprise.
 pub fn preflight() -> Result<(), ConfigError> {
     for tool in ["ffmpeg", "ffprobe"] {
         let ran = Command::new(tool)
@@ -559,7 +571,8 @@ fn parse_size(s: &str) -> Result<Option<u64>, String> {
         other => return Err(format!("unknown size unit {other:?} (use B/KB/MB/GB/TB)")),
     };
     let bytes = (value * mult as f64) as u64;
-    // A positive-but-tiny value rounding to 0 bytes is a mistake, not "unbounded".
+    // A positive but tiny value that rounds to 0 bytes is a mistake, not
+    // "unbounded".
     Ok(if bytes == 0 { None } else { Some(bytes) })
 }
 
@@ -663,7 +676,7 @@ mod tests {
 
     #[test]
     fn default_cover_url_resolves_from_cli_over_file_and_defaults_none() {
-        // Unset everywhere -> None.
+        // Unset everywhere gives `None`.
         let c = Config::resolve(&cli(Some("/books")), &FileConfig::default()).unwrap();
         assert_eq!(c.default_cover_url, None);
 
@@ -755,8 +768,9 @@ mod tests {
 
     #[test]
     fn a_wildcard_feed_bind_collides_with_a_specific_metrics_bind() {
-        // 0.0.0.0:8080 already claims 127.0.0.1:8080 — without this the second
-        // listener dies with a bare "address already in use" at startup.
+        // 0.0.0.0:8080 already claims 127.0.0.1:8080. Without this check, the
+        // second listener dies with a bare "address already in use" at
+        // startup.
         assert!(matches!(
             validate_binds("cfg-collide-wild", "0.0.0.0:8080", "127.0.0.1:8080"),
             Err(ConfigError::MetricsBindConflict { .. })
@@ -816,7 +830,7 @@ mod tests {
         // Folding must not make unrelated addresses collide.
         let elsewhere: SocketAddr = "[::ffff:192.0.2.1]:8080".parse().unwrap();
         assert!(!binds_collide(elsewhere, loopback));
-        // ...nor override the port check.
+        // It must also not override the port check.
         let mapped_other_port: SocketAddr = "[::ffff:127.0.0.1]:9090".parse().unwrap();
         assert!(!binds_collide(mapped_other_port, loopback));
     }
@@ -892,9 +906,10 @@ mod tests {
 
     #[test]
     fn preflight_matches_ffmpeg_availability() {
-        // ffmpeg/ffprobe aren't on every runner (e.g. the informational Windows
-        // leg, or a bare dev box), so don't hard-require them — assert instead that
-        // preflight's result MATCHES whether they're actually invocable.
+        // ffmpeg/ffprobe are not on every runner (e.g. the informational
+        // Windows leg, or a bare dev box), so do not hard-require them.
+        // Instead, assert that preflight's result MATCHES whether they are
+        // actually invocable.
         let have = ["ffmpeg", "ffprobe"].iter().all(|t| {
             std::process::Command::new(t)
                 .arg("-version")
@@ -965,8 +980,8 @@ mod tests {
     #[test]
     fn mode_labels_are_pinned_and_round_trip() {
         // These labels are persisted in the index (`book.storage_mode` /
-        // `book.transcode`), so changing one would re-ingest every library on
-        // upgrade — pin all values.
+        // `book.transcode`), so a change to one would re-ingest every library
+        // on upgrade. Pin all values.
         for (mode, label) in [(StorageMode::Full, "full"), (StorageMode::Saver, "saver")] {
             assert_eq!(mode.label(), label);
             assert_eq!(StorageMode::from_label(label), Some(mode));
@@ -979,7 +994,7 @@ mod tests {
             assert_eq!(mode.label(), label);
             assert_eq!(TranscodeMode::from_label(label), Some(mode));
         }
-        // Unknown or empty labels don't parse (the index reads them as None).
+        // Unknown or empty labels do not parse (the index reads them as None).
         assert_eq!(StorageMode::from_label(""), None);
         assert_eq!(StorageMode::from_label("Saver"), None);
         assert_eq!(TranscodeMode::from_label(""), None);
@@ -1022,12 +1037,14 @@ mod tests {
 
     #[test]
     fn validate_rejects_a_missing_or_non_dir_library() {
-        // Own subdir — must NOT share a fixed path with any sibling test, or the
-        // parallel runner races `scratch()`'s wipe-and-recreate against
-        // `validate_accepts_a_real_dir_and_creates_data_dir` (uses `-validate`).
+        // Own subdir: it must NOT share a fixed path with any sibling test.
+        // Otherwise the parallel runner races `scratch()`'s wipe-and-recreate
+        // against `validate_accepts_a_real_dir_and_creates_data_dir` (which
+        // uses `-validate`).
         let tmp = scratch("cfg-validate-reject");
 
-        // --library points at a real FILE (not a directory) → LibraryNotDir.
+        // --library points at a real FILE (not a directory), which gives
+        // `LibraryNotDir`.
         let as_file = tmp.join("not-a-dir");
         std::fs::write(&as_file, b"x").unwrap();
         let c = Config::resolve(
@@ -1037,7 +1054,7 @@ mod tests {
         .unwrap();
         assert!(matches!(c.validate(), Err(ConfigError::LibraryNotDir(_))));
 
-        // A missing --library → LibraryNotFound.
+        // A missing --library gives `LibraryNotFound`.
         let missing = tmp.join("nope");
         let c2 = Config::resolve(
             &cli(Some(missing.to_str().unwrap())),
@@ -1060,8 +1077,8 @@ mod tests {
 
     #[test]
     fn validate_reports_data_dir_when_the_path_is_unwritable() {
-        // library is a real dir (passes exists/is_dir), but data_dir sits UNDER a
-        // regular file, so create_dir_all fails -> ConfigError::DataDir.
+        // library is a real dir (passes exists/is_dir), but data_dir sits
+        // UNDER a regular file, so create_dir_all fails: `ConfigError::DataDir`.
         let tmp = scratch("cfg-datadir");
         let blocker = tmp.join("iam-a-file");
         std::fs::write(&blocker, b"x").unwrap();

--- a/crates/feed/Cargo.toml
+++ b/crates/feed/Cargo.toml
@@ -14,3 +14,6 @@ rss = { workspace = true }
 blake3 = { workspace = true }
 time = { workspace = true }
 thiserror = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/feed/src/lib.rs
+++ b/crates/feed/src/lib.rs
@@ -6,8 +6,9 @@
 //! - **Sequential `<pubDate>`, oldest = chapter 1.** Dates are anchored to the
 //!   source mtime and stepped so every episode lands in the past and pubDates are
 //!   strictly increasing with chapter order.
-//! - **Stable `<guid>`** = `blake3(book.id : idx : source_mtime)` — stable across
-//!   re-runs of an unchanged source; changes only when the source mtime changes.
+//! - **Stable `<guid>`** = `blake3(book.id : idx : source_mtime)`. It is
+//!   stable across re-runs of an unchanged source; it changes only when the
+//!   source mtime changes.
 //! - Every item carries `<itunes:episode>`, `<itunes:duration>` (`HH:MM:SS`) and
 //!   an `<enclosure>` whose `length` is the **real** output byte size.
 //!
@@ -24,8 +25,8 @@ pub mod selfcheck;
 
 const PODCAST_NS: &str = "https://podcastindex.org/namespace/1.0";
 
-/// Seconds between successive episode pubDates. Only the *ordering* matters to
-/// podcast apps; the spacing just keeps the dates visibly distinct.
+/// Seconds between successive episode pubDates. Only the *ordering* matters
+/// to podcast apps; the spacing only keeps the dates visibly distinct.
 const PUBDATE_STEP_SECS: i64 = 60;
 
 /// One episode's inputs to the feed.
@@ -37,7 +38,7 @@ pub struct FeedEpisode {
     pub title: String,
     /// Absolute URL to the audio file (the `<enclosure>` url).
     pub audio_url: String,
-    /// Real output size in bytes — the `<enclosure>` `length`.
+    /// Real output size in bytes: the `<enclosure>` `length`.
     pub byte_length: u64,
     /// Episode duration in seconds.
     pub duration_sec: f64,
@@ -48,7 +49,7 @@ pub struct FeedEpisode {
 /// One book's inputs to the feed.
 #[derive(Debug, Clone)]
 pub struct FeedBook {
-    /// Opaque, stable book id — part of each episode guid.
+    /// Opaque, stable book id: part of each episode guid.
     pub id: String,
     /// Feed/channel title.
     pub title: String,
@@ -58,7 +59,8 @@ pub struct FeedBook {
     pub description: Option<String>,
     /// Cover image URL (`itunes:image`, per-item and channel-level).
     pub cover_url: Option<String>,
-    /// Source file mtime (epoch seconds) — pubDate anchor + guid material.
+    /// Source file mtime (epoch seconds): the pubDate anchor and guid
+    /// material.
     pub source_mtime: i64,
     /// The feed's own URL (channel `<link>`).
     pub self_url: String,
@@ -83,9 +85,10 @@ pub fn format_itunes_duration(secs: f64) -> String {
     format!("{h:02}:{m:02}:{s:02}")
 }
 
-/// pubDate epoch for episode `idx` of `n`, anchored so the last episode sits at
-/// `anchor` and earlier ones step backwards — i.e. every date is `<= anchor`
-/// (in the past) and strictly increasing with `idx` (chapter 1 oldest).
+/// pubDate epoch for episode `idx` of `n`, anchored so that the last episode
+/// sits at `anchor` and earlier ones step backwards. So every date is
+/// `<= anchor` (in the past) and strictly increases with `idx` (chapter 1 is
+/// the oldest).
 ///
 /// Public so the scanner can persist the same value it would render, keeping the
 /// index and the feed in agreement.
@@ -109,7 +112,8 @@ fn format_rfc2822(epoch: i64) -> String {
 }
 
 /// Build the RSS [`Channel`] for a book. Items are emitted in chapter order
-/// (oldest first); ordering guarantees come from pubDate + `itunes:episode`.
+/// (oldest first); the ordering guarantees come from pubDate and
+/// `itunes:episode`.
 pub fn build_channel(book: &FeedBook) -> Channel {
     let n = book.episodes.len();
 
@@ -159,12 +163,13 @@ pub fn build_channel(book: &FeedBook) -> Channel {
     ch_it.set_author(book.author.clone());
     ch_it.set_image(book.cover_url.clone());
     ch_it.set_summary(book.description.clone());
-    // Feeds are private capability URLs — always ask directories not to list them.
+    // Feeds are private capability URLs. Always ask directories not to list
+    // them.
     ch_it.set_block(Some("Yes".to_string()));
     channel.set_itunes_ext(Some(ch_it));
 
-    // The rss crate emits xmlns:itunes automatically when itunes_ext is set; we
-    // only need to declare the podcast namespace here.
+    // The rss crate emits xmlns:itunes automatically when itunes_ext is set;
+    // only the podcast namespace needs a declaration here.
     let mut ns = BTreeMap::new();
     ns.insert("podcast".to_string(), PODCAST_NS.to_string());
     channel.set_namespaces(ns);
@@ -178,9 +183,9 @@ pub fn render(book: &FeedBook) -> String {
     build_channel(book).to_string()
 }
 
-/// Build, self-check, and render a book's feed — returning the XML only if the
-/// feed passes [`selfcheck::check`]. This is the entry point the server should
-/// use so a broken feed is never served.
+/// Build, self-check, and render a book's feed. Return the XML only when the
+/// feed passes [`selfcheck::check`]. This is the entry point for the server,
+/// so that a broken feed is never served.
 pub fn render_checked(book: &FeedBook) -> Result<String, Vec<selfcheck::SelfCheckError>> {
     let channel = build_channel(book);
     selfcheck::check(&channel)?;

--- a/crates/feed/src/selfcheck.rs
+++ b/crates/feed/src/selfcheck.rs
@@ -1,10 +1,12 @@
-//! Feed self-check — validate a built [`rss::Channel`] before it is ever served.
+//! Feed self-check: validate a built [`rss::Channel`] before it is ever
+//! served.
 //!
 //! This guards the failure modes that make podcast apps misbehave: episodes out
 //! of order (non-monotonic pubDates), a missing `enclosure length`, or a missing
 //! `itunes:duration`/`itunes:episode`. It operates on the *rendered* channel (not
-//! the domain input) so it catches builder bugs too, and it parses pubDates back
-//! to real timestamps so the ordering check is genuine. (PRD S4, TAD §4.)
+//! the domain input), so it catches builder bugs too. It parses pubDates
+//! back to real timestamps, so the ordering check is genuine. (PRD S4,
+//! TAD §4.)
 
 use rss::Channel;
 use time::OffsetDateTime;
@@ -55,8 +57,8 @@ pub enum SelfCheckError {
         /// The raw pubDate string, if any.
         value: String,
     },
-    /// Ordered by `itunes:episode`, pubDates are not strictly increasing — the
-    /// classic "episodes play out of order" bug.
+    /// Ordered by `itunes:episode`, pubDates are not strictly increasing:
+    /// the classic "episodes play out of order" bug.
     #[error("pubDate for episode {episode} is not later than the previous episode")]
     NonMonotonicPubDates {
         /// The episode whose pubDate breaks the strictly-increasing order.
@@ -80,8 +82,8 @@ pub fn check(channel: &Channel) -> Result<SelfCheckReport, Vec<SelfCheckError>> 
     }
 
     let mut errors = Vec::new();
-    // (episode, pubdate_epoch) for the monotonicity check — only items that have
-    // both a parseable episode and pubDate contribute.
+    // (episode, pubdate_epoch) for the monotonicity check. Only items that
+    // have both a parseable episode and pubDate contribute.
     let mut ordered: Vec<(i64, i64)> = Vec::new();
 
     for (idx, item) in items.iter().enumerate() {
@@ -183,7 +185,8 @@ mod tests {
     fn broken_pubdate_order_is_rejected() {
         let mut channel = build_channel(&sample(3));
         let mut items = channel.items().to_vec();
-        // Make episode 2 (item idx 1) far older than episode 1 -> out of order.
+        // Make episode 2 (item idx 1) far older than episode 1, so the order
+        // breaks.
         items[1].set_pub_date(Some("Thu, 01 Jan 1970 00:00:00 +0000".to_string()));
         channel.set_items(items);
 

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -34,3 +34,6 @@ axum = { workspace = true }
 tokio = { workspace = true }
 tower = { version = "=0.5.3", features = ["util"] }
 http-body-util = "=0.1.5"
+
+[lints]
+workspace = true

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -1,30 +1,36 @@
 //! `http` — the Axum HTTP surface.
 //!
 //! Routes split into two surfaces (v1.5):
-//! - **Browse UI (keyed by human `slug`)** — meant for the LAN / behind
-//!   proxy-auth; it enumerates the library, so it must not be publicly exposed:
+//! - **Browse UI (keyed by human `slug`)**: meant for the LAN or behind
+//!   proxy-auth. It enumerates the library, so it must not be publicly
+//!   exposed:
 //!   - `GET /` — the browsable book grid.
 //!   - `GET /book/{slug}` — a book's page: copy-feed-URL, QR, how-to panel.
-//! - **Public capability surface (keyed by unguessable `feed_id`)** — safe to
-//!   expose externally; a guessed id reveals nothing (404):
-//!   - `GET /feed/{feed_id}.xml` — the podcast feed (built from the index and
-//!     passed through the feed self-check before serving).
-//!   - `GET /audio/{feed_id}/{number}` — an episode file with HTTP Range support
-//!     (206 / `Content-Range` / 416) via `axum-range`.
+//! - **Public capability surface (keyed by unguessable `feed_id`)**: safe to
+//!   expose externally. A guessed id reveals nothing (404):
+//!   - `GET /feed/{feed_id}.xml` — the podcast feed. The handler builds it
+//!     from the index and passes it through the feed self-check before it
+//!     serves it.
+//!   - `GET /audio/{feed_id}/{number}` — an episode file with HTTP Range
+//!     support (206 / `Content-Range` / 416) via `axum-range`.
 //!   - `GET /cover/{feed_id}` — the book's cover image.
 //! - `GET /healthz` — liveness.
 //!
-//! Book/episode keys are resolved server-side through the index; the file path
-//! served comes from the database (written at scan time), never built from user
-//! input. Hardening (Task 3.5, TAD §7): the human slug is validated against an
-//! allow-list charset ([`valid_slug`]) and the capability id against
-//! [`valid_feed_id`], so `..`/separators/absolute markers 404 before touching
-//! the DB or filesystem; as defense-in-depth the resolved audio path is still
-//! canonicalized and asserted to live under a trusted root — the data dir, or the
-//! library root for whole-file episodes served in place (Sprint 6.2); a
-//! `ConcurrencyLimitLayer` bounds in-flight requests alongside the timeout and
-//! body-limit layers. Errors never leak filesystem paths or ffmpeg stderr (that
-//! detail is logged, collapsed to a bare status for the client). See TAD §4/§7.
+//! The handlers resolve book/episode keys server-side through the index. The
+//! served file path comes from the database (written at scan time); it is
+//! never built from user input. Hardening (Task 3.5, TAD §7):
+//! - The slug must match an allow-list charset ([`valid_slug`]), and the
+//!   capability id must match [`valid_feed_id`]. So `..`, separators, and
+//!   absolute markers 404 before they touch the DB or the filesystem.
+//! - As defense in depth, the resolved audio path is still canonicalized and
+//!   asserted to live under a trusted root: the data dir, or the library
+//!   root for whole-file episodes served in place (Sprint 6.2).
+//! - A `ConcurrencyLimitLayer` bounds in-flight requests, alongside the
+//!   timeout and body-limit layers.
+//! - Errors never leak filesystem paths or ffmpeg stderr. That detail is
+//!   logged; the client gets a bare status.
+//!
+//! See TAD §4/§7.
 
 use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
@@ -62,11 +68,12 @@ use podspine_ui::{
 const MAX_INFLIGHT_REQUESTS: usize = 512;
 
 /// Whether a URL slug is safe to use as an opaque index key. Allow-list only:
-/// non-empty and `[a-z0-9-]` — exactly what the scanner's `slugify` produces.
+/// non-empty and `[a-z0-9-]`, exactly what the scanner's `slugify` produces.
 /// This rejects `..`, `/`, `\`, absolute markers, dots, and any other
 /// separator-bearing or traversal input *before* it reaches the DB or the
-/// filesystem. Callers 404 on rejection (no 403 oracle). Belt to the path
-/// canonicalization suspenders in [`resolve_audio_path`]. See TAD §7 (A01).
+/// filesystem. Callers 404 on rejection (no 403 oracle). This check is the
+/// belt; the path canonicalization in [`resolve_audio_target`] is the
+/// suspenders. See TAD §7 (A01).
 fn valid_slug(slug: &str) -> bool {
     !slug.is_empty()
         && slug
@@ -76,10 +83,11 @@ fn valid_slug(slug: &str) -> bool {
 
 /// Whether a string is a syntactically valid capability `feed_id`: non-empty,
 /// bounded length, and the URL-safe base64 alphabet (`[A-Za-z0-9_-]`) that
-/// [`podspine_index::capability::generate`] produces. Same purpose as
-/// [`valid_slug`] — reject traversal/separator input before the DB/filesystem —
-/// but a wider charset because the id is random, not a lowercase slug. A bad id
-/// 404s (no oracle); a well-formed but unknown id also 404s.
+/// [`podspine_index::capability::generate`] produces. The purpose is the same
+/// as [`valid_slug`]: reject traversal/separator input before the
+/// DB/filesystem. The charset is wider because the id is random, not a
+/// lowercase slug. A bad id 404s (no oracle); a well-formed but unknown id
+/// also 404s.
 fn valid_feed_id(id: &str) -> bool {
     !id.is_empty()
         && id.len() <= 64
@@ -88,14 +96,16 @@ fn valid_feed_id(id: &str) -> bool {
             .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
 }
 
-/// Same-origin guard for the state-changing `POST` routes (CSRF defense). The only
-/// cookie the app sets is the non-auth `theme` preference (no session/auth cookie),
-/// so `SameSite` carries no ambient authority to protect; instead we check the
-/// browser-set fetch-metadata / `Origin` headers. Modern browsers always send
-/// `Sec-Fetch-Site`, so cross-site form posts are caught even in the proxy-auth
-/// deployment (where a forged request would otherwise ride the owner's proxy
-/// session). Non-browser clients (curl) send neither header and carry no ambient
-/// auth to abuse, so they're allowed. Fails closed on a mismatched `Origin`.
+/// Same-origin guard for the state-changing `POST` routes (CSRF defense). The
+/// only cookie the app sets is the non-auth `theme` preference (there is no
+/// session/auth cookie), so `SameSite` carries no ambient authority to
+/// protect. Instead the guard checks the browser-set fetch-metadata and
+/// `Origin` headers. Modern browsers always send `Sec-Fetch-Site`, so the
+/// guard catches cross-site form posts even in the proxy-auth deployment
+/// (there, a forged request would otherwise ride the owner's proxy session).
+/// Non-browser clients (curl) send neither header and carry no ambient auth
+/// to abuse, so they are allowed. The guard fails closed on a mismatched
+/// `Origin`.
 fn same_origin(headers: &HeaderMap, base_url: &str) -> bool {
     if let Some(sfs) = headers.get("sec-fetch-site").and_then(|v| v.to_str().ok()) {
         return sfs == "same-origin" || sfs == "none";
@@ -107,9 +117,10 @@ fn same_origin(headers: &HeaderMap, base_url: &str) -> bool {
     }
 }
 
-/// The visitor's colour [`Theme`] from the `theme` cookie (absent/garbage →
-/// [`Theme::System`], i.e. follow the OS). Parsed by hand — the app pulls in no
-/// cookie crate for one first-party, non-auth preference cookie.
+/// The visitor's colour [`Theme`] from the `theme` cookie. Absent or garbage
+/// input gives [`Theme::System`], i.e. follow the OS. The value is parsed by
+/// hand: the app pulls in no cookie crate for one first-party, non-auth
+/// preference cookie.
 fn theme_from_cookie(headers: &HeaderMap) -> Theme {
     headers
         .get(header::COOKIE)
@@ -123,14 +134,16 @@ fn theme_from_cookie(headers: &HeaderMap) -> Theme {
         .unwrap_or_default()
 }
 
-/// The same-origin path to redirect back to after a `POST /theme` (PRG), taken from
-/// the `Referer`. Returns the path+query of an absolute `scheme://host/path` URL, or
-/// a value that is already a plain absolute path. Rejects protocol-relative
-/// (`//host`) and anything not starting with a single `/`, so it can never become an
-/// open redirect. `None` (→ caller falls back to `/`) when there's no usable path.
+/// The same-origin path to redirect back to after a `POST /theme` (PRG),
+/// taken from the `Referer`. Return the path+query of an absolute
+/// `scheme://host/path` URL, or a value that is already a plain absolute
+/// path. Reject protocol-relative input (`//host`) and anything that does not
+/// start with a single `/`, so the result can never become an open redirect.
+/// Return `None` when there is no usable path (the caller falls back to `/`).
 fn referer_path(referer: &str) -> Option<String> {
-    // Strip `scheme://authority`, leaving `/path?query`; if there's no `://`, the
-    // header was already a bare path (defensive — Referer is normally absolute).
+    // Strip `scheme://authority`, which leaves `/path?query`. If there is no
+    // `://`, the header was already a bare path (defensive; a Referer is
+    // normally absolute).
     let candidate = match referer.split_once("://") {
         Some((_, after_authority)) => match after_authority.find('/') {
             Some(slash) => &after_authority[slash..],
@@ -144,22 +157,23 @@ fn referer_path(referer: &str) -> Option<String> {
 /// Shared server state.
 #[derive(Clone)]
 pub struct AppState {
-    /// The index (SQLite `Connection` is not `Sync`, so it lives behind a mutex;
-    /// handlers never hold the lock across an `.await`).
+    /// The index. The SQLite `Connection` is not `Sync`, so it lives behind a
+    /// mutex. Handlers never hold the lock across an `.await`.
     pub index: Arc<Mutex<Index>>,
     /// External base URL for feed/enclosure links (no trailing slash).
     pub base_url: String,
     /// Canonical data dir — extracted (chaptered) audio must stay under it.
     pub data_dir: PathBuf,
-    /// Canonical library root — whole-file episodes are streamed in place from
-    /// here (Sprint 6.2), so a resolved in-place path must stay under it. This is
-    /// the read-only source tree; the audio handler never writes to it.
+    /// Canonical library root. Whole-file episodes are streamed in place from
+    /// here (Sprint 6.2), so a resolved in-place path must stay under it. This
+    /// is the read-only source tree; the audio handler never writes to it.
     pub library_dir: PathBuf,
     /// Feed-level fallback cover URL for books with no embedded art.
     pub default_cover_url: Option<String>,
-    /// Server-default storage mode. Under [`StorageMode::Saver`], episode files
-    /// aren't pre-split — the audio handler regenerates a chapter on demand and
-    /// caches it; `Full` = pre-split. A book carrying its own mode overrides it.
+    /// Server-default storage mode. Under [`StorageMode::Saver`], episode
+    /// files are not pre-split: the audio handler regenerates a chapter on
+    /// demand and caches it. `Full` means pre-split. A book that carries its
+    /// own mode overrides this.
     pub storage: StorageMode,
     /// `saver`-mode cache cap in bytes (`None` = unbounded).
     pub cache_size_bytes: Option<u64>,
@@ -168,28 +182,29 @@ pub struct AppState {
     /// Per-chapter regeneration locks (single-flight): concurrent requests for
     /// the same uncached chapter run ffmpeg once, not N times.
     inflight: Arc<Mutex<HashMap<PathBuf, Arc<tokio::sync::Mutex<()>>>>>,
-    /// `true` once the initial library scan has finished. Defaults to `true`, so a
-    /// state built for a test or an already-populated library serves normally; the
-    /// server binary flips it to `false` before it kicks off the background first
-    /// scan and back to `true` when that scan completes (issue 159). While it is
-    /// `false`, `GET /` serves a "Scanning…" holding page and the capability routes
-    /// (`/feed`, `/audio`, `/cover`) return 503 + `Retry-After` instead of a 502 or
-    /// a bare 404 — so a first boot reads as "starting up", not "broken".
+    /// `true` once the initial library scan has finished. The default is
+    /// `true`, so a state built for a test or an already-populated library
+    /// serves normally. The server binary flips it to `false` before it kicks
+    /// off the background first scan, and back to `true` when that scan
+    /// completes (issue 159). While it is `false`, `GET /` serves a
+    /// "Scanning…" holding page, and the capability routes (`/feed`, `/audio`,
+    /// `/cover`) return 503 + `Retry-After` instead of a 502 or a bare 404. A
+    /// first boot then reads as "starting up", not "broken".
     ready: Arc<AtomicBool>,
 }
 
 impl AppState {
-    /// Build state, canonicalizing the data dir **and** the library root for the
-    /// path-safety checks (served files must stay under one of them). The
-    /// storage/cache args come from [`podspine_config::Config`] (pre-split
-    /// default: `StorageMode::Full`).
+    /// Build state. Canonicalize the data dir **and** the library root for
+    /// the path-safety checks (served files must stay under one of them). The
+    /// storage/cache args come from `podspine_config::Config` (the pre-split
+    /// default is `StorageMode::Full`).
     ///
-    /// Errors when either root can't be canonicalized. Both are guaranteed to
-    /// exist by `Config::validate` (library checked, data dir created), so a
-    /// failure here means the filesystem changed under us — and falling back to
-    /// the as-given path would make every containment check fail closed: a
-    /// server that silently 404s everything. Failing startup is louder and
-    /// therefore kinder.
+    /// This errors when either root cannot be canonicalized.
+    /// `Config::validate` guarantees that both exist (the library is checked,
+    /// the data dir is created), so a failure here means the filesystem
+    /// changed under the server. A fallback to the as-given path would make
+    /// every containment check fail closed: a server that silently 404s
+    /// everything. A startup failure is louder and therefore kinder.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         index: Index,
@@ -221,24 +236,27 @@ impl AppState {
         })
     }
 
-    /// Flip the "initial scan finished" flag. The server binary sets it `false`
-    /// before spawning the background first scan and `true` when that scan returns
-    /// (issue 159); it's cloned into the scan task via [`Clone`]. See [`AppState`]'s
-    /// `ready` field for what the two states change.
+    /// Flip the "initial scan finished" flag. The server binary sets it
+    /// `false` before it spawns the background first scan, and `true` when
+    /// that scan returns (issue 159); the state is cloned into the scan task
+    /// via [`Clone`]. See [`AppState`]'s `ready` field for what the two
+    /// states change.
     pub fn set_ready(&self, ready: bool) {
         self.ready.store(ready, Ordering::Release);
     }
 
-    /// Whether the initial library scan has finished (see [`set_ready`]).
+    /// Whether the initial library scan has finished (see
+    /// [`Self::set_ready`]).
     fn is_ready(&self) -> bool {
         self.ready.load(Ordering::Acquire)
     }
 }
 
-/// 503 + `Retry-After` for the capability routes while the initial scan is still
-/// running (issue 159). A podcatcher treats 503 as "retry shortly" and keeps the
-/// subscription; a 404 it can treat as "gone". Not routed through [`AppError`] so
-/// it isn't counted as a request failure — it's a readiness state, not an error.
+/// 503 + `Retry-After` for the capability routes while the initial scan is
+/// still running (issue 159). A podcatcher treats 503 as "retry shortly" and
+/// keeps the subscription; it can treat a 404 as "gone". This response is not
+/// routed through [`AppError`], so it does not count as a request failure. It
+/// is a readiness state, not an error.
 fn scanning_unavailable() -> Response {
     (
         StatusCode::SERVICE_UNAVAILABLE,
@@ -262,16 +280,16 @@ pub fn router(state: AppState) -> Router {
         .route("/feed/{feed_id}", get(feed))
         .route("/audio/{feed_id}/{number}", get(audio))
         .layer(TraceLayer::new_for_http())
-        // Bounds only response *production* (not the streamed body), so large
-        // audio downloads aren't truncated.
+        // This bounds only response *production* (not the streamed body), so
+        // large audio downloads are not truncated.
         .layer(TimeoutLayer::with_status_code(
             StatusCode::REQUEST_TIMEOUT,
             Duration::from_secs(30),
         ))
-        // Bound in-flight requests (DoS guard); excess requests wait rather than
-        // exhaust resources (NFR-S3, TAD §7).
+        // Bound in-flight requests (DoS guard). Excess requests wait; they do
+        // not exhaust resources (NFR-S3, TAD §7).
         .layer(ConcurrencyLimitLayer::new(MAX_INFLIGHT_REQUESTS))
-        // We accept no request bodies; keep them tiny.
+        // The server accepts no request bodies; keep the limit tiny.
         .layer(RequestBodyLimitLayer::new(16 * 1024))
         .with_state(state)
 }
@@ -287,16 +305,18 @@ async fn healthz() -> &'static str {
     "ok"
 }
 
-/// `GET /feed/{feed_id}.xml` — the route captures `{feed_id}` including the
-/// `.xml` suffix, which we strip before lookup. The capability URL is never
-/// crawlable: an `X-Robots-Tag: noindex` keeps it out of web search engines
-/// (the `itunes:block` in the XML separately keeps it out of podcast directories).
+/// `GET /feed/{feed_id}.xml` — the route captures `{feed_id}` together with
+/// the `.xml` suffix, and the handler strips the suffix before lookup. The
+/// capability URL is never crawlable: an `X-Robots-Tag: noindex` keeps it out
+/// of web search engines, and the `itunes:block` in the XML separately keeps
+/// it out of podcast directories.
 async fn feed(
     State(state): State<AppState>,
     Path(id_xml): Path<String>,
 ) -> Result<Response, AppError> {
-    // Before the first scan completes there is no feed to build yet: answer 503
-    // (retry shortly), never a 404 a podcatcher might treat as gone (issue 159).
+    // Before the first scan completes there is no feed to build yet: answer
+    // 503 (retry shortly), never a 404 that a podcatcher might treat as gone
+    // (issue 159).
     if !state.is_ready() {
         return Ok(scanning_unavailable());
     }
@@ -305,8 +325,8 @@ async fn feed(
         return Err(AppError::NotFound);
     }
     let xml = build_feed_xml(&state, feed_id)?;
-    // Counted after the self-check passes, so the metric means "a subscriber got
-    // a usable feed", not "a request arrived".
+    // The count happens after the self-check passes, so the metric means "a
+    // subscriber got a usable feed", not "a request arrived".
     podspine_metrics::feed_served();
     Ok((
         StatusCode::OK,
@@ -325,8 +345,8 @@ async fn index(
     headers: HeaderMap,
 ) -> Result<Html<String>, AppError> {
     let theme = theme_from_cookie(&headers);
-    // Until the initial scan finishes, hold on a "Scanning…" page rather than
-    // render an empty grid that reads as "no books / broken" (issue 159).
+    // Until the initial scan finishes, hold on a "Scanning…" page. An empty
+    // grid would read as "no books / broken" (issue 159).
     if !state.is_ready() {
         return Ok(Html(scanning_page(theme).into_string()));
     }
@@ -347,9 +367,10 @@ async fn index(
     Ok(Html(index_page(&cards, theme).into_string()))
 }
 
-/// Build the [`BookDetail`] view model the detail pages share: count the book's
-/// episodes and derive the public feed/subscribe URLs from its capability id.
-/// Each handler keeps its own lookup (slug vs `feed_id`) and page template.
+/// Build the [`BookDetail`] view model that the detail pages share: count the
+/// book's episodes and derive the public feed/subscribe URLs from its
+/// capability id. Each handler keeps its own lookup (slug vs `feed_id`) and
+/// page template.
 fn book_detail(state: &AppState, book: BookRow) -> Result<BookDetail, AppError> {
     let episode_count = {
         let index = state.index.lock().map_err(AppError::internal)?;
@@ -391,9 +412,10 @@ async fn book(
     Ok(Html(book_page(&detail, theme).into_string()))
 }
 
-/// `GET /subscribe/{feed_id}` — the "add to a podcast app" helper page (per-app
-/// deep links + QRs). Keyed by capability id: this is what the book-page QR points
-/// at, so an iOS Camera scan lands on real "Open in…" app links, not raw feed XML.
+/// `GET /subscribe/{feed_id}` — the "add to a podcast app" helper page
+/// (per-app deep links + QRs). Keyed by capability id: the book-page QR
+/// points here, so an iOS Camera scan lands on real "Open in…" app links, not
+/// on raw feed XML.
 async fn subscribe(
     State(state): State<AppState>,
     Path(feed_id): Path<String>,
@@ -414,9 +436,10 @@ async fn subscribe(
     Ok(Html(subscribe_page(&detail, theme).into_string()))
 }
 
-/// `POST /book/{slug}/regenerate` — rotate the book's capability `feed_id` (leak
-/// recovery). The old feed/audio/cover URLs 404 immediately. Redirects back to
-/// the book page (PRG) so a refresh doesn't re-submit.
+/// `POST /book/{slug}/regenerate` — rotate the book's capability `feed_id`
+/// (leak recovery). The old feed/audio/cover URLs 404 immediately. The
+/// handler redirects back to the book page (PRG), so a refresh does not
+/// re-submit.
 async fn regenerate(
     State(state): State<AppState>,
     Path(slug): Path<String>,
@@ -442,10 +465,11 @@ async fn regenerate(
 }
 
 /// `POST /theme/{mode}` — persist the visitor's colour theme. `mode` is
-/// `light`/`dark` (sets the `theme` cookie) or `system` (clears it, reverting to
-/// the OS preference). No-JS: the header picker is a form of submit buttons whose
-/// `formaction` posts here; we set the cookie and 303-redirect back (PRG) to the
-/// same-origin page they came from. Same-origin-guarded like [`regenerate`].
+/// `light`/`dark` (sets the `theme` cookie) or `system` (clears the cookie,
+/// which reverts to the OS preference). No JS: the header picker is a form of
+/// submit buttons whose `formaction` posts here. The handler sets the cookie
+/// and 303-redirects back (PRG) to the same-origin page the visitor came
+/// from. It is same-origin-guarded like [`regenerate`].
 async fn set_theme(
     State(state): State<AppState>,
     Path(mode): Path<String>,
@@ -454,20 +478,21 @@ async fn set_theme(
     if !same_origin(&headers, &state.base_url) {
         return Err(AppError::Forbidden);
     }
-    // A year-long, first-party, non-`Secure` (so it also works on a LAN over http)
-    // cosmetic cookie. `SameSite=Lax` still lets the top-level POST navigation set
-    // it. `system` clears the cookie via Max-Age=0.
+    // A year-long, first-party, non-`Secure` cosmetic cookie (non-`Secure` so
+    // that it also works on a LAN over http). `SameSite=Lax` still lets the
+    // top-level POST navigation set it. `system` clears the cookie via
+    // `Max-Age=0`.
     let cookie = match Theme::parse(&mode).cookie_value() {
         Some(value) => format!("theme={value}; Path=/; Max-Age=31536000; SameSite=Lax"),
         None => "theme=; Path=/; Max-Age=0; SameSite=Lax".to_string(),
     };
-    // Redirect back to the page they came from. Take the *path* of the Referer, not
-    // a match against `base_url`: the POST already passed the same-origin guard, so
-    // the Referer is this origin's page, and the browse UI is often on a different
-    // origin than `base_url` (which addresses podcatchers) — comparing against it
-    // would bounce every toggle to `/`. Only a single-slash absolute path is kept,
-    // so a protocol-relative (`//host`) or off-site value can't become an open
-    // redirect.
+    // Redirect back to the page the visitor came from. Take the *path* of the
+    // Referer, not a match against `base_url`. The POST already passed the
+    // same-origin guard, so the Referer is this origin's page. And the browse
+    // UI is often on a different origin than `base_url` (which addresses
+    // podcatchers), so a comparison against it would bounce every toggle to
+    // `/`. Only a single-slash absolute path is kept, so a protocol-relative
+    // (`//host`) or off-site value cannot become an open redirect.
     let back = headers
         .get(header::REFERER)
         .and_then(|v| v.to_str().ok())
@@ -482,21 +507,23 @@ async fn set_theme(
     Ok(resp)
 }
 
-/// `GET /cover/{feed_id}` — the book's cover image, keyed by capability id so it
-/// isn't a guessable catalog-probe surface. Covers are populated by cover
-/// extraction (Task 3.4); until then books have no cover and this 404s. The
-/// stored path is canonicalized and confirmed under the data dir before serving.
+/// `GET /cover/{feed_id}` — the book's cover image, keyed by capability id so
+/// that it is not a guessable catalog-probe surface. Cover extraction
+/// (Task 3.4) populates covers; until then books have no cover and this 404s.
+/// The handler canonicalizes the stored path and confirms it is under the
+/// data dir before it serves the file.
 ///
-/// Cached: an `ETag` (a blake3 hash of the served bytes) plus `Cache-Control` let a
-/// browser revalidate to a bodyless `304` instead of re-downloading the (often
-/// multi-MB) image on every page refresh — the grid pulls many covers at once, so
-/// over a slow link (e.g. Tailscale) that re-download was the bottleneck.
+/// Cached: an `ETag` (a blake3 hash of the served bytes) plus `Cache-Control`
+/// let a browser revalidate to a bodyless `304` instead of a re-download of
+/// the (often multi-MB) image on every page refresh. The grid pulls many
+/// covers at once, so over a slow link (e.g. Tailscale) that re-download was
+/// the bottleneck.
 async fn cover(
     State(state): State<AppState>,
     Path(feed_id): Path<String>,
     headers: HeaderMap,
 ) -> Result<Response, AppError> {
-    // No covers extracted until the first scan finishes — 503 (retry), not 404.
+    // No covers exist until the first scan finishes: 503 (retry), not 404.
     if !state.is_ready() {
         return Ok(scanning_unavailable());
     }
@@ -508,12 +535,12 @@ async fn cover(
     serve_image(&canonical, &headers).await
 }
 
-/// `GET /cover/{feed_id}/thumb` — a small `cover_thumb.jpg` for the browse UI grid
-/// (the RSS feed and `/cover` keep the full-res image). Serving is read-only: the
-/// scanner generates the thumbnail alongside the cover, and this handler just serves
-/// it. If it hasn't been generated yet (the reconcile backfills a missing one on the
-/// next scan) or generation failed, it falls back to the full cover rather than
-/// 404ing.
+/// `GET /cover/{feed_id}/thumb` — a small `cover_thumb.jpg` for the browse UI
+/// grid (the RSS feed and `/cover` keep the full-res image). Serving is
+/// read-only: the scanner generates the thumbnail alongside the cover, and
+/// this handler only serves it. When the thumbnail is not generated yet (the
+/// reconcile backfills a missing one on the next scan), or generation failed,
+/// the handler falls back to the full cover; it does not 404.
 async fn cover_thumb(
     State(state): State<AppState>,
     Path(feed_id): Path<String>,
@@ -529,16 +556,18 @@ async fn cover_thumb(
     // The full cover is the source of truth (must exist, under the data dir).
     let cover = resolve_under_data_dir(&cover_path, &state.data_dir, &feed_id)?;
 
-    // Prefer the scanner-generated thumbnail sitting next to the cover; fall back to
-    // the full cover if it hasn't been generated yet (the reconcile backfills a
-    // missing one) or generation failed — so a book with art never 404s. Serving is
-    // read-only: generation lives in the scanner (single-threaded, atomic), which is
-    // what keeps a thumbnail consistent with its cover with no cross-thread race.
+    // Prefer the scanner-generated thumbnail next to the cover. Fall back to
+    // the full cover when the thumbnail is not generated yet (the reconcile
+    // backfills a missing one) or generation failed, so a book with art never
+    // 404s. Serving is read-only: generation lives in the scanner
+    // (single-threaded, atomic), and that split keeps a thumbnail consistent
+    // with its cover with no cross-thread race.
     //
-    // Fall back to the cover when the thumbnail *serve* fails too, not just when it
-    // can't be resolved: a re-ingest deletes the old thumb before regenerating it, so
-    // it can vanish between canonicalize and read — the cover is only ever atomically
-    // replaced (never absent), so serving it is always safe.
+    // Fall back to the cover when the thumbnail *serve* fails too, not only
+    // when it cannot be resolved. A re-ingest deletes the old thumb before it
+    // regenerates it, so the thumb can vanish between canonicalize and read.
+    // The cover is only ever atomically replaced (never absent), so serving
+    // it is always safe.
     if let Some(dir) = cover.parent() {
         let thumb = cover_thumb_path(dir);
         if let Ok(canonical) =
@@ -562,13 +591,14 @@ fn book_cover_path(state: &AppState, feed_id: &str) -> Result<String, AppError> 
         .ok_or(AppError::NotFound)
 }
 
-/// The A01 containment check every serve path funnels through (TAD §7):
-/// canonicalize `path` (resolving `..` and symlinks) and confirm the result stays
-/// under the trusted `root`. A path that can't be canonicalized (missing file) or
-/// that resolves outside `root` is rejected as `NotFound` — never a distinct
-/// status, so the rejection is not an existence oracle. `what` names the site in
-/// the operator's log; the client never sees it. `number` is the episode number
-/// when the site has one — it identifies the poisoned row in the warn.
+/// The A01 containment check that every serve path funnels through (TAD §7):
+/// canonicalize `path` (this resolves `..` and symlinks) and confirm that the
+/// result stays under the trusted `root`. A path that cannot be canonicalized
+/// (a missing file), or that resolves outside `root`, is rejected as
+/// `NotFound`. The rejection is never a distinct status, so it is not an
+/// existence oracle. `what` names the site in the operator's log; the client
+/// never sees it. `number` is the episode number when the site has one; it
+/// identifies the poisoned row in the warn.
 fn canonical_under(
     path: &FsPath,
     root: &FsPath,
@@ -587,10 +617,11 @@ fn canonical_under(
     Ok(canonical)
 }
 
-/// Canonicalize a stored image path and confirm it stays under the data dir (a
-/// resolved path that escapes it is rejected as `NotFound`, never served). Fails
-/// with `NotFound` when the file doesn't exist — which the thumbnail handler relies
-/// on to fall back to the full cover.
+/// Canonicalize a stored image path and confirm that it stays under the data
+/// dir. A resolved path that escapes the data dir is rejected as `NotFound`,
+/// never served. This also fails with `NotFound` when the file does not
+/// exist; the thumbnail handler relies on that to fall back to the full
+/// cover.
 fn resolve_under_data_dir(
     path: &str,
     data_dir: &FsPath,
@@ -605,13 +636,13 @@ fn resolve_under_data_dir(
     )
 }
 
-/// Serve an on-disk image with content-addressed caching: an `ETag` (a blake3 hash
-/// of the served bytes) + `Cache-Control`, and a bodyless `304` on a matching
-/// `If-None-Match`, so a browser revalidates cheaply instead of re-downloading the
-/// image on every page refresh. `canonical` is already resolved and confirmed under
-/// the data dir. The ETag is over the exact bytes (not stat metadata), so it can't
-/// advertise a stale validator against a cover that was re-extracted between a stat
-/// and the read.
+/// Serve an on-disk image with content-addressed caching: an `ETag` (a blake3
+/// hash of the served bytes) plus `Cache-Control`, and a bodyless `304` on a
+/// matching `If-None-Match`. A browser then revalidates cheaply instead of a
+/// re-download of the image on every page refresh. `canonical` is already
+/// resolved and confirmed under the data dir. The `ETag` is over the exact
+/// bytes (not stat metadata), so it cannot advertise a stale validator
+/// against a cover that was re-extracted between a stat and the read.
 async fn serve_image(canonical: &FsPath, headers: &HeaderMap) -> Result<Response, AppError> {
     let bytes = tokio::fs::read(canonical)
         .await
@@ -646,43 +677,47 @@ async fn serve_image(canonical: &FsPath, headers: &HeaderMap) -> Result<Response
 
 /// `GET /audio/{feed_id}/{number}` — stream an episode with Range support.
 ///
-/// The `Content-Type` is set explicitly: `axum-range`'s `Ranged` emits
-/// Content-Range/Accept-Ranges/Content-Length but NO Content-Type, and a missing
-/// type makes strict clients (Apple Podcasts / iOS AVPlayer) refuse to play with
-/// "can't be played on this device" — even though the enclosure carries `type=`.
+/// The handler sets the `Content-Type` explicitly. `axum-range`'s `Ranged`
+/// emits Content-Range/Accept-Ranges/Content-Length but NO Content-Type, and
+/// a missing type makes strict clients (Apple Podcasts / iOS `AVPlayer`) refuse
+/// to play with "can't be played on this device", even though the enclosure
+/// carries `type=`.
 async fn audio(
     State(state): State<AppState>,
     Path((feed_id, number)): Path<(String, u32)>,
     range: Option<TypedHeader<Range>>,
 ) -> Result<Response, AppError> {
-    // Episodes aren't materialized until the first scan finishes — 503 (retry),
-    // not 404, so a podcatcher polling an enclosure keeps trying (issue 159).
+    // Episodes are not materialized until the first scan finishes: 503
+    // (retry), not 404, so a podcatcher that polls an enclosure keeps trying
+    // (issue 159).
     if !state.is_ready() {
         return Ok(scanning_unavailable());
     }
-    // The row is snapshotted under the index lock inside the resolver and the lock
-    // is released before any file I/O. A re-ingest that moves this book into
-    // another container (a transcode flag or target flip) can therefore replace the
-    // rows and sweep the old file between that snapshot and the `File::open` below.
-    // Every step from here fails closed, so the request 404s and the client
-    // retries — it can never be served partial or stale-length bytes. See the note
-    // at the sweep in `podspine_scanner::scan_book_as` for why that microsecond
-    // window is left unguarded.
+    // The resolver snapshots the row under the index lock and releases the
+    // lock before any file I/O. A re-ingest that moves this book into another
+    // container (a transcode flag or target flip) can therefore replace the
+    // rows and sweep the old file between that snapshot and the `File::open`
+    // below. Every step from here fails closed, so the request 404s and the
+    // client retries; it can never receive partial or stale-length bytes. See
+    // the note at the sweep in `podspine_scanner::scan_book_as` for why that
+    // microsecond window is left unguarded.
     let target = resolve_audio_target(&state, &feed_id, number)?;
-    // A missing file is regenerated on demand when the resolver supplied a `Regen`
-    // (a `saver` chapter split, or a faststart remux of a whole-file episode);
-    // otherwise (e.g. `full`-mode chapter, in-place whole file) it's a genuine 404.
+    // When the resolver supplied a `Regen` (a `saver` chapter split, or a
+    // faststart remux of a whole-file episode), a missing file is regenerated
+    // on demand. Otherwise (e.g. a `full`-mode chapter, an in-place whole
+    // file) it is a genuine 404.
     if !target.path.exists() {
         match &target.regen {
             Some(regen) => ensure_cached(&state, &target.path, regen).await?,
             None => return Err(AppError::NotFound),
         }
     }
-    // Final defense-in-depth: the file now exists, so canonicalize it (resolving
-    // any symlink) and confirm it still lives under a trusted root before opening
-    // — the data dir (extracted chapters) OR the library root (whole-file
-    // episodes served in place). The resolver already checked the relevant root;
-    // this additionally catches a file that is itself a symlink pointing outside.
+    // Final defense in depth: the file now exists, so canonicalize it (this
+    // resolves any symlink) and confirm that it still lives under a trusted
+    // root before the open. The trusted roots are the data dir (extracted
+    // chapters) OR the library root (whole-file episodes served in place).
+    // The resolver already checked the relevant root; this check additionally
+    // catches a file that is itself a symlink that points outside.
     let path = target.path.canonicalize().map_err(|_| AppError::NotFound)?;
     if !path.starts_with(&state.data_dir) && !path.starts_with(&state.library_dir) {
         tracing::warn!(
@@ -701,9 +736,10 @@ async fn audio(
     Ok(([(header::CONTENT_TYPE, mime)], Ranged::new(range, body)).into_response())
 }
 
-/// Build and self-check the feed XML for a capability `feed_id`. All public URLs
-/// in the feed (self link, enclosures, cover) are built from `feed_id` so the
-/// whole book is reachable from the one capability, and nothing guessable.
+/// Build and self-check the feed XML for a capability `feed_id`. All public
+/// URLs in the feed (self link, enclosures, cover) are built from `feed_id`,
+/// so the whole book is reachable from the one capability, and nothing is
+/// guessable.
 fn build_feed_xml(state: &AppState, feed_id: &str) -> Result<String, AppError> {
     let (book, episodes) = {
         let index = state.index.lock().map_err(AppError::internal)?;
@@ -718,9 +754,9 @@ fn build_feed_xml(state: &AppState, feed_id: &str) -> Result<String, AppError> {
     };
 
     let base = &state.base_url;
-    // Per-book cover served at /cover/{feed_id} when extracted; otherwise a
-    // per-book `.podspine.toml` fallback (Sprint 6.4), then the server-wide one,
-    // then no image at all. See Task 3.4.
+    // The per-book cover is served at `/cover/{feed_id}` when extracted. The
+    // fallbacks, in order: a per-book `.podspine.toml` URL (Sprint 6.4), then
+    // the server-wide one, then no image at all. See Task 3.4.
     let cover_url = book
         .cover_path
         .as_ref()
@@ -754,39 +790,40 @@ fn build_feed_xml(state: &AppState, feed_id: &str) -> Result<String, AppError> {
     })
 }
 
-/// Resolve `(feed_id, episode number)` to a validated on-disk path.
-/// What `/audio` needs: the canonical target file (which may not exist yet in
-/// `saver` mode) and, in `saver` mode, everything to regenerate it on demand.
-/// Whether a book's effective storage mode is `saver`: its per-book
-/// `.podspine.toml` override (Sprint 6.4) if set, else the server default. A
-/// `None` is a pre-6.4 row that follows the server config until re-scanned.
 /// Whether this book's episodes were **re-encoded** at ingest (Task 5.2).
 ///
-/// A re-encode is not byte-reproducible across ffmpeg builds, so such an episode
-/// must never be regenerated on demand (the rebuilt file's length could no longer
-/// match the `enclosure length` already published in the feed) and must never be
-/// evicted (nothing could rebuild it). Both callers below therefore treat a
-/// transcoded book as `full`, whatever its `storage_mode` says. `None` is a
-/// pre-5.2 row, which was necessarily stream-copied.
+/// A re-encode is not byte-reproducible across ffmpeg builds. So such an
+/// episode must never be regenerated on demand (the rebuilt file's length
+/// could no longer match the `enclosure length` already published in the
+/// feed), and it must never be evicted (nothing could rebuild it). Both
+/// callers below therefore treat a transcoded book as `full`, independent of
+/// its `storage_mode`. `None` is a pre-5.2 row, which was necessarily
+/// stream-copied.
 fn book_is_transcoded(book: &BookRow) -> bool {
     book.transcode.is_some_and(TranscodeMode::is_on)
 }
 
+/// Whether a book's effective storage mode is `saver`: its per-book
+/// `.podspine.toml` override (Sprint 6.4) if set, else the server default.
+/// `None` is a pre-6.4 row that follows the server config until it is
+/// re-scanned.
 fn book_is_saver(book: &BookRow, global: StorageMode) -> bool {
     book.storage_mode.unwrap_or(global) == StorageMode::Saver
 }
 
+/// What `/audio` needs: the canonical target file (which may not exist yet in
+/// `saver` mode) and, in `saver` mode, everything to regenerate it on demand.
 struct AudioTarget {
     path: PathBuf,
     regen: Option<Regen>,
 }
 
-/// Inputs to regenerate one cache file on demand — a `saver` chapter split, or a
-/// faststart remux of a whole-file episode (Sprint 6.3). The source is always a
-/// canonicalized file asserted to live under the library root — both arms of
-/// [`resolve_audio_target`] validate before constructing this, so nothing that
-/// reaches ffmpeg can have escaped. The op decides which ffmpeg call rebuilds the
-/// deterministic output.
+/// Inputs to regenerate one cache file on demand: a `saver` chapter split, or
+/// a faststart remux of a whole-file episode (Sprint 6.3). The source is
+/// always a canonicalized file asserted to live under the library root. Both
+/// arms of [`resolve_audio_target`] validate before they construct this, so
+/// nothing that reaches ffmpeg can have escaped. The op decides which ffmpeg
+/// call rebuilds the deterministic output.
 struct Regen {
     source: PathBuf,
     out_dir: PathBuf,
@@ -797,28 +834,30 @@ struct Regen {
 /// Which ffmpeg operation regenerates the cache file.
 #[derive(Clone)]
 enum RegenOp {
-    /// Re-split one chapter (`saver` mode) — a sub-range of the container.
+    /// Re-split one chapter (`saver` mode): a sub-range of the container.
     Chapter(ChapterCut),
     /// Remux a whole file to faststart (`PODSPINE_REMUX_NON_FASTSTART`).
     Faststart { idx: usize, duration_sec: f64 },
 }
 
-/// Resolve `/audio/{feed_id}/{number}` to its on-disk target. Three path-safe
-/// shapes, by whether the episode is a whole file (and how it's stored):
+/// Resolve `/audio/{feed_id}/{number}` to its on-disk target. There are three
+/// path-safe shapes, by whether the episode is a whole file (and how it is
+/// stored):
 ///
-/// - **In place (whole-file episode, `file_path == source_path`):** a whole file
-///   streamed from the library — canonicalized, asserted under the library root,
-///   and size-checked against the recorded length (Sprint 6.2).
-/// - **Faststart remux (whole-file episode, `file_path != source_path`):** the
-///   served file is a cache copy under the data dir; it's regenerated on demand by
-///   remuxing the library source to faststart (Sprint 6.3), so the resolver returns
-///   a [`Regen`] carrying [`RegenOp::Faststart`].
+/// - **In place (whole-file episode, `file_path == source_path`):** a whole
+///   file streamed from the library. It is canonicalized, asserted under the
+///   library root, and size-checked against the recorded length (Sprint 6.2).
+/// - **Faststart remux (whole-file episode, `file_path != source_path`):**
+///   the served file is a cache copy under the data dir. A remux of the
+///   library source to faststart regenerates it on demand (Sprint 6.3), so
+///   the resolver returns a [`Regen`] that carries [`RegenOp::Faststart`].
 /// - **Extracted (chaptered episode):** the path is reconstructed from the
-///   canonical `data_dir` plus **opaque DB keys** (`book.id`, chapter index) and a
-///   validated audio extension — never built from request input — so it stays
-///   under the data dir by construction (no traversal). In `saver` mode it's
-///   regenerated on demand ([`RegenOp::Chapter`]); existence is not required —
-///   unless the book was transcoded (Task 5.2), which is never regenerated.
+///   canonical `data_dir` plus **opaque DB keys** (`book.id`, chapter index)
+///   and a validated audio extension. It is never built from request input,
+///   so it stays under the data dir by construction (no traversal). In
+///   `saver` mode a chapter split regenerates it on demand
+///   ([`RegenOp::Chapter`]), and existence is not required — unless the book
+///   was transcoded (Task 5.2); a transcoded book is never regenerated.
 fn resolve_audio_target(
     state: &AppState,
     feed_id: &str,
@@ -844,21 +883,24 @@ fn resolve_audio_target(
         (book, ep)
     };
 
-    // Serve-in-place (Sprint 6.2): a whole-file episode streamed directly from the
-    // read-only library — never copied under the data dir. Recognized by a
-    // non-empty `source_path` whose value equals `file_path` (a whole-file episode
-    // whose `file_path != source_path` was remuxed to a faststart cache copy and
-    // is handled by the data-dir path below). Three guards, all 404 on failure:
-    //   1. canonicalize + assert under the library root (reject `..`/symlink
-    //      escape) — the A01 "assert under the library root" rule (TAD §7);
-    //   2. the recorded enclosure length must equal the on-disk source size —
+    // Serve-in-place (Sprint 6.2): a whole-file episode streamed directly
+    // from the read-only library, never copied under the data dir. It is
+    // recognized by a non-empty `source_path` whose value equals `file_path`.
+    // (A whole-file episode whose `file_path != source_path` was remuxed to a
+    // faststart cache copy; the data-dir path below handles it.) Two guards,
+    // both 404 on failure:
+    //   1. Canonicalize and assert under the library root (reject a `..` or
+    //      symlink escape): the A01 "assert under the library root" rule
+    //      (TAD §7).
+    //   2. The recorded enclosure length must equal the on-disk source size:
     //      the WHOLE-FILE invariant. A chaptered episode (a sub-range) that
-    //      wrongly carries a `source_path` from a bad migration / partial rescan
-    //      / manual edit has a chapter-sized `byte_length` ≠ the container size,
-    //      so it's rejected here instead of serving the full container's bytes
-    //      under the chapter's enclosure length.
-    // Returns before the data-dir/regeneration logic below, so a poisoned row can
-    // never fall through into it.
+    //      wrongly carries a `source_path` (from a bad migration, a partial
+    //      rescan, or a manual edit) has a chapter-sized `byte_length` that
+    //      differs from the container size. It is rejected here; the full
+    //      container's bytes are never served under the chapter's enclosure
+    //      length.
+    // This branch returns before the data-dir/regeneration logic below, so a
+    // poisoned row can never fall through into it.
     if !ep.source_path.is_empty() && ep.file_path == ep.source_path {
         let src = canonical_under(
             FsPath::new(&ep.source_path),
@@ -884,20 +926,22 @@ fn resolve_audio_target(
         });
     }
 
-    // The container extension is the audio ext the scanner recorded; reject
-    // anything non-alphanumeric so it can never introduce a path separator.
+    // The container extension is the audio extension the scanner recorded.
+    // Reject anything non-alphanumeric, so that it can never introduce a path
+    // separator.
     let out_ext = FsPath::new(&ep.file_path)
         .extension()
         .and_then(|e| e.to_str())
         .map(str::to_ascii_lowercase)
         .filter(|e| !e.is_empty() && e.chars().all(|c| c.is_ascii_alphanumeric()))
         .ok_or(AppError::NotFound)?;
-    // Defense-in-depth, at runtime (not a debug_assert that vanishes in release):
-    // resolve the book dir and confirm it stays under the canonical data dir
-    // before anything is opened or written. The components are opaque DB keys,
-    // but a poisoned row must never let a path escape. The chapter file itself
-    // may not exist yet (saver), so canonicalize the parent dir; a book dir that
-    // doesn't exist (never ingested) is a clean 404.
+    // Defense in depth, at runtime (not a debug_assert that vanishes in
+    // release): resolve the book dir and confirm that it stays under the
+    // canonical data dir before anything is opened or written. The components
+    // are opaque DB keys, but a poisoned row must never let a path escape.
+    // The chapter file itself may not exist yet (saver), so canonicalize the
+    // parent dir. A book dir that does not exist (never ingested) is a clean
+    // 404.
     let out_dir = state
         .data_dir
         .join("books")
@@ -912,13 +956,14 @@ fn resolve_audio_target(
 
     // Two kinds of episode materialize under the data dir here:
     let regen = if !ep.source_path.is_empty() && ep.needs_faststart {
-        // A non-faststart whole-file episode remuxed to a faststart cache copy
-        // (Sprint 6.3, `file_path != source_path`). Regenerate it on demand from
-        // the library source — always, independent of storage_mode. The
-        // `needs_faststart` gate means a chaptered row that merely carries a stray
-        // `source_path` is NOT remuxed into its container here; it drops to the
-        // chaptered arm and serves its actual split (or 404s). Validate the source
-        // stays under the library root first (the A01 rule), 404 on escape.
+        // A non-faststart whole-file episode remuxed to a faststart cache
+        // copy (Sprint 6.3, `file_path != source_path`). Regenerate it on
+        // demand from the library source: always, independent of
+        // `storage_mode`. The `needs_faststart` gate means a chaptered row
+        // that merely carries a stray `source_path` is NOT remuxed into its
+        // container here; it drops to the chaptered arm and serves its actual
+        // split (or 404s). Validate first that the source stays under the
+        // library root (the A01 rule); 404 on escape.
         let src = canonical_under(
             FsPath::new(&ep.source_path),
             &state.library_dir,
@@ -939,16 +984,18 @@ fn resolve_audio_target(
         && !book_is_transcoded(&book)
         && FsPath::new(&book.source_path).is_file()
     {
-        // A chaptered episode. Regen is possible only in `saver` mode (per-book,
-        // Sprint 6.4) when the book's source is a single file to re-split; the
-        // `is_file` guard is belt-and-suspenders (a directory source would make
-        // `ffmpeg <directory>` fail), so a missing file is a clean 404, not a 500.
+        // A chaptered episode. Regen is possible only in `saver` mode
+        // (per-book, Sprint 6.4) when the book's source is a single file to
+        // re-split. The `is_file` guard is belt-and-suspenders (a directory
+        // source would make `ffmpeg <directory>` fail), and a missing file is
+        // a clean 404, not a 500.
         //
-        // Same A01 containment rule as the remux arm above: `book.source_path` is
-        // an opaque DB value, so canonicalize it and assert it stays under the
-        // library root before it can reach ffmpeg. Checked here rather than at
-        // regen time so a poisoned row is rejected before anything is opened or
-        // written — including when the cached chapter happens to already exist.
+        // The same A01 containment rule as the remux arm above applies:
+        // `book.source_path` is an opaque DB value, so canonicalize it and
+        // assert that it stays under the library root before it can reach
+        // ffmpeg. The check runs here, not at regen time, so that a poisoned
+        // row is rejected before anything is opened or written — including
+        // when the cached chapter happens to already exist.
         let src = canonical_under(
             FsPath::new(&book.source_path),
             &state.library_dir,
@@ -960,12 +1007,14 @@ fn resolve_audio_target(
             source: src,
             out_dir,
             out_ext,
-            // `end_sec` is reconstructed as start + duration. This is EXACT, not an
-            // approximation: the scanner stores `duration_sec = cut.end - cut.start`
-            // (the requested cut length, not a measured output duration), so this
-            // yields the same `[start, end)` the ingest split used — and ffmpeg's
-            // 6-decimal arg formatting absorbs any float round-trip. The stream
-            // copy is therefore byte-identical (asserted in the serve test).
+            // `end_sec` is reconstructed as start + duration. This is EXACT,
+            // not an approximation: the scanner stores
+            // `duration_sec = cut.end - cut.start` (the requested cut length,
+            // not a measured output duration), so this yields the same
+            // `[start, end)` that the ingest split used. And ffmpeg's
+            // 6-decimal arg formatting absorbs any float round-trip. The
+            // stream copy is therefore byte-identical (asserted in the serve
+            // test).
             op: RegenOp::Chapter(ChapterCut {
                 idx: idx as usize,
                 start_sec: ep.start_sec,
@@ -978,10 +1027,10 @@ fn resolve_audio_target(
     Ok(AudioTarget { path, regen })
 }
 
-/// Ensure `target` exists, regenerating it on demand: a `saver` chapter split, or
-/// a whole-file faststart remux (Sprint 6.3). A per-path single-flight lock means
-/// concurrent requests for the same uncached file run ffmpeg once; the blocking
-/// ffmpeg work runs off the async runtime.
+/// Ensure that `target` exists; regenerate it on demand (a `saver` chapter
+/// split, or a whole-file faststart remux, Sprint 6.3). A per-path
+/// single-flight lock means concurrent requests for the same uncached file
+/// run ffmpeg once. The blocking ffmpeg work runs off the async runtime.
 async fn ensure_cached(state: &AppState, target: &FsPath, regen: &Regen) -> Result<(), AppError> {
     let lock = {
         let mut map = state.inflight.lock().map_err(AppError::internal)?;
@@ -992,7 +1041,8 @@ async fn ensure_cached(state: &AppState, target: &FsPath, regen: &Regen) -> Resu
     let _guard = lock.lock().await;
 
     let outcome = async {
-        // A concurrent request may have produced it while we waited on the lock.
+        // A concurrent request may have produced the file during the wait on
+        // the lock.
         if target.exists() {
             return Ok(());
         }
@@ -1018,40 +1068,45 @@ async fn ensure_cached(state: &AppState, target: &FsPath, regen: &Regen) -> Resu
         .map_err(AppError::internal)?
         .map_err(AppError::internal)?;
 
-        // Keep the cache under its cap/TTL, never evicting what we just produced.
+        // Keep the cache under its cap/TTL; never evict the file just
+        // produced.
         enforce_cache(state, target).await;
         Ok(())
     }
     .await;
 
-    // Drop the single-flight entry so the map stays bounded to *in-flight*
-    // regenerations, not every chapter ever served. Any waiter still blocked on
-    // `.lock()` holds its own `Arc` clone of this same mutex, and every path
-    // re-checks `target.exists()` after acquiring it, so removing the map entry
-    // here can never cause a duplicate ffmpeg run.
+    // Drop the single-flight entry, so that the map stays bounded to
+    // *in-flight* regenerations, not every chapter ever served. Any waiter
+    // still blocked on `.lock()` holds its own `Arc` clone of this same
+    // mutex, and every path re-checks `target.exists()` after it acquires the
+    // lock. So the removal of the map entry here can never cause a duplicate
+    // ffmpeg run.
     if let Ok(mut map) = state.inflight.lock() {
         map.remove(target);
     }
     outcome
 }
 
-/// Evict cached chapter files to keep the `saver` cache under its size cap and
-/// TTL; `keep` (the file we just served) is never evicted. No-op when both
-/// limits are unset. Best-effort — eviction never fails a request.
+/// Evict cached chapter files to keep the `saver` cache under its size cap
+/// and TTL. `keep` (the file just served) is never evicted. This is a no-op
+/// when both limits are unset. It is best-effort: eviction never fails a
+/// request.
 async fn enforce_cache(state: &AppState, keep: &FsPath) {
     let (cap, ttl) = (state.cache_size_bytes, state.cache_ttl);
     if cap.is_none() && ttl.is_none() {
         return; // unbounded + no TTL: nothing to evict
     }
     let books = state.data_dir.join("books");
-    // Evict only from **effective-`saver`, single-file-source, stream-copied**
-    // books (per-book storage_mode, Sprint 6.4): their cached chapters re-split on
-    // demand, so deleting one is safe. A transcoded book (Task 5.2) is excluded —
-    // nothing regenerates a re-encode, so evicting it would 404 until a rescan. A `full` book's chapters are kept — evicting them
-    // would 404 (no regen) — and a non-single-file book (MP3 folder) is served in
-    // place, so those dirs are left alone. (A `full` book's remux cache, if any,
-    // therefore persists — a minor, safe over-conservatism.) Snapshot the sources
-    // without holding the lock across the `is_file` stats.
+    // Evict only from **effective-`saver`, single-file-source,
+    // stream-copied** books (per-book `storage_mode`, Sprint 6.4): their
+    // cached chapters re-split on demand, so a delete is safe. A transcoded
+    // book (Task 5.2) is excluded: nothing regenerates a re-encode, so an
+    // eviction would 404 until a rescan. A `full` book's chapters are kept:
+    // an eviction would 404 (no regen). A non-single-file book (MP3 folder)
+    // is served in place, so those dirs are left alone. (A `full` book's
+    // remux cache, if any, therefore persists: a minor, safe
+    // over-conservatism.) Snapshot the sources without the lock held across
+    // the `is_file` stats.
     let sources: Vec<(String, bool)> = {
         let Ok(index) = state.index.lock() else {
             tracing::warn!("cache eviction skipped: index lock poisoned");
@@ -1087,11 +1142,12 @@ async fn enforce_cache(state: &AppState, keep: &FsPath) {
 }
 
 /// Collect cached chapter files (numeric stems under `books/*/`) from
-/// **regenerable** books only, drop TTL-expired ones, then delete oldest-first
-/// until under `cap`. mtime is the LRU key: regenerating a chapter refreshes it.
-/// Non-regenerable book dirs (a directory-source book, or a legacy pre-6.2 copy)
-/// are skipped entirely so nothing that can't be rebuilt is destroyed. Best-effort;
-/// per-file I/O errors are ignored.
+/// **regenerable** books only. Drop TTL-expired ones. Then delete
+/// oldest-first until the total is under `cap`. The mtime is the LRU key: a
+/// chapter regeneration refreshes it. Non-regenerable book dirs (a
+/// directory-source book, or a legacy pre-6.2 copy) are skipped entirely, so
+/// nothing that cannot be rebuilt is destroyed. Best-effort; per-file I/O
+/// errors are ignored.
 fn evict(
     books_dir: &FsPath,
     cap: Option<u64>,
@@ -1116,7 +1172,8 @@ fn evict(
         };
         for e in entries.flatten() {
             let p = e.path();
-            // Only chapter files (`001.m4a`-style, numeric stem): skips covers.
+            // Only chapter files (`001.m4a`-style, numeric stem); this skips
+            // covers.
             let numeric = p
                 .file_stem()
                 .and_then(|s| s.to_str())
@@ -1187,7 +1244,7 @@ fn image_mime(path: &str) -> &'static str {
     }
 }
 
-/// Handler error — maps to a status code and never leaks internals.
+/// Handler error. It maps to a status code and never leaks internals.
 #[derive(Debug)]
 enum AppError {
     NotFound,
@@ -1196,8 +1253,8 @@ enum AppError {
 }
 
 impl AppError {
-    /// Collapse any error into `Internal`, logging the detail — the client sees
-    /// only a 500, but the operator gets the cause.
+    /// Collapse any error into `Internal` and log the detail. The client sees
+    /// only a 500; the operator gets the cause.
     fn internal<E: std::fmt::Display>(e: E) -> Self {
         tracing::error!(error = %e, "internal error");
         AppError::Internal
@@ -1236,9 +1293,9 @@ mod tests {
         assert_eq!(mime_for("/x/blob"), "audio/mp4");
     }
 
-    /// `evict` deletes files — pin its guard branches directly: a regenerable
-    /// book dir that vanished, a directory entry with a numeric stem, a
-    /// non-regenerable sibling, the under-cap early return, and the
+    /// `evict` deletes files, so pin its guard branches directly: a
+    /// regenerable book dir that vanished, a directory entry with a numeric
+    /// stem, a non-regenerable sibling, the under-cap early return, and the
     /// stop-once-under-cap break.
     #[test]
     fn evict_edge_branches() {
@@ -1289,10 +1346,10 @@ mod tests {
         );
     }
 
-    /// Eviction is best-effort and must never panic or fail a request — fault-
-    /// inject both abandon paths: a database failure (the `book` table dropped
-    /// out from under a live [`Index`] by a second connection) and a poisoned
-    /// index lock. Each returns quietly after logging a warn.
+    /// Eviction is best-effort and must never panic or fail a request. The
+    /// test fault-injects both abandon paths: a database failure (a second
+    /// connection drops the `book` table out from under a live [`Index`]) and
+    /// a poisoned index lock. Each returns quietly after it logs a warn.
     #[tokio::test]
     async fn enforce_cache_survives_a_broken_index_and_a_poisoned_lock() {
         let dir = scratch("http-enforce-cache-faults");
@@ -1372,7 +1429,8 @@ mod tests {
             transcode,
         };
         let saver = Some(StorageMode::Saver);
-        // A re-encode can't be rebuilt byte-for-byte, so `saver` must not apply.
+        // A re-encode cannot be rebuilt byte-for-byte, so `saver` must not
+        // apply.
         assert!(book_is_transcoded(&mk(saver, Some(TranscodeMode::Aac))));
         assert!(book_is_transcoded(&mk(saver, Some(TranscodeMode::Mp3))));
         // Stream-copied books (and pre-5.2 rows) stay regenerable.
@@ -1434,8 +1492,9 @@ mod tests {
 
     #[test]
     fn referer_path_extracts_path_and_blocks_open_redirect() {
-        // Absolute URLs → their path+query, regardless of host/port (so a UI origin
-        // that differs from base_url still returns home to the right page).
+        // An absolute URL gives its path+query, independent of host/port (so
+        // a UI origin that differs from `base_url` still returns to the right
+        // page).
         assert_eq!(
             referer_path("http://192.168.1.5:8080/book/dracula").as_deref(),
             Some("/book/dracula")
@@ -1444,9 +1503,9 @@ mod tests {
             referer_path("https://podspine.example/subscribe/x?y=1").as_deref(),
             Some("/subscribe/x?y=1")
         );
-        // An absolute URL with no path → root.
+        // An absolute URL with no path gives the root.
         assert_eq!(referer_path("http://host").as_deref(), Some("/"));
-        // Already a bare path is accepted.
+        // A bare path is accepted as-is.
         assert_eq!(referer_path("/book/x").as_deref(), Some("/book/x"));
         // Open-redirect vectors are rejected (caller falls back to `/`).
         assert_eq!(referer_path("http://evil.com//evil.com/x"), None);
@@ -1478,7 +1537,8 @@ mod tests {
             &with("origin", "http://host:8087"),
             "http://host:8087/sub"
         ));
-        // Non-browser client (no headers) is allowed — no ambient auth to abuse.
+        // A non-browser client (no headers) is allowed; it has no ambient auth
+        // to abuse.
         assert!(same_origin(&HeaderMap::new(), base));
     }
 
@@ -1526,7 +1586,7 @@ mod tests {
         touch(&bk.join("cover.jpg"), 500); // non-numeric stem: never a cache file
         let keep = bk.join("003.m4a");
 
-        // Cap 150B: with `keep` (100B) protected, older chapters are evicted.
+        // Cap 150B: `keep` (100B) is protected, so older chapters are evicted.
         evict(&books, Some(150), None, &keep, &regen_set(&[&bk]));
 
         assert!(keep.exists(), "the just-served file is kept");
@@ -1576,7 +1636,7 @@ mod tests {
 
     #[test]
     fn evict_tolerates_a_missing_books_dir() {
-        // Top-level read_dir fails -> clean no-op, no panic.
+        // A failed top-level read_dir is a clean no-op, not a panic.
         evict(
             FsPath::new("/no/such/podspine/books"),
             Some(1),
@@ -1588,10 +1648,11 @@ mod tests {
 
     #[test]
     fn evict_never_touches_non_regenerable_books() {
-        // A regenerable (single-file-source) book and a non-regenerable book dir
-        // (a directory source — e.g. an MP3 folder, or a legacy pre-6.2 copy).
-        // Only the regenerable one may be evicted; the non-regenerable files must
-        // survive even a tiny cap (Greptile P1) — nothing would rebuild them.
+        // A regenerable (single-file-source) book and a non-regenerable book
+        // dir (a directory source, e.g. an MP3 folder, or a legacy pre-6.2
+        // copy). Only the regenerable one may be evicted. The non-regenerable
+        // files must survive even a tiny cap (Greptile P1): nothing would
+        // rebuild them.
         let dir = scratch("evict-mp3safe");
         let books = dir.join("books");
         let split = books.join("splitbook"); // regenerable
@@ -1632,10 +1693,10 @@ mod tests {
 
     #[test]
     fn internal_swallows_the_source_error() {
-        // `AppError::internal` is what every `.map_err(..)` on the request path
-        // funnels through: whatever the underlying error was — a poisoned mutex,
-        // a rusqlite failure — it must collapse to a bare Internal, so no
-        // filesystem path or SQL text can reach the client.
+        // `AppError::internal` is what every `.map_err(..)` on the request
+        // path funnels through. Whatever the underlying error was (a poisoned
+        // mutex, a rusqlite failure), it must collapse to a bare `Internal`,
+        // so that no filesystem path or SQL text can reach the client.
         let from_io = AppError::internal(std::io::Error::other("secret /srv/path detail"));
         assert!(matches!(from_io, AppError::Internal));
         assert_eq!(

--- a/crates/http/tests/server.rs
+++ b/crates/http/tests/server.rs
@@ -130,9 +130,10 @@ fn state_with_default_cover(
     .expect("test dirs canonicalize")
 }
 
-/// A root that can't be canonicalized must fail construction loudly. The old
-/// fallback kept the as-given path, and every containment check then failed
-/// closed — a server that silently 404s everything (security audit 2026-08-19).
+/// A root that cannot be canonicalized must fail construction loudly. The
+/// old fallback kept the as-given path, and every containment check then
+/// failed closed: a server that silently 404s everything (security audit
+/// 2026-08-19).
 #[test]
 fn state_construction_fails_when_a_root_is_missing() {
     let dir = scratch("http-missing-root");
@@ -157,8 +158,8 @@ fn state_construction_fails_when_a_root_is_missing() {
 
 /// Final defense-in-depth on the audio route: every resolver check passes (a
 /// chaptered episode, a real file under `data/books/<id>`), but the chapter file
-/// itself is a symlink pointing outside BOTH trusted roots. The last
-/// canonicalize-and-check must catch it and 404 — this is the deliberately
+/// itself is a symlink that points outside BOTH trusted roots. The last
+/// canonicalize-and-check must catch it and 404. This is the deliberately
 /// hand-rolled two-root check, and this is its only test.
 #[cfg(unix)]
 #[tokio::test]
@@ -190,7 +191,7 @@ async fn audio_file_symlinked_outside_both_roots_is_a_404() {
 }
 
 /// Invalid feed-id characters 404 at the allow-list, before any DB or
-/// filesystem work — on the thumb route too (the cover route's sibling).
+/// filesystem work, on the thumb route too (the cover route's sibling).
 #[tokio::test]
 async fn cover_thumb_rejects_an_invalid_feed_id() {
     let resp = router(empty_state())
@@ -204,8 +205,9 @@ async fn cover_thumb_rejects_an_invalid_feed_id() {
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }
 
-/// Synthesize a two-chapter FLAC (chapters via a `.cue` sidecar — embedded FLAC
-/// chapters carry no titles). `None` when this ffmpeg has no FLAC encoder.
+/// Synthesize a two-chapter FLAC (chapters via a `.cue` sidecar; embedded
+/// FLAC chapters carry no titles). `None` when this ffmpeg has no FLAC
+/// encoder.
 fn synth_flac_with_cue(dir: &Path) -> Option<PathBuf> {
     let input = dir.join("book.flac");
     let ok = Command::new("ffmpeg")
@@ -278,8 +280,8 @@ async fn serves_cover_when_present() {
         resp.headers().get(header::CONTENT_TYPE).unwrap(),
         "image/jpeg"
     );
-    // Cacheable: an ETag + Cache-Control so a refresh revalidates instead of
-    // re-downloading the image every time.
+    // Cacheable: an ETag + Cache-Control, so that a refresh revalidates
+    // instead of a re-download of the image every time.
     let etag = resp
         .headers()
         .get(header::ETAG)
@@ -296,8 +298,8 @@ async fn serves_cover_when_present() {
     );
     assert!(!body_bytes(resp).await.is_empty(), "cover bytes served");
 
-    // A conditional re-request with that ETag gets a bodyless 304, not the image
-    // again — the fix for re-pulling covers on every refresh.
+    // A conditional re-request with that ETag gets a bodyless 304, not the
+    // image again: the fix for covers re-pulled on every refresh.
     let resp = app
         .clone()
         .oneshot(
@@ -315,9 +317,10 @@ async fn serves_cover_when_present() {
     );
     assert!(body_bytes(resp).await.is_empty(), "a 304 carries no body");
 
-    // Content-addressed ETag: if the cover bytes change (a re-extraction), the old
-    // tag no longer matches, so the same conditional request now gets a fresh 200
-    // with a *different* ETag — never a stale 304 for the wrong bytes.
+    // Content-addressed ETag: if the cover bytes change (a re-extraction),
+    // the old tag no longer matches, so the same conditional request now gets
+    // a fresh 200 with a *different* ETag, never a stale 304 for the wrong
+    // bytes.
     std::fs::write(&cover_file, b"different cover bytes").unwrap();
     let resp = app
         .oneshot(
@@ -371,7 +374,7 @@ async fn saver_mode_regenerates_a_chapter_on_demand() {
     let state = saver_state(index, &data, &dir);
     let app = router(state);
 
-    // First request: the file is missing, so it's regenerated and served.
+    // First request: the file is missing, so it is regenerated and served.
     let resp = app
         .clone()
         .oneshot(
@@ -448,8 +451,8 @@ async fn saver_cache_evicts_over_the_size_cap() {
         let _ = body_bytes(resp).await;
     }
 
-    // After serving ch2 with a 1-byte cap, ch1 must have been evicted — leaving
-    // exactly one cached chapter file.
+    // After ch2 is served with a 1-byte cap, ch1 must have been evicted,
+    // which leaves exactly one cached chapter file.
     let cached = std::fs::read_dir(&book_out)
         .unwrap()
         .flatten()
@@ -491,7 +494,7 @@ async fn full_mode_missing_file_is_a_404_not_a_regeneration() {
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }
 
-/// Synthesize a chapterless AAC single file → served in place (Sprint 6.2).
+/// Synthesize a chapterless AAC single file, served in place (Sprint 6.2).
 fn synth_flat(dir: &Path) -> PathBuf {
     synth_sine(dir, "flat.m4a", 8.0)
 }
@@ -582,9 +585,10 @@ async fn in_place_source_outside_the_library_is_a_404() {
     let book = scan_book(&input, &data, &index).unwrap();
     let feed_id = book.feed_id.clone();
 
-    // Poison the row: point the episode's in-place source at a real file OUTSIDE
-    // the library root. Canonicalize succeeds, but the library-root guard must
-    // still reject it — a poisoned/traversing source path never escapes.
+    // Poison the row: point the episode's in-place source at a real file
+    // OUTSIDE the library root. Canonicalize succeeds, but the library-root
+    // guard must still reject it: a poisoned/traversing source path never
+    // escapes.
     let outside = base.join("outside.m4a");
     std::fs::copy(&input, &outside).unwrap();
     let mut ep = index.episodes_for_book(&book.id).unwrap()[0].clone();
@@ -628,11 +632,11 @@ async fn in_place_source_on_a_chaptered_episode_is_rejected() {
         "a chaptered episode has no source_path"
     );
 
-    // Corrupt the row: mark chapter 1 as an in-place whole-file episode pointing at
-    // the WHOLE container (`file_path == source_path`, under the library so the
-    // library-root check passes). Its recorded byte_length is the chapter's size,
-    // not the container's — so the whole-file size invariant must reject it rather
-    // than serve the full container's bytes.
+    // Corrupt the row: mark chapter 1 as an in-place whole-file episode that
+    // points at the WHOLE container (`file_path == source_path`, under the
+    // library, so the library-root check passes). Its recorded byte_length is
+    // the chapter's size, not the container's. So the whole-file size
+    // invariant must reject it; it must not serve the full container's bytes.
     let container = input.canonicalize().unwrap().to_string_lossy().into_owned();
     ep.source_path = container.clone();
     ep.file_path = container;
@@ -808,7 +812,8 @@ async fn regenerate_rejects_an_invalid_slug() {
     let index = Index::open_in_memory().unwrap();
     let state = test_state(index, &data, &dir);
     let app = router(state);
-    // Same-origin (no cross-site header) but an invalid slug (uppercase) → 404.
+    // Same-origin (no cross-site header) but an invalid slug (uppercase)
+    // gives 404.
     let resp = app
         .oneshot(
             Request::post("/book/BadSlug/regenerate")
@@ -858,7 +863,7 @@ async fn remux_source_outside_the_library_is_a_404() {
     let data = base.join("data");
     std::fs::create_dir_all(&library).unwrap();
     let index = Index::open_in_memory().unwrap();
-    // A non-faststart file, ingested with remux ON → a remux-cache episode
+    // A non-faststart file ingested with remux ON gives a remux-cache episode
     // (file_path != source_path, needs_faststart); the cache file was deleted.
     let input = synth_flat(&library);
     let book = scan_book_as(
@@ -936,7 +941,7 @@ async fn regenerate_rotates_the_capability() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::FORBIDDEN, "CSRF rejected");
 
-    // Regenerate -> the old capability URL 404s immediately.
+    // After regenerate, the old capability URL 404s immediately.
     let resp = app
         .clone()
         .oneshot(
@@ -1032,11 +1037,11 @@ async fn serves_feed_and_range_audio() {
     assert!(xml.contains(&format!("http://test/audio/{feed_id}/1")));
     // Feeds are always blocked from podcast directories.
     assert!(xml.contains("<itunes:block>Yes</itunes:block>"));
-    // No embedded cover -> feed-level fallback image is emitted.
+    // No embedded cover, so the feed-level fallback image is emitted.
     assert!(xml.contains("<itunes:image"));
     assert!(xml.contains("http://test/default-cover.png"));
 
-    // unknown id + missing .xml -> 404
+    // An unknown id, and a missing .xml, both give 404.
     for uri in ["/feed/nope.xml".to_string(), format!("/feed/{feed_id}")] {
         let resp = app
             .clone()
@@ -1046,7 +1051,7 @@ async fn serves_feed_and_range_audio() {
         assert_eq!(resp.status(), StatusCode::NOT_FOUND, "{uri}");
     }
 
-    // full audio GET -> 200 + Accept-Ranges
+    // A full audio GET gives 200 + Accept-Ranges.
     let resp = app
         .clone()
         .oneshot(
@@ -1066,7 +1071,7 @@ async fn serves_feed_and_range_audio() {
         "audio/mp4"
     );
 
-    // Range request -> 206 + Content-Range, exactly 100 bytes
+    // A Range request gives 206 + Content-Range, exactly 100 bytes.
     let resp = app
         .clone()
         .oneshot(
@@ -1086,7 +1091,7 @@ async fn serves_feed_and_range_audio() {
     );
     assert_eq!(body_bytes(resp).await.len(), 100);
 
-    // unknown episode number -> 404
+    // An unknown episode number gives 404.
     let resp = app
         .clone()
         .oneshot(
@@ -1158,7 +1163,8 @@ async fn serves_feed_and_range_audio() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 
-    // Unknown book -> 404; cover with no extracted art (Task 3.4) -> 404.
+    // An unknown book gives 404; a cover with no extracted art (Task 3.4)
+    // gives 404.
     for uri in ["/book/nope".to_string(), format!("/cover/{feed_id}")] {
         let resp = app
             .clone()
@@ -1193,8 +1199,9 @@ async fn serves_feed_and_range_audio() {
     }
 }
 
-/// The chapter dir is `<data_dir>/books/<book.id>`, and `book.id` is an opaque
-/// DB key — but a poisoned row must never resolve outside the data dir. The
+/// The chapter dir is `<data_dir>/books/<book.id>`, and `book.id` is an
+/// opaque DB key. But a poisoned row must never resolve outside the data
+/// dir. The
 /// escape target is a *real* directory holding a *real* file, so a pass here
 /// means the containment check rejected it, not that the path merely failed to
 /// canonicalize.
@@ -1246,8 +1253,9 @@ async fn a_feed_failing_the_self_check_is_a_500_not_a_broken_feed() {
     let feed_id = "capabilityidforselfcheck";
     let book = book_row("selfcheck-book", feed_id);
     index.upsert_book(&book).unwrap();
-    // byte_length 0 => MissingEnclosureLength, the #1 feed bug this check exists
-    // to catch (an enclosure length must be the real file size, never 0).
+    // A byte_length of 0 gives MissingEnclosureLength, the number-one feed
+    // bug this check exists to catch (an enclosure length must be the real
+    // file size, never 0).
     index.upsert_episode(&episode_row(&book.id, 0, 0)).unwrap();
 
     let state = test_state(index, &data, &dir);
@@ -1269,9 +1277,10 @@ async fn a_feed_failing_the_self_check_is_a_500_not_a_broken_feed() {
 }
 
 /// The saver-mode regen arm re-splits from `book.source_path`, an opaque DB
-/// value that reaches ffmpeg. A poisoned row pointing outside the library root
-/// must 404 rather than hand ffmpeg an arbitrary file — the same A01 containment
-/// rule the remux arm already enforced (Sprint 6.4 follow-up).
+/// value that reaches ffmpeg. A poisoned row that points outside the library
+/// root must 404; it must not hand ffmpeg an arbitrary file. This is the same
+/// A01 containment rule that the remux arm already enforced (Sprint 6.4
+/// follow-up).
 ///
 /// The escape target is a real file, so a pass means the containment check
 /// rejected it and not that the path merely failed to canonicalize.
@@ -1372,10 +1381,10 @@ async fn saver_source_inside_the_library_still_serves() {
     assert_eq!(body_bytes(resp).await, b"cached chapter bytes");
 }
 
-/// Task 5.2 end-to-end: with transcoding on, a FLAC book serves as AAC/`audio/mp4`
-/// — and even on a `saver` server its episodes are neither regenerated nor evicted
-/// (a re-encode can't be rebuilt byte-for-byte), so what the feed advertises is
-/// exactly what a client gets.
+/// Task 5.2 end-to-end: with transcoding on, a FLAC book serves as
+/// AAC/`audio/mp4`. Even on a `saver` server, its episodes are neither
+/// regenerated nor evicted (a re-encode cannot be rebuilt byte-for-byte), so
+/// what the feed advertises is exactly what a client gets.
 #[tokio::test]
 async fn transcoded_flac_book_serves_as_aac_and_is_never_evicted() {
     skip_unless_ffmpeg!();
@@ -1457,8 +1466,9 @@ async fn transcoded_flac_book_serves_as_aac_and_is_never_evicted() {
 
 /// A bare state over an empty in-memory index, used to drive the readiness gate
 /// without synthesizing audio. Defaults to `ready`; the tests flip it explicitly.
-/// The roots just need to exist (AppState::new canonicalizes them) — no file
-/// under them is ever touched, so the shared temp dir is fine on every OS.
+/// The roots only need to exist (`AppState::new` canonicalizes them). No
+/// file under them is ever touched, so the shared temp dir is fine on every
+/// OS.
 fn empty_state() -> AppState {
     let tmp = std::env::temp_dir();
     test_state(Index::open_in_memory().unwrap(), &tmp, &tmp)
@@ -1508,7 +1518,8 @@ async fn once_ready_the_browse_ui_serves_normally() {
     state.set_ready(false);
     state.set_ready(true); // scan finished
 
-    // Empty library, but the real grid (not the Scanning page) — a normal 200.
+    // Empty library, but the real grid (not the Scanning page): a normal
+    // 200.
     let resp = router(state.clone())
         .oneshot(Request::get("/").body(Body::empty()).unwrap())
         .await
@@ -1553,7 +1564,8 @@ async fn theme_cookie_renders_data_theme() {
         "{html}"
     );
 
-    // No cookie → no data-theme on <html> (follows the OS via prefers-color-scheme).
+    // No cookie means no data-theme on <html> (the page follows the OS via
+    // prefers-color-scheme).
     let resp = router(state)
         .oneshot(Request::get("/").body(Body::empty()).unwrap())
         .await
@@ -1584,7 +1596,8 @@ async fn set_theme_sets_cookie_then_clears_it() {
     assert!(cookie.contains("theme=dark"), "{cookie}");
     assert!(cookie.contains("Max-Age=31536000"), "{cookie}");
 
-    // Choosing "system" clears the cookie (Max-Age=0) → revert to the OS.
+    // A "system" choice clears the cookie (Max-Age=0), which reverts to the
+    // OS.
     let resp = router(empty_state())
         .oneshot(
             Request::post("/theme/system")
@@ -1607,7 +1620,8 @@ async fn set_theme_sets_cookie_then_clears_it() {
 
 #[tokio::test]
 async fn set_theme_rejects_cross_site() {
-    // A cross-site POST can't flip the theme (CSRF guard), same as regenerate.
+    // A cross-site POST cannot flip the theme (CSRF guard), same as
+    // regenerate.
     let resp = router(empty_state())
         .oneshot(
             Request::post("/theme/dark")
@@ -1694,9 +1708,10 @@ async fn serves_scanner_generated_thumbnail_with_fallback() {
 
 #[tokio::test]
 async fn cover_thumb_falls_back_to_the_full_cover_when_absent() {
-    // A book with a cover but no generated thumbnail (e.g. before a reconcile
-    // backfills it): `/thumb` must serve the full cover file rather than 404.
-    // ffmpeg-free — the handler only serves, it never generates.
+    // A book with a cover but no generated thumbnail (e.g. before a
+    // reconcile backfills it): `/thumb` must serve the full cover file, not
+    // 404. The test is ffmpeg-free: the handler only serves, it never
+    // generates.
     let dir = scratch("http-thumb-fallback");
     let data = dir.join("data");
     let book_dir = data.join("books").join("badcover");

--- a/crates/index/Cargo.toml
+++ b/crates/index/Cargo.toml
@@ -20,3 +20,6 @@ base64 = { workspace = true }
 
 [dev-dependencies]
 podspine-test-support = { path = "../test-support" }
+
+[lints]
+workspace = true

--- a/crates/index/src/lib.rs
+++ b/crates/index/src/lib.rs
@@ -1,17 +1,18 @@
 //! `index` — the `rusqlite` (bundled SQLite) access layer.
 //!
-//! Owns the schema (TAD §5.1) and provides idempotent upserts keyed on stable
-//! ids (`book.id`, `episode.guid`) so re-scans of an unchanged source don't churn
-//! the database. `rusqlite::Connection` is not `Sync`, so the server accesses an
-//! [`Index`] behind a mutex / `spawn_blocking` (Sprint 2.4); this layer is
-//! synchronous.
+//! This crate owns the schema (TAD §5.1) and provides idempotent upserts
+//! keyed on stable ids (`book.id`, `episode.guid`), so re-scans of an
+//! unchanged source do not churn the database. `rusqlite::Connection` is not
+//! `Sync`, so the server accesses an [`Index`] behind a mutex /
+//! `spawn_blocking` (Sprint 2.4); this layer is synchronous.
 //!
 //! Feed privacy (v1.5) is a **capability URL**: each book carries a random,
-//! unguessable `feed_id` (128 bits) that is the public key for its feed, audio,
-//! and cover — the human `slug` is only for the LAN browse UI. The `feed_id` is
-//! stable across re-scans (preserved on upsert) and rotated only on an explicit
-//! [`Index::regenerate_feed_id`] (leak recovery). Feeds are always kept out of
-//! podcast directories (`itunes:block`) — they're private capability URLs.
+//! unguessable `feed_id` (128 bits) that is the public key for its feed,
+//! audio, and cover. The human `slug` is only for the LAN browse UI. The
+//! `feed_id` is stable across re-scans (preserved on upsert) and rotated only
+//! by an explicit [`Index::regenerate_feed_id`] (leak recovery). Feeds are
+//! always kept out of podcast directories (`itunes:block`): they are private
+//! capability URLs.
 
 use std::path::Path;
 
@@ -22,9 +23,9 @@ use rusqlite::{Connection, OptionalExtension, Row, params};
 // their own.
 pub use podspine_config::{StorageMode, TranscodeMode};
 
-/// Capability-id generation: an unguessable, URL-safe feed id. Stored raw (it is
-/// the owner's own retrievable link, shown in the UI and QR — not a hashed
-/// per-subscriber secret).
+/// Capability-id generation: an unguessable, URL-safe feed id. Stored raw (it
+/// is the owner's own retrievable link, shown in the UI and QR; it is not a
+/// hashed per-subscriber secret).
 pub mod capability {
     use base64::Engine;
 
@@ -41,9 +42,10 @@ pub mod capability {
     }
 }
 
-/// Schema, created on open. `IF NOT EXISTS` makes open idempotent. Pre-release:
-/// changing this is a fresh-schema change (delete an old `data/podspine.db` and
-/// re-scan) — no migration path is maintained before v1.
+/// Schema, created on open. `IF NOT EXISTS` makes open idempotent.
+/// Pre-release: a change here is a fresh-schema change (delete an old
+/// `data/podspine.db` and re-scan); no migration path is maintained before
+/// v1.
 const SCHEMA: &str = "
 CREATE TABLE IF NOT EXISTS book (
     id           TEXT PRIMARY KEY,
@@ -81,10 +83,11 @@ CREATE INDEX IF NOT EXISTS episode_book_idx ON episode(book_id, idx);
 pub struct BookRow {
     /// Opaque stable id.
     pub id: String,
-    /// URL slug (unique) — the human key for the LAN browse UI only.
+    /// URL slug (unique): the human key for the LAN browse UI only.
     pub slug: String,
-    /// Capability id (unique, unguessable) — the public key for feed/audio/cover.
-    /// Stable across re-scans; rotated only by [`Index::regenerate_feed_id`].
+    /// Capability id (unique, unguessable): the public key for
+    /// feed/audio/cover. Stable across re-scans; rotated only by
+    /// [`Index::regenerate_feed_id`].
     pub feed_id: String,
     /// Title.
     pub title: String,
@@ -127,20 +130,22 @@ pub struct EpisodeRow {
     pub idx: i64,
     /// Episode title.
     pub title: String,
-    /// Path to the served audio file. Extracted (chaptered) episode → the split
-    /// under `<data_dir>`. Whole-file episode served in place → the original
-    /// library file (`== source_path`). Whole-file episode remuxed to faststart
-    /// (Sprint 6.3) → the cache file under `<data_dir>` (`!= source_path`).
+    /// Path to the served audio file. For an extracted (chaptered) episode,
+    /// this is the split under `<data_dir>`. For a whole-file episode served
+    /// in place, it is the original library file (`== source_path`). For a
+    /// whole-file episode remuxed to faststart (Sprint 6.3), it is the cache
+    /// file under `<data_dir>` (`!= source_path`).
     pub file_path: String,
-    /// When non-empty, the episode IS a whole source file (MP3-folder track, or a
-    /// chapterless single file). `file_path == source_path` ⇒ streamed in place
-    /// from the library; `file_path != source_path` ⇒ remuxed to faststart and
-    /// cached under `<data_dir>`. Empty ⇒ an extracted sub-range (`full`/`saver`).
-    /// See TAD §5.3.
+    /// When non-empty, the episode IS a whole source file (an MP3-folder
+    /// track, or a chapterless single file). `file_path == source_path` means
+    /// streamed in place from the library. `file_path != source_path` means
+    /// remuxed to faststart and cached under `<data_dir>`. Empty means an
+    /// extracted sub-range (`full`/`saver`). See TAD §5.3.
     pub source_path: String,
-    /// `true` when the source is a non-faststart MP4 (`moov` after `mdat`), so a
-    /// whole-file serve seeks slowly. Recorded at ingest; drives the callout and,
-    /// with `PODSPINE_REMUX_NON_FASTSTART` on, the remux-vs-in-place decision.
+    /// `true` when the source is a non-faststart MP4 (`moov` after `mdat`),
+    /// so a whole-file serve seeks slowly. It is recorded at ingest. It
+    /// drives the log notice and, with `PODSPINE_REMUX_NON_FASTSTART` on, the
+    /// remux-vs-in-place decision.
     pub needs_faststart: bool,
     /// Real output size in bytes.
     pub byte_length: i64,
@@ -188,15 +193,16 @@ impl Index {
         Ok(Self { conn })
     }
 
-    /// Additive migrations for databases created by an older Podspine. Pre-v1 we
-    /// don't keep a full migration path, but silently breaking an existing DB at
-    /// request time is worse than a cheap `ADD COLUMN` here: `CREATE TABLE IF NOT
-    /// EXISTS` won't add a column to a table that already exists, so an older
-    /// `episode` table would be missing `start_sec` and every audio/feed query
-    /// would fail mid-request. `ADD COLUMN` preserves all rows (and the
-    /// capability `feed_id`s — a drop+recreate would rotate every feed URL).
-    /// Existing episodes get `start_sec = 0`; that value is only read for
-    /// `saver`-mode regeneration and is corrected on the next re-scan.
+    /// Additive migrations for databases created by an older Podspine.
+    /// Podspine keeps no full migration path before v1, but a silent break of
+    /// an existing DB at request time is worse than a cheap `ADD COLUMN`
+    /// here. `CREATE TABLE IF NOT EXISTS` will not add a column to a table
+    /// that already exists, so an older `episode` table would lack
+    /// `start_sec`, and every audio/feed query would fail mid-request.
+    /// `ADD COLUMN` preserves all rows, and also the capability `feed_id`s (a
+    /// drop+recreate would rotate every feed URL). Existing episodes get
+    /// `start_sec = 0`; that value is only read for `saver`-mode
+    /// regeneration, and the next re-scan corrects it.
     fn migrate(conn: &Connection) -> Result<(), IndexError> {
         // `episode.start_sec` (saver-mode regeneration). Existing rows get 0;
         // corrected on the next re-scan.
@@ -229,38 +235,39 @@ impl Index {
         // matching how every pre-5.2 book was actually produced.
         add_column_if_missing(conn, "book", "transcode", "TEXT NOT NULL DEFAULT ''")?;
         // `book.created_at` (first-seen time, epoch millis). Its only use is
-        // picking the survivor when healing a database that holds two rows for one
-        // source: the earliest-created row is the feed subscribers have held
-        // longest (`collapse_duplicate_source_rows`).
+        // to pick the survivor when a database that holds two rows for one
+        // source is healed: the earliest-created row is the feed that
+        // subscribers have held longest (`collapse_duplicate_source_rows`).
         //
-        // Pre-existing rows are back-filled from `rowid`, NOT a flat 0. rowid is
-        // SQLite's monotonic insertion counter, so it reproduces the order rows
-        // were first written — which is exactly "created_at" for rows we didn't
-        // stamp. A flat 0 would tie every migrated row, and a database that already
-        // held a duplicate (an established suffixed `book-2` plus a later base
-        // `book`) would then fall back to id order and delete the established feed
-        // (Greptile). rowid keeps them distinct and correctly ordered. rowid values
-        // are tiny next to the epoch-millis stamps new rows get, so a migrated row
-        // always sorts before any row written afterwards — still correct, since it
-        // is genuinely older.
+        // Pre-existing rows are back-filled from `rowid`, NOT a flat 0. rowid
+        // is SQLite's monotonic insertion counter, so it reproduces the order
+        // in which rows were first written. That order is exactly
+        // "created_at" for rows that were never stamped. A flat 0 would tie
+        // every migrated row, and a database that already held a duplicate
+        // (an established suffixed `book-2` plus a later base `book`) would
+        // then fall back to id order and delete the established feed
+        // (Greptile). rowid keeps them distinct and correctly ordered. rowid
+        // values are tiny next to the epoch-millis stamps that new rows get,
+        // so a migrated row always sorts before any row written afterwards.
+        // That is still correct: the migrated row is genuinely older.
         if add_column_if_missing(conn, "book", "created_at", "INTEGER NOT NULL DEFAULT 0")? {
             conn.execute("UPDATE book SET created_at = rowid", [])?;
         }
-        // `book.status` is gone: it was write-only — always `"ready"`, never read
-        // anywhere in the workspace — so it was dead weight in every SELECT and
-        // struct literal. A database created by an older Podspine still carries
-        // the column (with `NOT NULL`, which would break the column-less INSERT
-        // in `upsert_book`), so drop it rather than leave fresh and migrated
-        // schemas divergent.
+        // `book.status` is gone: it was write-only (always `"ready"`, never
+        // read anywhere in the workspace), so it was dead weight in every
+        // SELECT and struct literal. A database created by an older Podspine
+        // still carries the column (with `NOT NULL`, which would break the
+        // column-less INSERT in `upsert_book`). So drop it; fresh and migrated
+        // schemas must not diverge.
         drop_column_if_present(conn, "book", "status")?;
         Ok(())
     }
 
-    /// Insert or update a book by `id` (idempotent — no duplicate rows).
+    /// Insert or update a book by `id` (idempotent: no duplicate rows).
     ///
-    /// On conflict, `feed_id` is **preserved**, not overwritten: a re-scan
-    /// supplies a fresh `feed_id` it doesn't know is already set, and the
-    /// capability must stay stable across re-scans (it changes only via
+    /// On conflict, `feed_id` is **preserved**, not overwritten. A re-scan
+    /// supplies a fresh `feed_id`; it does not know one is already set. And
+    /// the capability must stay stable across re-scans (it changes only via
     /// [`Index::regenerate_feed_id`]).
     pub fn upsert_book(&self, b: &BookRow) -> Result<(), IndexError> {
         self.conn.execute(
@@ -273,9 +280,9 @@ impl Index {
                source_mtime=excluded.source_mtime,
                storage_mode=excluded.storage_mode, default_cover_url=excluded.default_cover_url,
                force_embedded=excluded.force_embedded, transcode=excluded.transcode",
-            // created_at is set on first insert and deliberately absent from the
-            // UPDATE set, so a re-scan preserves a book's first-seen time — the same
-            // way feed_id is preserved.
+            // created_at is set on first insert and deliberately absent from
+            // the UPDATE set, so a re-scan preserves a book's first-seen time,
+            // the same way feed_id is preserved.
             params![
                 b.id,
                 b.slug,
@@ -285,9 +292,10 @@ impl Index {
                 b.cover_path,
                 b.source_path,
                 b.source_mtime,
-                // The enum↔TEXT boundary (write side): `None` persists as `""`,
-                // a known mode as its canonical label — byte-identical to what
-                // pre-typed builds wrote, so a re-scan never churns rows.
+                // The enum↔TEXT boundary (write side): `None` persists as
+                // `""`, and a known mode persists as its canonical label. That
+                // is byte-identical to what pre-typed builds wrote, so a
+                // re-scan never churns rows.
                 b.storage_mode.map_or("", StorageMode::label),
                 b.default_cover_url,
                 b.force_embedded,
@@ -360,10 +368,11 @@ impl Index {
         Ok(rows.collect::<Result<Vec<_>, _>>()?)
     }
 
-    /// `(id, source_path, created_at)` for every book — the minimum the scanner
-    /// needs to collapse duplicate-source rows to their earliest-created survivor,
-    /// without pulling every full [`BookRow`]. Ordered oldest-first, id-tiebroken,
-    /// so a caller keeping the first of a source-group keeps the established feed.
+    /// `(id, source_path, created_at)` for every book: the minimum that the
+    /// scanner needs to collapse duplicate-source rows to their
+    /// earliest-created survivor, without a pull of every full [`BookRow`].
+    /// Ordered oldest-first, id-tiebroken, so a caller that keeps the first of
+    /// a source-group keeps the established feed.
     pub fn book_source_identities(&self) -> Result<Vec<(String, String, i64)>, IndexError> {
         let mut stmt = self.conn.prepare(
             "SELECT id, source_path, created_at FROM book ORDER BY created_at ASC, id ASC",
@@ -383,8 +392,8 @@ impl Index {
     }
 
     /// Fetch a book by its capability `feed_id` (the public feed/audio/cover
-    /// lookup key). Unknown ids return `None` → 404, so a guessed id reveals
-    /// nothing.
+    /// lookup key). Unknown ids return `None`, which the caller maps to 404,
+    /// so a guessed id reveals nothing.
     pub fn get_book_by_feed_id(&self, feed_id: &str) -> Result<Option<BookRow>, IndexError> {
         Ok(self
             .conn
@@ -397,8 +406,8 @@ impl Index {
     }
 
     /// Rotate a book's capability id (leak recovery): the old feed/audio/cover
-    /// URLs stop resolving immediately. Returns the new `feed_id`. No-op returns
-    /// `Ok(None)` if the book id is unknown.
+    /// URLs stop resolving immediately. Return the new `feed_id`. An unknown
+    /// book id is a no-op that returns `Ok(None)`.
     pub fn regenerate_feed_id(&self, book_id: &str) -> Result<Option<String>, IndexError> {
         let new_id = capability::generate();
         let n = self.conn.execute(
@@ -418,7 +427,7 @@ impl Index {
 }
 
 /// Add `column` to `table` if it is missing; `ddl` is the type + constraints
-/// clause. Returns whether the column was added, so a migration can run a
+/// clause. Return whether the column was added, so that a migration can run a
 /// one-time backfill on exactly the databases that migrated.
 fn add_column_if_missing(
     conn: &Connection,
@@ -432,8 +441,8 @@ fn add_column_if_missing(
         |r| r.get(0),
     )?;
     if present == 0 {
-        // table/column/ddl are compile-time literals from `migrate`, never user
-        // input — safe to splice.
+        // table/column/ddl are compile-time literals from `migrate`, never
+        // user input. They are safe to splice.
         conn.execute(
             &format!("ALTER TABLE {table} ADD COLUMN {column} {ddl}"),
             [],
@@ -443,10 +452,11 @@ fn add_column_if_missing(
     Ok(false)
 }
 
-/// Drop `column` from `table` if present — [`add_column_if_missing`]'s inverse,
-/// for retiring a column an older Podspine wrote that nothing reads anymore.
-/// Same `pragma_table_info` probe; `ALTER TABLE … DROP COLUMN` needs SQLite ≥
-/// 3.35, and the bundled SQLite in rusqlite 0.40 is far past that.
+/// Drop `column` from `table` if present: [`add_column_if_missing`]'s
+/// inverse, used to retire a column that an older Podspine wrote and nothing
+/// reads anymore. It uses the same `pragma_table_info` probe.
+/// `ALTER TABLE … DROP COLUMN` needs SQLite ≥ 3.35, and the bundled SQLite in
+/// rusqlite 0.40 is far past that.
 fn drop_column_if_present(conn: &Connection, table: &str, column: &str) -> Result<(), IndexError> {
     let present: i64 = conn.query_row(
         "SELECT COUNT(*) FROM pragma_table_info(?1) WHERE name = ?2",
@@ -454,15 +464,17 @@ fn drop_column_if_present(conn: &Connection, table: &str, column: &str) -> Resul
         |r| r.get(0),
     )?;
     if present > 0 {
-        // table/column are compile-time literals from `migrate` — safe to splice.
+        // table/column are compile-time literals from `migrate`. They are
+        // safe to splice.
         conn.execute(&format!("ALTER TABLE {table} DROP COLUMN {column}"), [])?;
     }
     Ok(())
 }
 
-/// Wall-clock **milliseconds** since the Unix epoch, for a book's first-seen time.
-/// Milliseconds (not seconds) so two books indexed close together still order
-/// distinctly. A clock before 1970 (unset RTC) clamps to 0 rather than panicking.
+/// Wall-clock **milliseconds** since the Unix epoch, for a book's first-seen
+/// time. Milliseconds (not seconds), so that two books indexed close together
+/// still order distinctly. A clock before 1970 (an unset RTC) clamps to 0; it
+/// does not panic.
 fn now_epoch_millis() -> i64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -470,8 +482,9 @@ fn now_epoch_millis() -> i64 {
         .unwrap_or(0)
 }
 
-/// The `book` SELECT column list. Order must match `book_from_row`'s ordinals —
-/// one definition so adding a column edits exactly one string and one mapper.
+/// The `book` SELECT column list. The order must match `book_from_row`'s
+/// ordinals. One definition, so that a new column edits exactly one string and
+/// one mapper.
 const BOOK_COLUMNS: &str = "id, slug, feed_id, title, author, cover_path, source_path, source_mtime, storage_mode, default_cover_url, force_embedded, transcode";
 
 fn book_from_row(row: &Row) -> rusqlite::Result<BookRow> {
@@ -484,10 +497,11 @@ fn book_from_row(row: &Row) -> rusqlite::Result<BookRow> {
         cover_path: row.get(5)?,
         source_path: row.get(6)?,
         source_mtime: row.get(7)?,
-        // The enum↔TEXT boundary (read side): `""` — a pre-6.4/pre-5.2 row — and
-        // any unrecognized value both map to `None`, preserving the historical
-        // fall-through-to-global behavior (a typo'd or future mode can never
-        // crash a serve; it just follows the server config until re-scanned).
+        // The enum↔TEXT boundary (read side): `""` (a pre-6.4/pre-5.2 row) and
+        // any unrecognized value both map to `None`, which preserves the
+        // historical fall-through-to-global behavior. A typo'd or future mode
+        // can never crash a serve; it follows the server config until the book
+        // is re-scanned.
         storage_mode: StorageMode::from_label(&row.get::<_, String>(8)?),
         default_cover_url: row.get(9)?,
         force_embedded: row.get(10)?,
@@ -606,7 +620,7 @@ mod tests {
     #[test]
     fn foreign_key_is_enforced() {
         let idx = Index::open_in_memory().unwrap();
-        // No such book -> FK violation.
+        // No such book, so the insert is an FK violation.
         let err = idx.upsert_episode(&episode("ghost", 0)).unwrap_err();
         assert!(matches!(err, IndexError::Sqlite(_)));
     }
@@ -666,8 +680,8 @@ mod tests {
             .unwrap();
         }
 
-        // Opening runs the additive migration: start_sec is added (default 0),
-        // existing rows and the capability feed_id survive.
+        // The open runs the additive migration: start_sec is added
+        // (default 0), and existing rows and the capability feed_id survive.
         let idx = Index::open(&db).unwrap();
         let eps = idx.episodes_for_book("b1").unwrap();
         assert_eq!(eps.len(), 1);
@@ -717,7 +731,7 @@ mod tests {
             "a migrated row is back-filled from its rowid (the only book, so rowid 1)"
         );
 
-        // Idempotent: reopening an already-migrated DB is a no-op.
+        // Idempotent: a reopen of an already-migrated DB is a no-op.
         drop(idx);
         assert!(Index::open(&db).is_ok());
     }
@@ -725,12 +739,13 @@ mod tests {
     #[test]
     fn migration_backfills_created_at_from_insertion_order() {
         // Greptile's case: a pre-`created_at` database that already holds an
-        // established suffixed row (`book-2`, inserted first) and a later base-id
-        // duplicate (`book`) for ONE source. Back-filling both to a flat 0 would
-        // tie them and let survivor-selection fall back to id order, deleting the
-        // established feed. rowid preserves insertion order, so `book-2` keeps the
-        // earlier `created_at` and `book_source_identities` returns it first — which
-        // is the row the heal keeps.
+        // established suffixed row (`book-2`, inserted first) and a later
+        // base-id duplicate (`book`) for ONE source. A back-fill of both to a
+        // flat 0 would tie them and let survivor-selection fall back to id
+        // order, which would delete the established feed. rowid preserves
+        // insertion order, so `book-2` keeps the earlier `created_at`, and
+        // `book_source_identities` returns it first. That is the row the heal
+        // keeps.
         let dir = scratch("index-createdat-order");
         let db = dir.join("old.db");
         {
@@ -742,7 +757,8 @@ mod tests {
                     source_mtime INTEGER NOT NULL, status TEXT NOT NULL);",
             )
             .unwrap();
-            // Established row FIRST (smaller rowid), duplicate SECOND — same source.
+            // The established row is FIRST (smaller rowid), the duplicate
+            // SECOND; both share one source.
             conn.execute(
                 "INSERT INTO book VALUES ('book-2','book-2','cap-established','Book',NULL,NULL,'/lib/book.m4b',1,'ready')",
                 [],
@@ -804,7 +820,7 @@ mod tests {
         assert!(idx.delete_book("b1").unwrap());
         assert_eq!(idx.get_book("b1").unwrap(), None);
         assert!(idx.episodes_for_book("b1").unwrap().is_empty());
-        // Deleting a missing book is a no-op.
+        // A delete of a missing book is a no-op.
         assert!(!idx.delete_book("b1").unwrap());
     }
 
@@ -813,8 +829,8 @@ mod tests {
         let idx = Index::open_in_memory().unwrap();
         idx.upsert_book(&book("b1", "a-book", "A Book")).unwrap();
 
-        // A re-scan supplies a different feed_id; the capability must be preserved
-        // (only title/etc update).
+        // A re-scan supplies a different feed_id; the capability must be
+        // preserved (only title etc. update).
         let mut rescan = book("b1", "a-book", "A Book v2");
         rescan.feed_id = "cap-DIFFERENT".to_string();
         idx.upsert_book(&rescan).unwrap();
@@ -837,7 +853,7 @@ mod tests {
             None,
             "old capability URL 404s after regenerate"
         );
-        // Unknown book → no-op.
+        // An unknown book is a no-op.
         assert_eq!(idx.regenerate_feed_id("ghost").unwrap(), None);
     }
 

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -18,3 +18,6 @@ tokio = { workspace = true }
 [dev-dependencies]
 tower = { version = "=0.5.3", features = ["util"] }
 http-body-util = "=0.1.5"
+
+[lints]
+workspace = true

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -7,14 +7,15 @@
 //!
 //! The endpoint is a **standalone listener**, never a route on the feed server.
 //! Feeds are capability URLs meant to be safe to expose publicly ([TAD §5.3]);
-//! metrics are operator data — how many books exist, how often things fail —
-//! and putting them on that same surface would hand an anonymous caller a
+//! metrics are operator data (how many books exist, how often things fail),
+//! and to put them on that same surface would hand an anonymous caller a
 //! library-size oracle. Bind this to loopback or the LAN.
 //!
 //! Label cardinality is deliberately bounded: the only label anywhere is
 //! [`ErrorKind`], a closed set of three static strings. Book titles, slugs,
-//! capability ids, and filesystem paths are never emitted — they would both
-//! explode series count and leak exactly what the private-feed design protects.
+//! capability ids, and filesystem paths are never emitted: they would both
+//! explode the series count and leak exactly what the private-feed design
+//! protects.
 
 use std::time::Duration;
 
@@ -34,26 +35,27 @@ pub const SPLIT_DURATION: &str = "podspine_split_duration_seconds";
 /// Request failures, labelled by [`ErrorKind`] (counter).
 pub const ERRORS: &str = "podspine_errors_total";
 
-/// Bucket bounds (seconds) for [`SPLIT_DURATION`]. Chosen around the measured
-/// ingest profile — a stream-copy chapter split lands in the tens of
-/// milliseconds to a few seconds — with a long tail up to two minutes so a
-/// pathological source is visible rather than lumped into `+Inf`.
+/// Bucket bounds (seconds) for [`SPLIT_DURATION`]. The bounds are chosen
+/// around the measured ingest profile (a stream-copy chapter split lands in
+/// the tens of milliseconds to a few seconds), with a long tail up to two
+/// minutes, so that a pathological source is visible and not lumped into
+/// `+Inf`.
 const SPLIT_BUCKETS: &[f64] = &[0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0];
 
-/// How often histogram data is drained. Without this the recorder's histograms
-/// grow unboundedly — with the crate's own HTTP listener disabled, running
-/// upkeep is our job.
+/// How often histogram data is drained. Without this, the recorder's
+/// histograms grow without bound. The crate's own HTTP listener is disabled,
+/// so the upkeep run is this crate's job.
 const UPKEEP_INTERVAL: Duration = Duration::from_secs(30);
 
-/// What failed, as a bounded label set. Kept to a closed enum of static strings
-/// so series count can't grow with traffic.
+/// What failed, as a bounded label set. Kept to a closed enum of static
+/// strings, so that the series count cannot grow with traffic.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ErrorKind {
     /// Unknown book, episode, or capability id (also every rejected slug).
     NotFound,
     /// A resolved path escaped its trusted root, or an origin check failed.
     Forbidden,
-    /// Anything we consider our own fault: I/O, ffmpeg, index, render.
+    /// Anything that is Podspine's own fault: I/O, ffmpeg, index, render.
     Internal,
 }
 
@@ -73,7 +75,7 @@ impl ErrorKind {
 /// Call once, before serving. Until this runs every helper below is a no-op.
 ///
 /// # Errors
-/// Returns [`BuildError`] if the recorder can't be built, or if a global
+/// Returns [`BuildError`] if the recorder cannot be built, or if a global
 /// recorder was already installed.
 pub fn install() -> Result<PrometheusHandle, BuildError> {
     let handle = PrometheusBuilder::new()
@@ -85,13 +87,13 @@ pub fn install() -> Result<PrometheusHandle, BuildError> {
     metrics::describe_histogram!(SPLIT_DURATION, "Seconds spent splitting one chapter");
     metrics::describe_counter!(ERRORS, "Request failures by kind");
 
-    // Touch every counter/gauge at zero. The exporter only renders a series once
-    // it has been recorded, so without this a freshly started server exposes
-    // nothing and dashboards read "no data" — indistinguishable from a scrape
-    // failure — until the first feed request happens to arrive. The histogram is
-    // deliberately left out: there is no way to register it without recording an
-    // observation, and a fake 0s split would skew the very distribution it exists
-    // to measure.
+    // Touch every counter/gauge at zero. The exporter only renders a series
+    // once it has been recorded. Without this, a freshly started server
+    // exposes nothing, and dashboards read "no data" (indistinguishable from
+    // a scrape failure) until the first feed request happens to arrive. The
+    // histogram is deliberately left out: there is no way to register it
+    // without an observation, and a fake 0s split would skew the very
+    // distribution it exists to measure.
     metrics::gauge!(BOOKS_INDEXED).set(0.0);
     metrics::counter!(FEEDS_SERVED).increment(0);
     for kind in [
@@ -145,12 +147,12 @@ async fn render(State(handle): State<PrometheusHandle>) -> impl IntoResponse {
 }
 
 /// Serve the metrics endpoint on an already-bound listener until shutdown,
-/// draining histograms on an interval alongside it.
+/// and drain histograms on an interval alongside it.
 ///
 /// Takes a bound listener rather than an address on purpose: this runs as a
 /// detached background task, so a bind failure here would only reach a log
-/// line. The caller binds first and treats that failure as fatal — if the
-/// operator asked for metrics and the port is taken, they should hear about it
+/// line. The caller binds first and treats that failure as fatal. If the
+/// operator asked for metrics and the port is taken, they must hear about it
 /// at startup, not discover a silently missing endpoint at scrape time.
 ///
 /// # Errors
@@ -179,7 +181,7 @@ mod tests {
     use http_body_util::BodyExt;
     use tower::ServiceExt;
 
-    /// One recorder per process — `install` on a second test would fail with
+    /// One recorder per process: `install` on a second test would fail with
     /// `FailedToSetGlobalRecorder`, so the tests that need real output share
     /// this one handle.
     ///
@@ -311,7 +313,7 @@ mod tests {
     #[tokio::test]
     async fn serve_answers_a_real_scrape_over_tcp() {
         // The oneshot tests above exercise the router; this covers `serve`
-        // itself — the listener, the spawned upkeep task, and the wiring in
+        // itself: the listener, the spawned upkeep task, and the wiring in
         // between, which is what a Prometheus scrape actually talks to.
         let installed = handle();
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -327,8 +329,8 @@ mod tests {
         server.abort();
     }
 
-    /// Minimal HTTP/1.1 GET — enough to prove the listener answers, without
-    /// adding an HTTP client dependency for one test.
+    /// Minimal HTTP/1.1 GET: enough to prove that the listener answers,
+    /// without an HTTP client dependency for one test.
     async fn reqwest_get(url: &str) -> String {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
         let (host, path) = url.trim_start_matches("http://").split_once('/').unwrap();

--- a/crates/prober/Cargo.toml
+++ b/crates/prober/Cargo.toml
@@ -13,3 +13,6 @@ publish = false
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/prober/src/faststart.rs
+++ b/crates/prober/src/faststart.rs
@@ -1,4 +1,4 @@
-//! Faststart detection for whole-file MP4 (`.m4a`/`.m4b`) — pure byte parsing,
+//! Faststart detection for whole-file MP4 (`.m4a`/`.m4b`): pure byte parsing,
 //! **no ffprobe**.
 //!
 //! An MP4 seeks quickly only when its `moov` atom (the index) sits BEFORE the
@@ -14,17 +14,17 @@ use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
 use std::path::Path;
 
-/// Upper bound on top-level boxes scanned, so a malformed or hostile file can't
-/// spin the loop. A real MP4 reaches `moov`/`mdat` within a handful of boxes.
+/// Upper bound on top-level boxes scanned, so that a malformed or hostile
+/// file cannot spin the loop. A real MP4 reaches `moov`/`mdat` within a handful of boxes.
 const MAX_BOXES: usize = 256;
 
-/// Whether `path` is a **non-faststart MP4** — i.e. it IS an MP4 (a `ftyp` box is
-/// present) and its `mdat` box precedes `moov`.
+/// Whether `path` is a **non-faststart MP4**: it IS an MP4 (a `ftyp` box is
+/// present), and its `mdat` box precedes `moov`.
 ///
-/// Returns `false` for a faststart MP4 (`moov` first), a non-MP4 (MP3/OGG/FLAC —
-/// no `ftyp`/`moov`/`mdat` boxes), or any read/parse error. Failing to `false` is
-/// deliberate: a file we can't classify is served in place unchanged, never
-/// remuxed on a guess.
+/// Return `false` for a faststart MP4 (`moov` first), a non-MP4
+/// (MP3/OGG/FLAC: no `ftyp`/`moov`/`mdat` boxes), or any read/parse error.
+/// The fail-to-`false` is deliberate: a file that cannot be classified is
+/// served in place unchanged, never remuxed on a guess.
 pub fn needs_faststart(path: &Path) -> bool {
     scan(path).unwrap_or(false)
 }
@@ -60,21 +60,22 @@ fn scan(path: &Path) -> std::io::Result<bool> {
             n => u64::from(n),
         };
         if box_size < 8 {
-            break; // malformed header — give up (serve in place)
+            break; // A malformed header: give up (serve in place).
         }
 
         match &kind {
             b"ftyp" => saw_ftyp = true,
-            // `moov` seen before any `mdat` => already faststart.
+            // `moov` before any `mdat` means the file is already faststart.
             b"moov" => return Ok(false),
-            // `mdat` seen before `moov` => needs faststart, but only for a real
-            // MP4 (a stray `mdat`-like tag in a non-MP4 shouldn't trigger a remux).
+            // `mdat` before `moov` means the file needs faststart, but only
+            // for a real MP4 (a stray `mdat`-like tag in a non-MP4 must not
+            // trigger a remux).
             b"mdat" => return Ok(saw_ftyp),
             _ => {}
         }
 
-        // Advance to the next top-level box; stop on overflow or a non-advancing
-        // size so a crafted file can't loop.
+        // Advance to the next top-level box. Stop on overflow or a
+        // non-advancing size, so that a crafted file cannot loop.
         match pos.checked_add(box_size) {
             Some(next) if next > pos => pos = next,
             _ => break,
@@ -133,7 +134,8 @@ mod tests {
 
     #[test]
     fn mdat_first_without_ftyp_is_not_treated_as_mp4() {
-        // No `ftyp` => not an MP4 we should touch, even if an `mdat`-like tag leads.
+        // No `ftyp` means this is not an MP4 to touch, even when an
+        // `mdat`-like tag leads.
         let p = write(
             "nottyp",
             &[mp4_box(b"mdat", &[0u8; 32]), mp4_box(b"moov", &[0u8; 8])],
@@ -165,8 +167,8 @@ mod tests {
 
     #[test]
     fn a_box_smaller_than_its_8_byte_header_is_malformed() {
-        // A size field below the 8-byte box header (here 4) is malformed → give up
-        // (return false), never loop or misread.
+        // A size field below the 8-byte box header (here 4) is malformed:
+        // give up (return false), never loop or misread.
         let p = write("tinybox", &[vec![0, 0, 0, 4, b'f', b't', b'y', b'p']]);
         assert!(!needs_faststart(&p));
         let _ = std::fs::remove_file(&p);
@@ -175,7 +177,8 @@ mod tests {
     #[test]
     fn a_box_size_overflowing_the_offset_terminates() {
         // A valid `ftyp`, then a 64-bit largesize box whose size overflows
-        // `pos + size` → `checked_add` returns None → clean break (no panic/loop).
+        // `pos + size`. `checked_add` returns None, and the loop breaks
+        // cleanly (no panic, no spin).
         let mut bytes = mp4_box(b"ftyp", b"isom");
         bytes.extend_from_slice(&1u32.to_be_bytes()); // size32 = 1 (largesize follows)
         bytes.extend_from_slice(b"free");
@@ -188,8 +191,9 @@ mod tests {
     #[test]
     fn a_crafted_64bit_largesize_box_does_not_overflow() {
         // First box: size32 == 1 (a 64-bit largesize follows the type), type
-        // "free", largesize near u64::MAX. Advancing `pos` by it must not overflow
-        // the `pos + 8` guard (would panic under overflow-checks); returns false.
+        // "free", largesize near u64::MAX. An advance of `pos` by it must not
+        // overflow the `pos + 8` guard (a plain add would panic under
+        // overflow-checks); the result is false.
         let mut bytes = 1u32.to_be_bytes().to_vec(); // size32 = 1
         bytes.extend_from_slice(b"free");
         bytes.extend_from_slice(&(u64::MAX - 4).to_be_bytes()); // largesize
@@ -206,7 +210,7 @@ mod tests {
         bytes.extend_from_slice(b"free");
         bytes.extend_from_slice(&[0u8; 16]);
         let p = write("zerobox", &[bytes]);
-        // free-to-EOF with no moov/mdat => false, and returns promptly.
+        // free-to-EOF with no moov/mdat gives false, and it returns promptly.
         assert!(!needs_faststart(&p));
         let _ = std::fs::remove_file(&p);
     }

--- a/crates/prober/src/lib.rs
+++ b/crates/prober/src/lib.rs
@@ -7,15 +7,15 @@
 //! present. See TAD §4.
 //!
 //! ## Design notes
-//! - The subprocess call passes every argument as a separate argv element (no
-//!   shell string) — a habit kept consistent with the splitter, where chapter
-//!   titles are untrusted (command-injection surface).
+//! - The subprocess call passes every argument as a separate argv element
+//!   (no shell string). This habit is kept consistent with the splitter,
+//!   where chapter titles are untrusted (a command-injection surface).
 //! - Parsing is split out into [`parse_probe_json`] so the parser can be
 //!   unit-tested hermetically, without ffprobe or a real audiobook on disk.
 //! - **Chapter-less is not an error.** A readable file with zero chapter markers
 //!   returns `Ok` with an empty [`ProbedBook::chapters`]; the single-episode
 //!   fallback is decided downstream (Task 1.7). Only an unreadable/corrupt file,
-//!   a non-zero ffprobe exit, unparseable JSON, or a file with no audio stream
+//!   a non-zero ffprobe exit, unparsable JSON, or a file with no audio stream
 //!   yields a typed [`ProbeError`].
 
 use std::path::Path;
@@ -67,8 +67,8 @@ pub struct ProbedBook {
     pub chapters: Vec<Chapter>,
 }
 
-/// Everything that can go wrong probing a file. Chapter-less input is *not* here
-/// — it is a valid [`ProbedBook`] with no chapters.
+/// Everything that can go wrong in a probe of a file. Chapter-less input is
+/// *not* here: it is a valid [`ProbedBook`] with no chapters.
 #[derive(Debug, thiserror::Error)]
 pub enum ProbeError {
     /// `ffprobe` could not be launched (not on PATH, permissions, …).
@@ -84,7 +84,7 @@ pub enum ProbeError {
     #[error("could not parse ffprobe JSON output: {0}")]
     Json(#[source] serde_json::Error),
     /// A chapter carried a `start_time`/`end_time` that was not a decimal number.
-    #[error("chapter {idx} has an unparseable {field} ({value:?})")]
+    #[error("chapter {idx} has an unparsable {field} ({value:?})")]
     InvalidChapterTime {
         /// Zero-based chapter position.
         idx: usize,
@@ -93,7 +93,7 @@ pub enum ProbeError {
         /// The raw string ffprobe reported.
         value: String,
     },
-    /// The file has no audio stream — it is not a playable audiobook.
+    /// The file has no audio stream: it is not a playable audiobook.
     #[error("no audio stream found in file")]
     NoAudioStream,
     /// Duration could not be determined from format, chapters, or streams.
@@ -103,7 +103,7 @@ pub enum ProbeError {
 
 /// Probe `path` with `ffprobe` and return its chapters, duration, and cover flag.
 pub fn probe(path: &Path) -> Result<ProbedBook, ProbeError> {
-    // argv vector — never a shell string.
+    // An argv vector, never a shell string.
     let output = Command::new("ffprobe")
         .args([
             "-v",
@@ -311,7 +311,7 @@ mod tests {
         assert!((c0.end_sec - 31.312).abs() < 1e-9);
         assert_eq!(c0.title.as_deref(), Some("Introduction"));
 
-        // Short middle chapter — exercises small segments.
+        // The short middle chapter exercises small segments.
         assert!((book.chapters[1].duration_sec() - 2.288).abs() < 1e-9);
     }
 
@@ -385,7 +385,7 @@ mod tests {
 
     #[test]
     fn duration_falls_back_to_stream_then_chapters() {
-        // No format.duration -> use the audio stream's duration.
+        // There is no format.duration, so use the audio stream's duration.
         let json = r#"{
             "streams": [{"codec_type": "audio", "duration": "123.5",
                          "disposition": {"attached_pic": 0}}],
@@ -396,7 +396,7 @@ mod tests {
     }
 
     #[test]
-    fn unparseable_chapter_time_is_a_typed_error() {
+    fn unparsable_chapter_time_is_a_typed_error() {
         let json = r#"{
             "streams": [{"codec_type": "audio", "disposition": {"attached_pic": 0}}],
             "chapters": [{"start_time": "not-a-number", "end_time": "10.0", "tags": {}}],

--- a/crates/prober/tests/real_ffprobe.rs
+++ b/crates/prober/tests/real_ffprobe.rs
@@ -1,10 +1,10 @@
 //! Integration test that runs the *real* `ffprobe` against a real audiobook.
 //!
 //! Fixtures are large and local-only, so this is existence-gated: it points at
-//! `$PODSPINE_TEST_M4B` if set, else a generic local fixture, and quietly skips
-//! when neither the file nor ffprobe is available (keeps CI green, runs
-//! automatically on a dev box that has the fixture). Assertions are structural
-//! so any DRM-free multi-chapter M4B works as the fixture.
+//! `$PODSPINE_TEST_M4B` if set, else a generic local fixture, and it quietly
+//! skips when neither the file nor ffprobe is available (this keeps CI green,
+//! and it runs automatically on a dev box that has the fixture). Assertions
+//! are structural, so any DRM-free multi-chapter M4B works as the fixture.
 
 use std::path::PathBuf;
 

--- a/crates/scanner/Cargo.toml
+++ b/crates/scanner/Cargo.toml
@@ -27,3 +27,6 @@ podspine-test-support = { path = "../test-support" }
 # Fault injection: a second connection to the same SQLite file, to break the
 # schema out from under a live Index.
 rusqlite = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/scanner/src/lib.rs
+++ b/crates/scanner/src/lib.rs
@@ -1,39 +1,45 @@
-//! `scanner` — orchestrate `prober -> splitter -> index`.
+//! The `scanner` crate runs the ingest pipeline: `prober` -> `splitter` -> `index`.
 //!
-//! [`scan_book`] probes one audio file, resolves its chapter source (a sibling
-//! `.cue`/`.ffmeta` sidecar wins over embedded markers unless `force_embedded`,
-//! Task 3.8), splits those chapters into `<data>/books/<id>/`, and persists a
-//! book + episodes to the index. It:
-//! - falls back to a single episode for a chapter-less file,
-//! - is **idempotent**: an unchanged source that is already fully indexed is not
-//!   re-split (guids/pubDates are stable),
-//! - **skips DRM-protected input** (AAX/AAXC/`.aa`/`.odm`) with a typed error —
-//!   Podspine ships no circumvention (PRD W5).
+//! [`scan_book`] ingests one audio file. It probes the file, resolves the
+//! chapter source, splits the chapters into `<data>/books/<id>/`, and persists
+//! one book and its episodes to the index. A sibling `.cue`/`.ffmeta` sidecar
+//! wins over embedded markers unless `force_embedded` is set (Task 3.8).
+//! Three more rules apply:
+//! - A file with no chapters becomes a single episode.
+//! - The scan is **idempotent**. If an unchanged source is already fully
+//!   indexed, the scanner does not split it again. The `guid`s and `pubDate`s
+//!   stay stable.
+//! - The scanner **skips DRM-protected input** (AAX/AAXC/`.aa`/`.odm`) and
+//!   returns a typed error. Podspine ships no circumvention (PRD W5).
 //!
-//! [`scan_library`] walks a library root of many audiobooks (Task 3.1): each
-//! top-level audio file and each per-book subfolder becomes one independent
-//! book. It distinguishes single-file books (`.m4b`/`.m4a`, or a lone `.mp3`),
-//! split by chapters, from multi-track **MP3 folders** (Task 3.3) — a folder of
-//! per-chapter MP3s ingested as one episode per file with **no splitting and no
-//! re-encode** (ordered by track number, falling back to filename order). It
-//! assigns collision-free slugs deterministically and never lets one bad book
-//! abort the whole scan. Tier-2 inputs (Ogg Vorbis/Opus/FLAC) are stream-copied
-//! into a matching container (Task 3.9); DRM inputs (AAX/AAXC/`.aa`/`.odm`) are
-//! skipped with a logged notice (PRD W5).
+//! [`scan_library`] walks a library root that holds many audiobooks (Task 3.1).
+//! Each top-level audio file and each per-book subfolder becomes one
+//! independent book. Books have two shapes:
+//! - A single-file book (`.m4b`/`.m4a`, or a lone `.mp3`). The scanner splits
+//!   it by chapters.
+//! - A multi-track **MP3 folder** (Task 3.3): a folder of per-chapter MP3s.
+//!   The scanner ingests one episode per file, with **no split and no
+//!   re-encode**. Track number sets the order; filename order is the fallback.
 //!
-//! **Whole-file episodes are served in place (Sprint 6.2):** when an episode IS
-//! a whole source file — every MP3-folder track, or a chapterless single file —
-//! it is streamed directly from the read-only library and its `source_path` is
-//! recorded; nothing is copied under `<data_dir>`. Only chaptered books, whose
-//! episodes are sub-ranges of a container, are extracted (`full`/`saver`).
+//! The scanner assigns collision-free slugs deterministically. One bad book
+//! never aborts the whole scan. The scanner stream-copies Tier-2 inputs
+//! (Ogg Vorbis/Opus/FLAC) into a matching container (Task 3.9). It skips DRM
+//! inputs (AAX/AAXC/`.aa`/`.odm`) and logs a notice (PRD W5).
+//!
+//! **The server serves whole-file episodes in place (Sprint 6.2).** An episode
+//! can be a whole source file: every MP3-folder track, and each chapterless
+//! single file. The server streams such an episode directly from the read-only
+//! library, and the scanner records its `source_path`. The scanner copies
+//! nothing under `<data_dir>`. Only chaptered books are extracted
+//! (`full`/`saver`), because their episodes are sub-ranges of one container.
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
-// Re-exported: all three are part of this crate's public surface — `BookOverrides`
-// is a parameter of the scan API, `StorageMode`/`TranscodeMode` fields of
-// [`ScanOptions`].
+// All three re-exports are part of this crate's public surface. `BookOverrides`
+// is a parameter of the scan API. `StorageMode` and `TranscodeMode` are fields
+// of [`ScanOptions`].
 use podspine_config::book_overrides;
 pub use podspine_config::{BookOverrides, StorageMode, TranscodeMode};
 use podspine_feed::{episode_guid, pubdate_epoch};
@@ -45,27 +51,29 @@ use podspine_splitter::{
     transcode_whole,
 };
 
-/// Extensions we refuse to ingest (DRM). Matched case-insensitively.
+/// DRM extensions that the scanner refuses to ingest. The match ignores case.
 const DRM_EXTENSIONS: &[&str] = &["aax", "aaxc", "aa", "odm"];
 
-/// The server-global ingest knobs, threaded through the scan API as one value.
+/// The server-global ingest options, passed through the scan API as one value.
 ///
-/// Per-book `.podspine.toml` overrides refine these per book (Sprint 6.4), so a
-/// field here is the *default* for a book, not the last word.
+/// Per-book `.podspine.toml` overrides refine these values per book
+/// (Sprint 6.4). A field here is the *default* for a book, not the final value.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct ScanOptions {
     /// Ignore any `.cue`/`.ffmeta` sidecar and use embedded chapters (Task 3.8).
     pub force_embedded: bool,
-    /// Storage strategy for chaptered books (Sprint 5.1): `Saver` splits at
-    /// ingest to record each real `byte_length`, then deletes and regenerates on
-    /// demand; `Full` (the default) pre-splits and keeps the files.
+    /// Storage strategy for chaptered books (Sprint 5.1). `Saver` splits at
+    /// ingest to record each real `byte_length`, then deletes the files and
+    /// regenerates them on demand. `Full` (the default) pre-splits and keeps
+    /// the files.
     pub storage: StorageMode,
     /// Remux a non-faststart whole-file mp4 to a faststart cache copy instead of
     /// serving it in place (Sprint 6.3).
     pub remux_non_faststart: bool,
-    /// Re-encode sources no podcatcher can be relied on to play (FLAC/Vorbis/
-    /// Opus/ALAC) to AAC or MP3 at ingest (Task 5.2). Off by default: Podspine is
-    /// copy-first, and MP3/AAC sources are never re-encoded whatever this says.
+    /// Re-encode sources that podcatchers do not play reliably (FLAC/Vorbis/
+    /// Opus/ALAC) to AAC or MP3 at ingest (Task 5.2). The default is off:
+    /// Podspine is copy-first. Podspine never re-encodes MP3/AAC sources,
+    /// independent of this setting.
     pub transcode: TranscodeMode,
 }
 
@@ -75,10 +83,10 @@ pub enum ScanError {
     /// The input path is not a regular file.
     #[error("not a file: {0}")]
     NotAFile(PathBuf),
-    /// The input is DRM-protected and was skipped.
+    /// The input is DRM-protected, so the scanner skipped it.
     #[error("DRM-protected input skipped (Podspine ships no circumvention): {0}")]
     UnsupportedDrm(PathBuf),
-    /// The source mtime could not be read.
+    /// The scanner could not read the source `mtime`.
     #[error("could not read source mtime for {path}: {source}")]
     Mtime {
         /// The path.
@@ -109,7 +117,8 @@ pub enum ScanError {
 }
 
 /// Scan one audiobook `input` into `index` under a slug derived from its file
-/// name. Convenience wrapper over [`scan_book_as`] for single-book callers.
+/// name. This is a convenience wrapper over [`scan_book_as`] for single-book
+/// callers.
 pub fn scan_book(input: &Path, data_dir: &Path, index: &Index) -> Result<BookRow, ScanError> {
     let id = slugify(&file_stem(input));
     scan_book_as(
@@ -122,19 +131,20 @@ pub fn scan_book(input: &Path, data_dir: &Path, index: &Index) -> Result<BookRow
     )
 }
 
-/// Scan one audiobook `input` into `index` under the explicit `id` (also used as
-/// the slug), writing split episodes under `<data_dir>/books/<id>/`. Returns the
-/// persisted [`BookRow`]. The library scanner uses this to assign collision-free
-/// slugs; single-book callers should use [`scan_book`].
+/// Scan one audiobook `input` into `index` under the explicit `id`, which is
+/// also the slug. Write the split episodes under `<data_dir>/books/<id>/`.
+/// Return the persisted [`BookRow`]. The library scanner uses this function to
+/// assign collision-free slugs. Single-book callers should use [`scan_book`].
 ///
-/// `force_embedded` skips sidecar (`.cue`/`.ffmeta`) chapter resolution and uses
-/// the embedded chapters even when a sidecar exists (Task 3.8).
+/// `force_embedded` skips sidecar (`.cue`/`.ffmeta`) chapter resolution. It
+/// uses the embedded chapters even when a sidecar exists (Task 3.8).
 ///
-/// `saver` is the on-demand storage mode (Sprint 5.1): each chapter is still
-/// split once so its real `byte_length` (the `enclosure length`) is recorded,
-/// but the file is deleted immediately afterwards — the http layer regenerates
-/// it on demand. Peak extra disk is one chapter, not a full second copy of the
-/// book. `false` is the default (pre-split, files kept).
+/// `saver` is the on-demand storage mode (Sprint 5.1). The scan still splits
+/// each chapter once, so that it records the real `byte_length` (the
+/// `enclosure length`). It then deletes the file immediately; the http layer
+/// regenerates the file on demand. The peak extra disk usage is one chapter,
+/// not a full second copy of the book. The default is `false` (pre-split, keep
+/// the files).
 pub fn scan_book_as(
     input: &Path,
     id: &str,
@@ -149,16 +159,16 @@ pub fn scan_book_as(
     if is_drm(input) {
         return Err(ScanError::UnsupportedDrm(input.to_path_buf()));
     }
-    // Persist an ABSOLUTE, symlink-resolved source path. In-place serving (and
-    // saver regeneration) resolves this later from the server's cwd, so a
-    // relative `--library` stored verbatim would 404 after a restart from a
-    // different directory (systemd/Docker). `is_file` above proved it exists, so
-    // canonicalize succeeds; the fallback only guards a race.
+    // Persist an ABSOLUTE, symlink-resolved source path. In-place serving and
+    // saver regeneration resolve this path later from the server's cwd. A
+    // relative `--library` path stored verbatim would 404 after a restart from
+    // a different directory (systemd/Docker). `is_file` above proved that the
+    // file exists, so `canonicalize` succeeds. The fallback only guards a race.
     let input_canonical = input.canonicalize().unwrap_or_else(|_| input.to_path_buf());
     let input = input_canonical.as_path();
 
     // Per-book `.podspine.toml` overrides refine the global flags for this book
-    // (Sprint 6.4); `disabled` is handled by the caller before we're reached.
+    // (Sprint 6.4). The caller handles `disabled` before it calls this function.
     let force_embedded = overrides
         .force_embedded_chapters
         .unwrap_or(opts.force_embedded);
@@ -169,9 +179,10 @@ pub fn scan_book_as(
     let saver = storage == StorageMode::Saver;
     let force_reingest = overrides.force_reingest == Some(true);
 
-    // Effective per-book metadata (override → default). Computed up here so the
-    // idempotency check can spot a `.podspine.toml` edit (which doesn't change the
-    // audio mtime) and re-ingest, and so the BookRow build below reuses it.
+    // Compute the effective per-book metadata (override → default) up here, for
+    // two reasons. The idempotency check can then spot a `.podspine.toml` edit
+    // and re-ingest (such an edit does not change the audio mtime). And the
+    // `BookRow` build below reuses these values.
     let eff_title = overrides.title.clone().unwrap_or_else(|| file_stem(input));
     let eff_author = overrides.author.clone();
     let eff_cover = overrides.default_cover_url.clone();
@@ -180,66 +191,72 @@ pub fn scan_book_as(
     let source_mtime = mtime_epoch(input)?;
     let book_out = data_dir.join("books").join(&id);
 
-    // Idempotency: already indexed at this mtime with all files present -> done,
-    // no re-probe / re-split.
+    // Idempotency check: if the book is already indexed at this mtime and all
+    // files are present, the scan is done. Do not re-probe or re-split.
     if let Some(existing) = index.get_book(&id)?
         && existing.source_mtime == source_mtime
     {
         let eps = index.episodes_for_book(&id)?;
-        // In `saver` mode the split files are intentionally absent (regenerated
-        // on demand), so don't require them on disk — the index entry is enough.
+        // In `saver` mode the split files are intentionally absent (the http
+        // layer regenerates them on demand). Do not require them on disk. The
+        // index entry is enough.
         //
-        // BUT guard against a migrated database: `Index::migrate` back-fills
-        // `start_sec = 0` for pre-5.1 rows, and a non-first chapter with
-        // `start_sec == 0` can't drive correct on-demand regeneration (it would
-        // ffmpeg `-ss 0` and serve the book's opening seconds). Force a one-time
-        // re-split (skip this early return) so the real offsets are recorded
-        // before any eviction can serve the wrong segment. Chapter 0 legitimately
-        // starts at 0, so only non-first chapters are checked.
+        // BUT guard against a migrated database. `Index::migrate` back-fills
+        // `start_sec = 0` for pre-5.1 rows. A non-first chapter with
+        // `start_sec == 0` cannot drive correct on-demand regeneration: it
+        // would run ffmpeg with `-ss 0` and serve the book's opening seconds.
+        // Force a one-time re-split (skip this early return), so that the
+        // re-split records the real offsets before any eviction can serve the
+        // wrong segment. Chapter 0 legitimately starts at 0, so this check
+        // covers only non-first chapters.
         let start_secs_recorded =
             !saver || eps.iter().filter(|e| e.idx > 0).all(|e| e.start_sec > 0.0);
-        // Faststart re-ingest guard (Sprint 6.3): if PODSPINE_REMUX_NON_FASTSTART
-        // was toggled since the last scan, a `needs_faststart` whole-file episode's
-        // recorded serve mode (in place ⇒ `file_path == source_path`; remuxed ⇒
-        // `file_path != source_path`) no longer matches the flag — re-ingest so
-        // `byte_length`/`file_path` are re-recorded for the current mode.
+        // Faststart re-ingest guard (Sprint 6.3). `PODSPINE_REMUX_NON_FASTSTART`
+        // can change between scans. The recorded serve mode of a
+        // `needs_faststart` whole-file episode (in place ⇒
+        // `file_path == source_path`; remuxed ⇒ `file_path != source_path`)
+        // then no longer matches the flag. Re-ingest, so that the scan records
+        // `byte_length`/`file_path` again for the current mode.
         let faststart_consistent = eps.iter().all(|e| {
             !e.needs_faststart
                 || e.source_path.is_empty()
                 || (e.file_path != e.source_path) == remux_non_faststart
         });
-        // An episode's file may legitimately be absent when it's regenerated on
-        // demand: a saver chapter, or a remuxed whole-file cache copy. Everything
-        // else (full chapters, in-place whole files) must be present on disk.
+        // An episode's file may legitimately be absent when the server
+        // regenerates it on demand: a saver chapter, or a remuxed whole-file
+        // cache copy. Everything else (full chapters, in-place whole files)
+        // must be present on disk.
         let files_present = eps.iter().all(|e| {
             let regenerable = (saver && e.source_path.is_empty())
                 || (!e.source_path.is_empty() && e.file_path != e.source_path);
             regenerable || Path::new(&e.file_path).exists()
         });
-        // A `.podspine.toml` edit doesn't change the audio mtime, so also re-ingest
-        // when the persisted metadata no longer matches the current overrides
-        // (Greptile 6.4 P1) — otherwise a changed title/author/storage_mode/cover
-        // would stay stale in the index. `source_mtime` is unchanged, so episode
-        // guids stay stable (no spurious client re-downloads).
+        // A `.podspine.toml` edit does not change the audio mtime. So also
+        // re-ingest when the persisted metadata no longer matches the current
+        // overrides (Greptile 6.4 P1). Otherwise a changed
+        // title/author/storage_mode/cover would stay stale in the index.
+        // `source_mtime` is unchanged, so episode `guid`s stay stable (clients
+        // do not re-download anything).
         let metadata_consistent = existing.title == eff_title
             && existing.author == eff_author
             && existing.storage_mode == Some(storage)
             && existing.default_cover_url == eff_cover
-            // `force_embedded_chapters` changes the chapter SOURCE (embedded vs a
-            // `.cue`/`.ffmeta` sidecar) without touching the fields above, so a
-            // toggle must also re-ingest (Greptile 6.4 P1).
+            // `force_embedded_chapters` changes the chapter SOURCE (embedded vs
+            // a `.cue`/`.ffmeta` sidecar) and touches none of the fields above.
+            // So a toggle must also re-ingest (Greptile 6.4 P1).
             && existing.force_embedded == force_embedded;
-        // Transcode toggle guard (Task 5.2): flipping `PODSPINE_TRANSCODE` changes
-        // the episode container AND every recorded `byte_length`, and touches no
-        // source mtime — so re-ingest when the persisted mode no longer matches
-        // what this setting would produce. A pre-5.2 row (`None`) was produced by
-        // a stream copy, which is exactly what `Off` means, so it is not a
-        // mismatch and doesn't re-split anyone's library on upgrade.
+        // Transcode toggle guard (Task 5.2). A `PODSPINE_TRANSCODE` flip changes
+        // the episode container AND every recorded `byte_length`, and touches
+        // no source mtime. So re-ingest when the persisted mode no longer
+        // matches what this setting would produce. A stream copy produced each
+        // pre-5.2 row (`None`), and a stream copy is exactly what `Off` means.
+        // Such a row is therefore not a mismatch, and an upgrade re-splits
+        // nobody's library.
         let stored_transcode = existing.transcode.unwrap_or(TranscodeMode::Off);
         let transcode_consistent = expected_transcode(input, opts.transcode)
             .is_none_or(|expected| stored_transcode == expected);
-        // `force_reingest` (a troubleshooting knob) always skips the early return
-        // so the book is re-processed on every scan while set.
+        // `force_reingest` (a troubleshooting option) always skips the early
+        // return. While it is set, every scan re-processes the book.
         if !force_reingest
             && metadata_consistent
             && !eps.is_empty()
@@ -248,10 +265,11 @@ pub fn scan_book_as(
             && transcode_consistent
             && files_present
         {
-            // The book is up to date, but a browse-UI thumbnail may be missing — an
-            // existing library from before thumbnails, or one deleted from the cache.
-            // Backfill it from the already-extracted cover without a re-split, so the
-            // grid gets thumbnails on the next reconcile rather than a re-index.
+            // The book is up to date, but a browse-UI thumbnail can be missing:
+            // a library that predates thumbnails, or a thumbnail deleted from
+            // the cache. Backfill it from the already-extracted cover, without
+            // a re-split. The grid then gets thumbnails on the next reconcile,
+            // not on a re-index.
             if let Some(cover) = existing.cover_path.as_deref()
                 && !cover_thumb_path(&book_out).exists()
                 && let Err(err) = extract_cover_thumb(Path::new(cover), &book_out)
@@ -265,16 +283,17 @@ pub fn scan_book_as(
     let probed = probe(input)?;
 
     // Resolve the chapter source: a sibling `.cue`/`.ffmeta` sidecar wins over
-    // embedded markers unless overridden (Task 3.8).
+    // embedded markers unless `force_embedded` overrides it (Task 3.8).
     let resolved =
         podspine_chapters::resolve(input, &probed.chapters, probed.duration_sec, force_embedded);
     if resolved.source != podspine_chapters::ChapterSource::Embedded {
         tracing::info!(id = %id, source = ?resolved.source, "using sidecar chapters");
     }
 
-    // Transcoding (Task 5.2): a source no podcatcher can be relied on to play
-    // (FLAC/Vorbis/Opus/ALAC) is re-encoded at ingest when the operator opts in.
-    // MP3/AAC sources are always stream-copied, whatever the flag says.
+    // Transcoding (Task 5.2). When the operator opts in, the scan re-encodes at
+    // ingest each source that podcatchers do not play reliably
+    // (FLAC/Vorbis/Opus/ALAC). The scan always stream-copies MP3/AAC sources,
+    // independent of the flag.
     let enc = encoding_for(probed.audio_codec.as_deref(), opts.transcode);
     let transcoding = enc != Encoding::Copy;
     if transcoding {
@@ -286,14 +305,15 @@ pub fn scan_book_as(
         );
     }
 
-    // A chapterless file is ONE whole-file episode → streamed in place from the
-    // library (no split, no copy under <data_dir>). A chaptered book is extracted
-    // per chapter (full/saver). See TAD §5.3. A transcoded book is never served in
-    // place: the bytes clients get are the re-encoded ones, which only exist under
-    // <data_dir>.
+    // A chapterless file becomes ONE whole-file episode. The server streams it
+    // in place from the library (no split, no copy under `<data_dir>`). The
+    // splitter extracts a chaptered book per chapter (full/saver). See TAD
+    // §5.3. The server never serves a transcoded book in place: clients get
+    // the re-encoded bytes, and those bytes exist only under `<data_dir>`.
     let chapterless = resolved.chapters.is_empty();
     let serve_in_place = chapterless && !transcoding;
-    // Chapters -> (cut, title). Chapter-less -> a single episode over the file.
+    // Map chapters to (cut, title) pairs. A chapterless file gets a single
+    // episode that spans the whole file.
     let specs: Vec<(ChapterCut, String)> = if chapterless {
         tracing::warn!(
             id = %id,
@@ -327,17 +347,19 @@ pub fn scan_book_as(
     };
     let n = specs.len();
     let cuts: Vec<ChapterCut> = specs.iter().map(|(cut, _)| cut.clone()).collect();
-    // Stream-copy into a container matching the source codec (Task 3.9), or into
-    // the transcode target's container when re-encoding (Task 5.2).
+    // Pick the output container: one that matches the source codec for a stream
+    // copy (Task 3.9), or the transcode target's container for a re-encode
+    // (Task 5.2).
     let out_ext = episode_ext(probed.audio_codec.as_deref(), enc);
-    // Set for the single whole-file episode below; chaptered episodes never need
-    // faststart (`split_chapter` already writes `moov`-first).
+    // The whole-file branch below sets this flag. Chaptered episodes never need
+    // faststart (`split_chapter` already writes `moov` first).
     let mut needs_ft = false;
-    // A re-encode is not byte-reproducible across ffmpeg builds, so a transcoded
-    // book is always materialized here and never regenerated on demand — that is
-    // what keeps the published `enclosure length` equal to the bytes served. The
-    // serve/evict layers read `book.transcode` and skip regeneration + eviction to
-    // match, so an explicit `saver` request is deliberately overridden per book.
+    // A re-encode is not byte-reproducible across ffmpeg builds. So the scan
+    // always materializes a transcoded book here, and nothing regenerates it on
+    // demand. That rule keeps the published `enclosure length` equal to the
+    // bytes served. The serve/evict layers read `book.transcode` and skip
+    // regeneration and eviction to match. The scan therefore deliberately
+    // overrides an explicit `saver` request for such a book.
     if transcoding && saver {
         tracing::info!(
             id = %id,
@@ -345,8 +367,9 @@ pub fn scan_book_as(
         );
     }
     let episodes = if chapterless && transcoding {
-        // One whole-file episode, re-encoded into <data_dir> (no -ss/-t: the
-        // episode is the entire file, so a short probed duration can't clip it).
+        // One whole-file episode, re-encoded into `<data_dir>`. No `-ss`/`-t`:
+        // the episode is the entire file, so a short probed duration cannot
+        // clip it.
         vec![transcode_whole(
             input,
             &book_out,
@@ -356,15 +379,17 @@ pub fn scan_book_as(
             enc,
         )?]
     } else if serve_in_place {
-        // Whole source file — nothing to extract. (Any per-episode copy a previous
-        // ingest left is reclaimed after the index is updated, below.)
-        // Faststart (Sprint 6.3): a non-faststart whole-file mp4 (`moov` after
-        // `mdat`) seeks slowly when streamed in place. Detect it ffmpeg-free.
+        // The episode is the whole source file, so there is nothing to extract.
+        // (The cleanup below reclaims any per-episode copy that a previous
+        // ingest left, after the index update.) Faststart check (Sprint 6.3): a
+        // non-faststart whole-file mp4 (`moov` after `mdat`) seeks slowly when
+        // streamed in place. Detect it without ffmpeg.
         needs_ft = needs_faststart(input);
         if needs_ft && remux_non_faststart {
             // Opt-in remux: write a faststart cache copy (byte-deterministic
-            // `-c copy`), measure it, then delete — the http layer regenerates it
-            // on demand and evicts it under the cache cap. The source is untouched.
+            // `-c copy`), measure it, then delete it. The http layer
+            // regenerates the copy on demand and evicts it under the cache cap.
+            // The source stays untouched.
             std::fs::create_dir_all(&book_out).map_err(|source| ScanError::Io {
                 path: book_out.clone(),
                 source,
@@ -376,9 +401,10 @@ pub fn scan_book_as(
             })?;
             vec![ep]
         } else {
-            // Serve in place from the read-only library — no ffmpeg, no copy; the
-            // enclosure length is the real source size. A non-faststart mp4 still
-            // plays, so just log a one-line callout naming the (opt-in) fix.
+            // Serve in place from the read-only library: no ffmpeg, no copy.
+            // The enclosure length is the real source size. A non-faststart mp4
+            // still plays, so only log a one-line notice that names the
+            // (opt-in) fix.
             if needs_ft {
                 tracing::warn!(
                     id = %id,
@@ -400,9 +426,10 @@ pub fn scan_book_as(
             }]
         }
     } else if saver && !transcoding {
-        // Split each chapter to record its real byte size, then delete it — the
-        // http layer regenerates on demand (deterministic stream-copy, so the
-        // regenerated bytes match the recorded length). Peak disk = one chapter.
+        // Split each chapter to record its real byte size, then delete it. The
+        // http layer regenerates the file on demand (the stream copy is
+        // deterministic, so the regenerated bytes match the recorded length).
+        // The peak extra disk usage is one chapter.
         std::fs::create_dir_all(&book_out).map_err(|source| ScanError::Io {
             path: book_out.clone(),
             source,
@@ -421,21 +448,24 @@ pub fn scan_book_as(
         split_book_encoded(input, &book_out, &cuts, out_ext, enc)?
     };
 
-    // Extract the embedded cover, if any. A missing cover is a normal case, and
-    // an extraction failure never fails the book — we just serve no cover art.
+    // Extract the embedded cover, if any. A missing cover is a normal case. An
+    // extraction failure never fails the book; the server then serves no cover
+    // art.
     let cover_path = if probed.has_cover {
         let ext = cover_ext(probed.cover_codec.as_deref());
         match extract_cover(input, &book_out, ext) {
             Ok(path) => {
-                // Regenerate the browse-UI thumbnail from the freshly-extracted cover,
-                // in this same (single) scanner thread and atomically, so it always
-                // matches the cover — the http layer only ever *serves* it, which is
-                // what keeps thumbnail and cover consistent with no cross-thread race.
+                // Regenerate the browse-UI thumbnail from the freshly extracted
+                // cover, in this same (single) scanner thread and atomically,
+                // so that it always matches the cover. The http layer only ever
+                // *serves* the thumbnail. That split keeps thumbnail and cover
+                // consistent with no cross-thread race.
                 //
-                // Delete the previous thumbnail FIRST: if regeneration then fails, the
-                // book is left with NO thumbnail (the serve layer falls back to the
-                // current full cover, and the next reconcile backfills it) rather than
-                // a stale one derived from the old cover.
+                // Delete the previous thumbnail FIRST. If regeneration then
+                // fails, the book is left with NO thumbnail, not with a stale
+                // one derived from the old cover. (The serve layer falls back
+                // to the current full cover, and the next reconcile backfills
+                // the thumbnail.)
                 let _ = std::fs::remove_file(cover_thumb_path(&book_out));
                 if let Err(err) = extract_cover_thumb(&path, &book_out) {
                     tracing::warn!(error = %err, id = %id, "cover thumbnail failed; browse UI will use the full cover");
@@ -443,14 +473,14 @@ pub fn scan_book_as(
                 Some(path.to_string_lossy().into_owned())
             }
             Err(err) => {
-                // `extract_cover` publishes atomically (writes a `.part` sibling,
-                // renames only on success), so a failed extraction leaves the
-                // previous `cover.jpg` — and its thumbnail — intact on disk. Keep
-                // the stored path rather than dropping it to None and orphaning
-                // that still-valid art: None would 404 both cover routes and block
-                // the reconcile thumbnail backfill, which is gated on a populated
-                // cover_path. `upsert_book` below hasn't run yet, so this still
-                // reads the prior row.
+                // `extract_cover` publishes atomically: it writes a `.part`
+                // sibling and renames it only on success. A failed extraction
+                // therefore leaves the previous `cover.jpg`, and its thumbnail,
+                // intact on disk. Keep the stored path; do not drop it to
+                // `None` and orphan that still-valid art. `None` would 404 both
+                // cover routes and block the reconcile thumbnail backfill,
+                // which requires a populated `cover_path`. `upsert_book` below
+                // has not run yet, so this read still sees the prior row.
                 let kept = index
                     .get_book(&id)
                     .ok()
@@ -473,8 +503,9 @@ pub fn scan_book_as(
         id: id.clone(),
         slug: id.clone(),
         feed_id: podspine_index::capability::generate(),
-        // Per-book overrides (Sprint 6.4), computed above and re-checked by the
-        // idempotency guard so a sidecar edit re-persists them.
+        // Per-book overrides (Sprint 6.4). The code above computes them, and
+        // the idempotency guard re-checks them, so a sidecar edit re-persists
+        // them.
         title: eff_title,
         author: eff_author,
         cover_path,
@@ -484,9 +515,9 @@ pub fn scan_book_as(
         storage_mode: Some(storage),
         default_cover_url: eff_cover,
         force_embedded,
-        // What actually happened to this book's audio (Task 5.2): `Off` when it
-        // was stream-copied. Read by the serve/evict layers (a transcoded book is
-        // never regenerated) and by the toggle guard above.
+        // What actually happened to this book's audio (Task 5.2): `Off` means a
+        // stream copy. The serve/evict layers read this field (nothing
+        // regenerates a transcoded book), and so does the toggle guard above.
         transcode: Some(if transcoding {
             opts.transcode
         } else {
@@ -502,16 +533,18 @@ pub fn scan_book_as(
             idx: ep.idx as i64,
             title: title.clone(),
             file_path: ep.path.to_string_lossy().into_owned(),
-            // Non-empty for a whole-file episode (source path); empty for an
-            // extracted chapter under <data_dir>. `file_path == source_path` ⇒
-            // in place, `file_path != source_path` ⇒ remuxed to the faststart cache.
+            // This field is non-empty for a whole-file episode (the source
+            // path) and empty for an extracted chapter under `<data_dir>`.
+            // `file_path == source_path` means in-place serving.
+            // `file_path != source_path` means a remux to the faststart cache.
             source_path: if serve_in_place {
                 input.to_string_lossy().into_owned()
             } else {
                 String::new()
             },
-            // Only ever true for the single whole-file episode; drives the http
-            // remux-vs-in-place decision + the toggle guard above.
+            // This flag is only ever true for the single whole-file episode.
+            // It drives the http remux-vs-in-place decision and the toggle
+            // guard above.
             needs_faststart: needs_ft,
             byte_length: ep.byte_length as i64,
             duration_sec: ep.duration_sec,
@@ -520,28 +553,34 @@ pub fn scan_book_as(
         })?;
     }
 
-    // Sweep leftovers only now, AFTER the index points at this ingest's episodes.
-    // Until that upsert lands, the old files are the ones being served, and this
-    // function can sit inside a re-encode for minutes: deleting them up front
-    // would 404 every request for the whole window, and would leave the book with
-    // no playable episodes at all if the encode then failed. Once the rows are
-    // written, whatever is left in another container is unreferenced.
+    // Sweep leftovers only now, AFTER the index points at this ingest's
+    // episodes. Until that upsert lands, the server still serves the old files,
+    // and this function can sit inside a re-encode for minutes. An up-front
+    // delete would 404 every request for that whole window. And if the encode
+    // then failed, it would leave the book with no playable episodes at all.
+    // Once the rows are written, any file left in another container is
+    // unreferenced.
     //
-    // A residual window remains, deliberately unguarded: a request that snapshotted
-    // an episode row just before the upsert can reach its `File::open` just after
-    // the unlink, and gets a clean 404 (the http layer fails closed at three
-    // points; it never serves partial or wrong bytes). It is bounded by the few
-    // microseconds between that snapshot and the open, it can only fire on an
-    // ingest that actually CHANGED a book's container — a transcode flag or target
-    // flip, not a steady-state rescan, which deletes nothing — and on POSIX a
-    // reader that already opened the file keeps its inode regardless. Closing it
-    // would mean either holding the index lock across blocking file I/O, or a
-    // re-resolve-and-retry in the handler that no test can drive deterministically.
-    // Neither is worth it for one retryable 404 during an operator-triggered
-    // re-ingest.
+    // A residual window remains, deliberately unguarded. A request can
+    // snapshot an episode row just before the upsert and reach its
+    // `File::open` just after the unlink. That request gets a clean 404 (the
+    // http layer fails closed at three points; it never serves partial or
+    // wrong bytes). Three facts bound the window:
+    // - Only the few microseconds between that snapshot and the open are
+    //   exposed.
+    // - It can only fire on an ingest that actually CHANGED a book's
+    //   container: a transcode flag or target flip. A steady-state rescan
+    //   deletes nothing.
+    // - On POSIX, a reader that already opened the file keeps its inode
+    //   regardless.
+    // A guard would mean one of two bad options: hold the index lock across
+    // blocking file I/O, or add a re-resolve-and-retry in the handler that no
+    // test can drive deterministically. Neither is worth it for one retryable
+    // 404 during an operator-triggered re-ingest.
     if serve_in_place {
-        // Episodes stream from the library now, so any per-episode copy a pre-6.2
-        // ingest — or a previous transcode — left under <data_dir> is dead weight.
+        // Episodes stream from the library now. Any per-episode copy that a
+        // pre-6.2 ingest or a previous transcode left under `<data_dir>` is
+        // therefore dead weight.
         remove_stale_episode_copies(&book_out);
     } else {
         remove_episode_files_in_other_containers(&book_out, out_ext);
@@ -550,21 +589,22 @@ pub fn scan_book_as(
     Ok(book)
 }
 
-/// Remove episode files under `book_out` that this ingest will **not** overwrite:
-/// leftovers in a container the book no longer uses.
+/// Remove episode files under `book_out` that this ingest will **not**
+/// overwrite: leftovers in a container that the book no longer uses.
 ///
-/// Switching a book between stream-copy and a transcode target (Task 5.2), or
-/// between the AAC and MP3 targets, changes the episode extension — `001.flac`
-/// becomes `001.m4a`. The index points at the new path, so the old files are
-/// unreferenced from that moment on, and nothing else reclaims them: the cache
+/// A switch between stream copy and a transcode target (Task 5.2), or between
+/// the AAC and MP3 targets, changes the episode extension: `001.flac` becomes
+/// `001.m4a`. The index points at the new path, so the old files are
+/// unreferenced from that moment on. Nothing else reclaims them: the cache
 /// eviction only touches regenerable (`saver`, stream-copied) books, and a
-/// transcoded book is never regenerable. Left alone they cost a full extra copy of
-/// the audiobook per mode change.
+/// transcoded book is never regenerable. Left in place, the old files cost a
+/// full extra copy of the audiobook per mode change.
 ///
-/// Only numbered episode files (`NNN.<ext>`) and their `NNN.part.<ext>`
-/// temporaries are considered, so an extracted `cover.*` is never touched. Files
-/// already in `keep_ext` are left for the ingest to overwrite. Best-effort — a
-/// missing dir or a failed unlink is logged, never fatal.
+/// This sweep only considers numbered episode files (`NNN.<ext>`) and their
+/// `NNN.part.<ext>` temporaries, so it never touches an extracted `cover.*`.
+/// It leaves files already in `keep_ext` for the ingest to overwrite. It is
+/// best-effort: it logs a missing directory or a failed unlink, and neither is
+/// fatal.
 fn remove_episode_files_in_other_containers(book_out: &Path, keep_ext: &str) {
     let Ok(entries) = std::fs::read_dir(book_out) else {
         return;
@@ -586,11 +626,12 @@ fn remove_episode_files_in_other_containers(book_out: &Path, keep_ext: &str) {
     }
 }
 
-/// Remove per-episode audio copies a previous (pre-6.2) ingest wrote under
-/// `<data_dir>/books/<id>/` now that this book's episodes stream in place from
-/// the library. Only numbered episode files (`NNN.<ext>`) are removed; an
-/// extracted `cover.*` is left in place. Best-effort — a missing dir or a failed
-/// unlink is logged, never fatal (the book still serves from the library).
+/// Remove per-episode audio copies that a previous (pre-6.2) ingest wrote
+/// under `<data_dir>/books/<id>/`. This book's episodes now stream in place
+/// from the library. The sweep only removes numbered episode files
+/// (`NNN.<ext>`); it leaves an extracted `cover.*` in place. It is
+/// best-effort: it logs a missing directory or a failed unlink, and neither is
+/// fatal (the book still serves from the library).
 fn remove_stale_episode_copies(book_out: &Path) {
     let Ok(entries) = std::fs::read_dir(book_out) else {
         return;
@@ -606,11 +647,12 @@ fn remove_stale_episode_copies(book_out: &Path) {
     }
 }
 
-/// Whether `path` is a produced episode file rather than something else in the
-/// book directory: a numbered `NNN.<ext>` (the splitter's cross-crate
+/// Whether `path` is a produced episode file, not something else in the book
+/// directory. That means a numbered `NNN.<ext>` (the splitter's cross-crate
 /// [`podspine_splitter::episode_file_name`] contract), or the `NNN.part.<ext>`
-/// temporary an interrupted encode can leave (see `podspine_splitter::part_path`).
-/// An extracted `cover.*` matches neither, so no sweep ever removes it.
+/// temporary that an interrupted encode can leave (see
+/// `podspine_splitter::part_path`). An extracted `cover.*` matches neither, so
+/// no sweep ever removes it.
 fn is_episode_stem(path: &Path) -> bool {
     path.file_stem()
         .and_then(|s| s.to_str())
@@ -632,10 +674,11 @@ struct Mp3Track {
 }
 
 /// Ingest a folder of per-chapter MP3s as one book under `id`: one episode per
-/// file, **no splitting, no re-encode, and no copy** — each track is served in
-/// place from the library (Sprint 6.2). Files are ordered by track number when
-/// every track is present and distinct, otherwise by filename with a warning.
-/// Idempotent on an unchanged folder.
+/// file, with **no split, no re-encode, and no copy**. The server serves each
+/// track in place from the library (Sprint 6.2). Track number sets the file
+/// order when every track number is present and distinct; otherwise filename
+/// order applies and the scan logs a warning. The scan is idempotent on an
+/// unchanged folder.
 fn scan_mp3_folder(
     dir: &Path,
     id: &str,
@@ -644,8 +687,9 @@ fn scan_mp3_folder(
     overrides: &BookOverrides,
     library_root: &Path,
 ) -> Result<BookRow, ScanError> {
-    // Canonicalize the folder so every track path stored below is absolute and
-    // symlink-resolved — in-place serving must not depend on the server's cwd.
+    // Canonicalize the folder, so that every track path stored below is
+    // absolute and symlink-resolved. In-place serving must not depend on the
+    // server's cwd.
     let dir_canonical = dir.canonicalize().unwrap_or_else(|_| dir.to_path_buf());
     let dir = dir_canonical.as_path();
     let files = collect_mp3s(dir, library_root);
@@ -653,7 +697,8 @@ fn scan_mp3_folder(
         return Err(ScanError::EmptyFolder(dir.to_path_buf()));
     }
 
-    // Book mtime = newest track mtime: stable while unchanged, bumps on replace.
+    // The book mtime is the newest track mtime. It is stable while the folder
+    // is unchanged, and it bumps when a track is replaced.
     let source_mtime = files
         .iter()
         .map(|f| mtime_epoch(f))
@@ -663,18 +708,20 @@ fn scan_mp3_folder(
         .unwrap_or(0);
     let book_out = data_dir.join("books").join(id);
 
-    // Effective per-book metadata (override → default). `storage_mode`/`remux`/
-    // `force_embedded` are no-ops for MP3 folders, so only title/author/cover
-    // apply. Computed here to detect a `.podspine.toml` edit and reused below.
+    // Compute the effective per-book metadata (override → default) up here to
+    // detect a `.podspine.toml` edit; the `BookRow` build below reuses it.
+    // `storage_mode`/`remux`/`force_embedded` are no-ops for MP3 folders, so
+    // only title/author/cover apply.
     let eff_title = overrides.title.clone().unwrap_or_else(|| dir_name(dir));
     let eff_author = overrides.author.clone();
     let eff_cover = overrides.default_cover_url.clone();
 
-    // Idempotency: unchanged and already served in place -> no re-probe.
-    // The `source_path` guard forces a one-time re-ingest of a pre-6.2 book
-    // (tracks copied under <data_dir>, empty `source_path`) so it flips to
-    // in-place serving and its copies get reclaimed. The metadata checks re-ingest
-    // on a `.podspine.toml` edit that didn't change the folder mtime (Greptile P1).
+    // Idempotency check: if the folder is unchanged and already served in
+    // place, do not re-probe. The `source_path` guard forces a one-time
+    // re-ingest of a pre-6.2 book (tracks copied under `<data_dir>`, empty
+    // `source_path`). The book then flips to in-place serving, and the sweep
+    // reclaims its copies. The metadata checks re-ingest on a `.podspine.toml`
+    // edit that did not change the folder mtime (Greptile P1).
     if overrides.force_reingest != Some(true)
         && let Some(existing) = index.get_book(id)?
         && existing.source_mtime == source_mtime
@@ -692,8 +739,8 @@ fn scan_mp3_folder(
         }
     }
 
-    // Probe each track for duration/track/title; a corrupt file is skipped, not
-    // fatal to the book.
+    // Probe each track for duration/track/title. The scan skips a corrupt
+    // file; it is not fatal to the book.
     let mut tracks: Vec<Mp3Track> = Vec::new();
     for path in &files {
         match probe(path) {
@@ -717,10 +764,11 @@ fn scan_mp3_folder(
         id: id.to_string(),
         slug: id.to_string(),
         feed_id: podspine_index::capability::generate(),
-        // Per-book overrides (Sprint 6.4), computed above and re-checked by the
-        // idempotency guard so a sidecar edit re-persists them. storage_mode/remux/
-        // force_embedded are no-ops for MP3 folders (tracks are served in place),
-        // so persist no storage_mode (`None` = follow global).
+        // Per-book overrides (Sprint 6.4). The code above computes them, and
+        // the idempotency guard re-checks them, so a sidecar edit re-persists
+        // them. `storage_mode`/`remux`/`force_embedded` are no-ops for MP3
+        // folders (the server serves tracks in place), so persist no
+        // `storage_mode` (`None` = follow the global setting).
         title: eff_title,
         author: eff_author,
         cover_path: None,
@@ -728,16 +776,18 @@ fn scan_mp3_folder(
         source_mtime,
         storage_mode: None,
         default_cover_url: eff_cover,
-        // No chapters in an MP3 folder, so force_embedded never applies.
+        // An MP3 folder has no chapters, so `force_embedded` never applies.
         force_embedded: false,
-        // MP3 is podcast-safe: an MP3 folder is never re-encoded (Task 5.2).
+        // MP3 is podcast-safe: the scan never re-encodes an MP3 folder
+        // (Task 5.2).
         transcode: Some(TranscodeMode::Off),
     };
     index.upsert_book(&book)?;
 
     let n = tracks.len();
-    // Each track is a whole file → served in place from the library, no copy.
-    // Reclaim any verbatim copies a pre-6.2 ingest wrote under <data_dir>.
+    // Each track is a whole file. The server serves it in place from the
+    // library, with no copy. Reclaim any verbatim copies that a pre-6.2 ingest
+    // wrote under `<data_dir>`.
     remove_stale_episode_copies(&book_out);
     for (idx, t) in tracks.iter().enumerate() {
         let byte_length = std::fs::metadata(&t.path)
@@ -752,13 +802,14 @@ fn scan_mp3_folder(
             idx: idx as i64,
             title: t.title.clone(),
             file_path: t.path.to_string_lossy().into_owned(),
-            // A folder track IS a whole source file — stream it in place.
+            // A folder track IS a whole source file. Stream it in place.
             source_path: t.path.to_string_lossy().into_owned(),
             // MP3 has no `moov` atom, so faststart never applies.
             needs_faststart: false,
             byte_length: byte_length as i64,
             duration_sec: t.duration_sec,
-            // Whole files (not sub-ranges of a container), so each starts at 0.
+            // Tracks are whole files, not sub-ranges of a container, so each
+            // starts at 0.
             start_sec: 0.0,
             pubdate_epoch: pubdate_epoch(source_mtime, idx, n),
         })?;
@@ -767,8 +818,8 @@ fn scan_mp3_folder(
     Ok(book)
 }
 
-/// Order tracks by track number when every one is present and the numbers are
-/// distinct; otherwise fall back to a case-insensitive filename sort (warning).
+/// Order tracks by track number when every number is present and distinct.
+/// Otherwise fall back to a case-insensitive filename sort and log a warning.
 fn order_mp3_tracks(tracks: &mut [Mp3Track], dir: &Path) {
     let numbers: Option<Vec<u32>> = tracks.iter().map(|t| t.track).collect();
     let usable = numbers.as_ref().is_some_and(|v| {
@@ -800,11 +851,12 @@ fn collect_mp3s(dir: &Path, library_root: &Path) -> Vec<PathBuf> {
         .flatten()
         .map(|e| e.path())
         .filter(|p| p.is_file() && ext_lower(p).as_deref() == Some("mp3"))
-        // A track can itself be a symlink out of the library even when its folder
-        // is inside it — `source_is_inside` only vetted the folder. Such a track
-        // would be indexed into the feed and then 404 at serve time, because the
-        // http layer canonicalizes each enclosure and refuses anything outside the
-        // library root. Drop it here, loudly (Greptile) — [`resolve_inside`] warns.
+        // A track can itself be a symlink out of the library even when its
+        // folder is inside it: `source_is_inside` only vetted the folder. Such
+        // a track would land in the feed and then 404 at serve time, because
+        // the http layer canonicalizes each enclosure and refuses anything
+        // outside the library root. Drop it here, loudly (Greptile):
+        // [`resolve_inside`] warns.
         .filter(|p| resolve_inside(p, library_root).is_some())
         .collect()
 }
@@ -816,8 +868,9 @@ fn dir_name(dir: &Path) -> String {
         .unwrap_or_else(|| "book".to_string())
 }
 
-/// Outcome of a library scan (counts only — a library of thousands of books is
-/// never held in memory; each is indexed and dropped in turn, NFR-P4).
+/// Outcome of a library scan. Counts only: the scan never holds a library of
+/// thousands of books in memory; it indexes each book and drops it in turn
+/// (NFR-P4).
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct ScanSummary {
     /// Books successfully indexed.
@@ -833,7 +886,7 @@ pub struct ScanSummary {
 enum BookSource {
     /// A single splittable audio file (`.m4b`/`.m4a`, or a lone `.mp3`).
     File(PathBuf),
-    /// A folder of per-track MP3s — recognized in v1, ingested in Task 3.3.
+    /// A folder of per-track MP3s (recognized in v1, ingested since Task 3.3).
     Mp3Folder(PathBuf),
 }
 
@@ -846,21 +899,23 @@ impl BookSource {
         }
     }
 
-    /// The base name a slug is derived from.
+    /// The base name that a slug is derived from.
     ///
-    /// For anything discoverable before recursive walking existed — a file at the
-    /// library root, or a book folder directly below it — this is exactly what it
-    /// always was: the file stem, or the folder name. That is deliberate and load
-    /// bearing. The slug becomes `book.id`, and a book's capability `feed_id` is
-    /// preserved per id across re-scans, so changing how an existing book's id is
-    /// derived would rotate its feed URL and silently break every subscriber.
+    /// Some books were discoverable before recursive walking existed: a file
+    /// at the library root, or a book folder directly below it. For those, the
+    /// base name is exactly what it always was: the file stem, or the folder
+    /// name. That is deliberate and load-bearing. The slug becomes `book.id`,
+    /// and a book's capability `feed_id` is preserved per id across re-scans.
+    /// A change to how an existing book's id is derived would therefore rotate
+    /// its feed URL and silently break every subscriber.
     ///
-    /// A book found *deeper* than that has never been indexed before, so its name
-    /// can be the better one: the path from the library root to its folder, joined
-    /// — `Jules Verne/The Mysterious Island/…m4b` → `Jules Verne - The Mysterious Island`. That reads well, and it
-    /// keeps two books of the same title under different authors from colliding
-    /// into `the-mysterious-island` and `-2`, whose assignment would depend on walk
-    /// order.
+    /// A book found *deeper* than that has never been indexed before, so its
+    /// name can be the better one: the path from the library root to its
+    /// folder, joined. `Jules Verne/The Mysterious Island/…m4b` becomes
+    /// `Jules Verne - The Mysterious Island`. That reads well. It also keeps
+    /// two books with the same title under different authors from colliding
+    /// into `the-mysterious-island` and `-2`, whose assignment would depend on
+    /// walk order.
     fn base_name(&self, library_root: &Path) -> String {
         match self {
             BookSource::File(p) => match nested_prefix(p.parent(), library_root) {
@@ -879,31 +934,35 @@ impl BookSource {
     }
 }
 
-/// The folder a nested book sits in, as its display title: `Jules Verne/The Mysterious
-/// Island/Jules Verne -   - The Mysterious Island.m4b` → `Some("The Mysterious Island")`.
+/// The folder that a nested book sits in, as its display title:
+/// `Jules Verne/The Mysterious Island/Jules Verne -   - The Mysterious Island.m4b`
+/// becomes `Some("The Mysterious Island")`.
 ///
 /// A nested library names the book on the folder and treats the filename as a
-/// dumping ground for author, narrator and separators, so the folder is almost
-/// always the better title. `None` for a book at or directly below the root, whose
-/// title stays the file stem — those books may already be indexed, and a feed
-/// title that changes under a subscriber is a change worth not making by accident.
-/// A `.podspine.toml` `title` still wins over this.
+/// dumping ground for author, narrator, and separators. So the folder is
+/// almost always the better title. The result is `None` for a book at or
+/// directly below the root; such a book keeps the file stem as its title.
+/// Those books may already be indexed, and a feed title must not change under
+/// a subscriber by accident. A `.podspine.toml` `title` still wins over this.
 fn nested_title(source: &BookSource, library_root: &Path) -> Option<String> {
     let BookSource::File(path) = source else {
         // An MP3-folder book is already titled by its folder.
         return None;
     };
     let dir = path.parent()?;
-    // Only for a book below the first level: `<root>/<author>/<title>/…`.
+    // This applies only to a book below the first level:
+    // `<root>/<author>/<title>/…`.
     nested_prefix(Some(dir), library_root)?;
     dir.file_name().map(|s| s.to_string_lossy().into_owned())
 }
 
-/// The joined path from `library_root` to a book folder, for a book nested deeper
-/// than one level: `<root>/Jules Verne/The Mysterious Island` → `Some("Jules Verne - The Mysterious Island")`.
+/// The joined path from `library_root` to a book folder, for a book nested
+/// deeper than one level: `<root>/Jules Verne/The Mysterious Island` becomes
+/// `Some("Jules Verne - The Mysterious Island")`.
 ///
-/// `None` for a book at or directly below the root — those keep their historical
-/// name (see [`BookSource::base_name`]) — and for anything outside the root.
+/// The result is `None` for a book at or directly below the root (those keep
+/// their historical name, see [`BookSource::base_name`]), and for anything
+/// outside the root.
 fn nested_prefix(book_dir: Option<&Path>, library_root: &Path) -> Option<String> {
     let rel = book_dir?.strip_prefix(library_root).ok()?;
     let parts: Vec<String> = rel
@@ -913,20 +972,22 @@ fn nested_prefix(book_dir: Option<&Path>, library_root: &Path) -> Option<String>
     (parts.len() > 1).then(|| parts.join(" - "))
 }
 
-/// Audio extensions Podspine ingests: Tier-1 (M4B/M4A/MP3) and Tier-2 (Ogg
-/// Vorbis/Opus/FLAC, Task 3.9). DRM inputs (AAX/AAXC/`.aa`/`.odm`) are
-/// deliberately absent and logged as skipped during discovery (PRD W5).
+/// Audio extensions that Podspine ingests: Tier-1 (M4B/M4A/MP3) and Tier-2
+/// (Ogg Vorbis/Opus/FLAC, Task 3.9). DRM inputs (AAX/AAXC/`.aa`/`.odm`) are
+/// deliberately absent from this list; discovery logs them as skipped
+/// (PRD W5).
 const AUDIO_EXTENSIONS: &[&str] = &["m4b", "m4a", "mp3", "ogg", "oga", "opus", "flac"];
 
-/// How far below the library root the walk descends before giving up. Deep
-/// enough for `shelf/author/series/title/`, shallow enough that a symlink the loop
-/// guard somehow misses can't spin.
+/// How far below the library root the walk descends before it gives up. The
+/// limit is deep enough for `shelf/author/series/title/`, and shallow enough
+/// that a symlink that the loop guard somehow misses cannot spin.
 const MAX_LIBRARY_DEPTH: usize = 8;
 
-/// Resolve + parse a book's `.podspine.toml` (Sprint 6.4). A missing sidecar
-/// yields the empty default; a bad sidecar or a server-global key that doesn't
-/// apply per book is logged and dropped — never fatal to the scan. `source` is
-/// canonicalized so the folder-vs-library-root check compares like-for-like.
+/// Resolve and parse a book's `.podspine.toml` (Sprint 6.4). A missing sidecar
+/// yields the empty default. The scan logs and drops a bad sidecar, and also a
+/// server-global key that does not apply per book; neither is fatal. `source`
+/// is canonicalized, so the folder-vs-library-root check compares like for
+/// like.
 fn resolve_book_overrides(source: &Path, library_root: &Path) -> BookOverrides {
     let source = source
         .canonicalize()
@@ -946,27 +1007,24 @@ fn resolve_book_overrides(source: &Path, library_root: &Path) -> BookOverrides {
     }
 }
 
-/// Scan a library root of many audiobooks into `index`, writing each book's
-/// episodes under `<data_dir>/books/<slug>/`. One independent book per top-level
-/// audio file or per-book subfolder. Slugs are collision-free and deterministic
-/// across re-scans; a single failing book is logged and skipped, never fatal.
-/// Collapse any set of index rows that share one source to a single row, keeping
-/// the **earliest-created** row (the feed subscribers have held longest) and
-/// deleting the rest with their extracted output.
+/// Collapse any set of index rows that share one source to a single row. Keep
+/// the **earliest-created** row (the one whose feed subscribers have held
+/// longest). Delete the rest, together with their extracted output.
 ///
-/// This is the floor the rest of the identity logic stands on: **one source, one
-/// book row, one feed.** Nothing the current scanner writes creates a second row
-/// for one source — the source→id reuse map in [`scan_library`] sees to that — but
-/// a database written by an earlier build, or edited by hand, can hold them, and
-/// neither reuse nor orphan pruning would ever reconcile it: the map keeps one id
-/// arbitrarily, and both rows survive pruning because their shared source still
-/// exists. The book would stay listed under two capability URLs forever. Running
-/// this first makes the reuse map unambiguous and heals such a database in one
-/// reconcile.
+/// This is the floor that the rest of the identity logic stands on: **one
+/// source, one book row, one feed.** Nothing the current scanner writes
+/// creates a second row for one source; the source→id reuse map in
+/// [`scan_library`] sees to that. But a database written by an earlier build,
+/// or edited by hand, can hold such rows, and neither reuse nor orphan pruning
+/// would ever reconcile it: the map keeps one id arbitrarily, and both rows
+/// survive pruning because their shared source still exists. The book would
+/// stay listed under two capability URLs forever. Running this first makes the
+/// reuse map unambiguous and heals such a database in one reconcile.
 ///
-/// A row whose source is *gone* is left for [`prune_orphans`] — grouping only
-/// canonicalizable paths also means an unmounted library (every source missing)
-/// collapses nothing. Best-effort: a failed lookup leaves the index untouched.
+/// A row whose source is *gone* is left for [`prune_orphans`]. The collapse
+/// groups only canonicalizable paths, so an unmounted library (every source
+/// missing) collapses nothing. It is best-effort: a failed lookup leaves the
+/// index untouched.
 fn collapse_duplicate_source_rows(index: &Index, data_dir: &Path) {
     let identities = match index.book_source_identities() {
         Ok(identities) => identities,
@@ -975,15 +1033,16 @@ fn collapse_duplicate_source_rows(index: &Index, data_dir: &Path) {
             return;
         }
     };
-    // `book_source_identities` is ordered oldest-first (created_at asc), so the
-    // FIRST row seen for a source is the earliest-created — the feed subscribers
-    // have held longest — and is the one to keep. Sorting by id instead would drop
-    // an established `foo-2` in favour of a `foo` a later bug duplicated, deleting
-    // the very feed people use (Greptile).
+    // `book_source_identities` is ordered oldest-first (`created_at` asc). So
+    // the FIRST row seen for a source is the earliest-created one (the feed
+    // that subscribers have held longest), and it is the one to keep. A sort
+    // by id instead would drop an established `foo-2` in favour of a `foo`
+    // that a later bug duplicated. That would delete the very feed people use
+    // (Greptile).
     let mut kept_for_source: HashMap<PathBuf, String> = HashMap::new();
     for (id, source_path, _created_at) in identities {
-        // A gone source is orphan-pruning's job; grouping only canonicalizable
-        // paths also means an unmounted library collapses nothing.
+        // A gone source is orphan-pruning's job. The grouping also covers only
+        // canonicalizable paths, so an unmounted library collapses nothing.
         let Ok(real) = Path::new(&source_path).canonicalize() else {
             continue;
         };
@@ -1011,30 +1070,36 @@ fn collapse_duplicate_source_rows(index: &Index, data_dir: &Path) {
     }
 }
 
+/// Scan a library root of many audiobooks into `index`. Write each book's
+/// episodes under `<data_dir>/books/<slug>/`. Each top-level audio file and
+/// each per-book subfolder becomes one independent book. Slugs are
+/// collision-free and deterministic across re-scans. The scan logs and skips a
+/// single failing book; it is never fatal.
 pub fn scan_library(
     library: &Path,
     data_dir: &Path,
     index: &Index,
     opts: ScanOptions,
 ) -> ScanSummary {
-    // Canonical library root, for resolving per-book `.podspine.toml` sidecars
-    // (Sprint 6.4) — matched against each book's canonical source path — and for
-    // naming books found below the top level.
+    // The canonical library root serves two purposes. It resolves per-book
+    // `.podspine.toml` sidecars (Sprint 6.4; the match is against each book's
+    // canonical source path). And it names books found below the top level.
     let library_root = library
         .canonicalize()
         .unwrap_or_else(|_| library.to_path_buf());
     let sources = discover(&library_root, data_dir);
 
-    // Enforce one row per source BEFORE the reuse map is read, so the map cannot
-    // inherit a duplicate (invariant A — see the function's doc).
+    // Enforce one row per source BEFORE this scan reads the reuse map, so that
+    // the map cannot inherit a duplicate (invariant A; see the function's doc).
     collapse_duplicate_source_rows(index, data_dir);
 
-    // Every already-indexed book, keyed by its (canonical) source path. A source
-    // that is already indexed keeps whatever id it has — including a `-2` suffix it
-    // once earned — instead of being re-derived from its name. Without this, a book
-    // that was suffixed because a now-pruned stale row occupied its base id would,
-    // on the next scan, ALSO be indexed under the freed base id: one audiobook
-    // under two capability feeds (Greptile). Reuse makes the id stable per source.
+    // Every already-indexed book, keyed by its (canonical) source path. A
+    // source that is already indexed keeps whatever id it has, including a
+    // `-2` suffix it once earned; the scan does not re-derive the id from the
+    // name. Without this map, a book once suffixed (because a now-pruned stale
+    // row occupied its base id) would ALSO be indexed under the freed base id
+    // on the next scan: one audiobook under two capability feeds (Greptile).
+    // Reuse makes the id stable per source.
     let existing_by_source: HashMap<PathBuf, String> = match index.list_books() {
         Ok(books) => books
             .into_iter()
@@ -1042,8 +1107,8 @@ pub fn scan_library(
             .collect(),
         Err(err) => {
             // Proceed with an empty map (same behavior as before), but say so:
-            // id reuse — the primary feed-URL stability mechanism — is skipped
-            // for this scan, leaving only the owns_a_different_source guard.
+            // this scan skips id reuse, the primary feed-URL stability
+            // mechanism. Only the `owns_a_different_source` guard remains.
             tracing::warn!(error = %err, "listing books failed; id reuse skipped this scan");
             HashMap::new()
         }
@@ -1053,10 +1118,11 @@ pub fn scan_library(
     let mut summary = ScanSummary::default();
     for source in sources {
         let source_path = source.path();
-        // If this exact source is already indexed, keep its id — that is what makes
-        // a feed URL stable across scans, and what stops a once-suffixed book from
-        // being re-indexed under a since-freed base id. Otherwise reserve a slug in
-        // deterministic order, never one a different still-present book holds.
+        // If this exact source is already indexed, keep its id. That rule
+        // makes a feed URL stable across scans, and it stops a once-suffixed
+        // book from landing under a since-freed base id. Otherwise reserve a
+        // slug in deterministic order, and never one that a different
+        // still-present book holds.
         let slug = match source_path
             .canonicalize()
             .ok()
@@ -1074,20 +1140,22 @@ pub fn scan_library(
             ),
         };
         let mut overrides = resolve_book_overrides(source_path, &library_root);
-        // A nested book's filename is usually `Author -   - Title.m4b`; its folder
-        // is just `Title`. Seed the title from the folder unless the book's own
-        // `.podspine.toml` says otherwise — an explicit title always wins.
+        // A nested book's filename is usually `Author -   - Title.m4b`; its
+        // folder is just `Title`. Seed the title from the folder unless the
+        // book's own `.podspine.toml` says otherwise. An explicit title always
+        // wins.
         if overrides.title.is_none()
             && let Some(title) = nested_title(&source, &library_root)
         {
             overrides.title = Some(title);
         }
-        // `disabled` (a `.podspine.toml` troubleshooting knob): drop the book from
-        // every surface — prune it if it was previously indexed, and skip.
+        // `disabled` (a `.podspine.toml` troubleshooting option): drop the
+        // book from every surface. Prune it if it was previously indexed, then
+        // skip it.
         if overrides.disabled == Some(true) {
-            // `delete_book` reports via its bool whether a row existed, so no
-            // pre-check is needed; a failed delete must be surfaced — the book
-            // would silently stay indexed and keep serving its feed.
+            // `delete_book` reports via its bool whether a row existed, so this
+            // code needs no pre-check. Surface a failed delete: the book would
+            // otherwise silently stay indexed and keep serving its feed.
             if let Err(err) = index.delete_book(&slug) {
                 tracing::warn!(slug = %slug, error = %err, "failed to prune disabled book");
             }
@@ -1130,14 +1198,15 @@ pub fn scan_library(
     summary
 }
 
-/// Remove indexed books whose source file/folder no longer exists, along with
-/// their split output under `<data_dir>/books/<id>/`. Returns the count pruned.
+/// Remove indexed books whose source file or folder no longer exists, together
+/// with their split output under `<data_dir>/books/<id>/`. Return the count of
+/// pruned books.
 ///
 /// **Empty-root guard:** if the library root is missing, unreadable, or empty,
-/// nothing is pruned. A transiently-unmounted library looks like "every source
-/// vanished"; without this guard an unmount would wipe the whole index. The cost
-/// is that genuinely deleting your *last* book leaves it indexed until another
-/// book is present — a safe trade.
+/// the prune removes nothing. A transiently unmounted library looks like
+/// "every source vanished"; without this guard, an unmount would wipe the
+/// whole index. The cost: when you genuinely delete your *last* book, it stays
+/// indexed until another book is present. That is a safe trade.
 pub fn prune_orphans(library: &Path, data_dir: &Path, index: &Index) -> Result<usize, ScanError> {
     let root_has_entries = std::fs::read_dir(library)
         .map(|mut rd| rd.next().is_some())
@@ -1169,19 +1238,20 @@ pub fn prune_orphans(library: &Path, data_dir: &Path, index: &Index) -> Result<u
     Ok(pruned)
 }
 
-/// Reconcile the index with the library: [`scan_library`] (add/update) then
-/// [`prune_orphans`] (remove sources that disappeared). This is what the
-/// auto-watch runs after each debounced batch of changes, and what the server
-/// runs at startup so a book deleted while it was down is cleaned up.
+/// Reconcile the index with the library: [`scan_library`] (add/update), then
+/// [`prune_orphans`] (remove sources that disappeared). The auto-watch runs
+/// this after each debounced batch of changes. The server also runs it at
+/// startup, so that it cleans up a book deleted while the server was down.
 pub fn reconcile(library: &Path, data_dir: &Path, index: &Index, opts: ScanOptions) -> ScanSummary {
     let mut summary = scan_library(library, data_dir, index, opts);
     summary.pruned = prune_orphans(library, data_dir, index).unwrap_or_else(|err| {
         tracing::warn!(error = %err, "orphan prune failed");
         0
     });
-    // Set from the index rather than accumulated from this run's adds, so a
-    // prune (or a book that failed to ingest) is reflected just as accurately.
-    // Reconcile is startup + debounced-watch only, so the extra read is cheap.
+    // Read the count from the index; do not accumulate this run's adds. The
+    // metric then also reflects a prune, and a book that failed to ingest,
+    // accurately. Reconcile runs only at startup and on the debounced watch,
+    // so the extra read is cheap.
     match index.list_books() {
         Ok(books) => podspine_metrics::set_books_indexed(books.len() as u64),
         Err(err) => tracing::warn!(error = %err, "could not count books for metrics"),
@@ -1189,27 +1259,29 @@ pub fn reconcile(library: &Path, data_dir: &Path, index: &Index, opts: ScanOptio
     summary
 }
 
-/// Debounce window: a burst of filesystem events (e.g. one big file copy lands
-/// as many) is coalesced into a single reconcile once things go quiet.
+/// Debounce window. One big file copy lands as many filesystem events; the
+/// watch loop coalesces such a burst into a single reconcile once the events
+/// stop.
 const WATCH_DEBOUNCE: std::time::Duration = std::time::Duration::from_secs(2);
 
 /// Spawn a background thread that establishes the library watch, runs the
-/// **initial** reconcile, then [`reconcile`]s again whenever the library changes
-/// (debounced). The thread opens its **own** index connection on `db_path` — with
-/// WAL enabled, its rescans (including a long split of a newly-added book) don't
-/// block the server's feed/audio reads.
+/// **initial** reconcile, and then runs [`reconcile`] again whenever the
+/// library changes (debounced). The thread opens its **own** index connection
+/// on `db_path`. With WAL enabled, its rescans (including a long split of a
+/// newly added book) do not block the server's feed/audio reads.
 ///
-/// The watch is registered *before* the initial reconcile, so a change that lands
-/// during the first scan is buffered in the channel and picked up by the loop
-/// rather than missed until the next event or a restart (issue 159).
-/// `on_initial_scan` fires once the initial reconcile returns — the server uses it
-/// to leave its "Scanning…" holding state and start serving feeds. It runs even if
-/// the index can't be opened or the watch can't be established, so the server
-/// never hangs on "Scanning…".
+/// The thread registers the watch *before* the initial reconcile. A change
+/// that lands during the first scan is then buffered in the channel, and the
+/// loop picks it up; it is not missed until the next event or a restart
+/// (issue 159). `on_initial_scan` fires once the initial reconcile returns.
+/// The server uses it to leave its "Scanning…" holding state and start serving
+/// feeds. It runs even if the index cannot be opened or the watch cannot be
+/// established, so the server never hangs on "Scanning…".
 ///
-/// Returns immediately; the watcher runs for the process lifetime. A setup
-/// failure (or the watch ending) is logged and simply disables auto-refresh —
-/// the server keeps serving what's already indexed. (Task 4.3 / PRD C2.)
+/// This function returns immediately; the watcher runs for the process
+/// lifetime. The thread logs a setup failure (or the end of the watch) and
+/// simply disables auto-refresh; the server keeps serving what is already
+/// indexed. (Task 4.3 / PRD C2.)
 pub fn spawn_library_watcher(
     library: PathBuf,
     data_dir: PathBuf,
@@ -1235,9 +1307,9 @@ fn watch_loop(
 
     let index = match Index::open(db_path) {
         Ok(index) => index,
-        // No index → no scan and no watch. Flip readiness anyway so the server
-        // stops holding "Scanning…" (it serves whatever is already indexed), then
-        // surface the failure.
+        // No index means no scan and no watch. Flip readiness anyway, so that
+        // the server stops holding "Scanning…" (it serves whatever is already
+        // indexed). Then surface the failure.
         Err(err) => {
             on_initial_scan();
             return Err(err.into());
@@ -1245,22 +1317,26 @@ fn watch_loop(
     };
 
     let (tx, rx) = std::sync::mpsc::channel();
-    // Filter events at the source so an unrelated write can't spin the watcher into
-    // a rescan-every-few-seconds loop: ignore reads (another app streaming the
-    // files bumps atime but changes nothing), our own split output under `data_dir`
-    // (writing an episode there would otherwise self-trigger a rescan forever), and
-    // the dir names discovery never walks (dotdirs, `@eaDir`, `lost+found` — NAS
-    // junk / thumbnail caches). Only a real library change reaches the debounced
-    // reconcile below; an irrelevant trickle no longer defeats the debounce.
+    // Filter events at the source, so that an unrelated write cannot spin the
+    // watcher into a rescan-every-few-seconds loop. Ignore three groups:
+    // - reads (another app that streams the files bumps atime but changes
+    //   nothing),
+    // - our own split output under `data_dir` (an episode written there would
+    //   otherwise self-trigger a rescan forever),
+    // - the dir names discovery never walks (dotdirs, `@eaDir`, `lost+found`:
+    //   NAS junk and thumbnail caches).
+    // Only a real library change reaches the debounced reconcile below. An
+    // irrelevant trickle no longer defeats the debounce.
     let library_root = library.to_path_buf();
     let data_dir_owned = data_dir.to_path_buf();
     let data_canon = data_dir.canonicalize().ok();
-    // Bring the watch up BEFORE the initial reconcile: a change that lands during
-    // the scan's directory walk is then buffered in `rx` and picked up by the loop
-    // below, instead of being missed until the next event or a restart (issue 159).
+    // Bring the watch up BEFORE the initial reconcile. A change that lands
+    // during the scan's directory walk is then buffered in `rx`, and the loop
+    // below picks it up. It is not missed until the next event or a restart
+    // (issue 159).
     let watcher = notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
-        // Drop irrelevant events; forward everything else (incl. errors, so the
-        // loop still sees a watch failure).
+        // Drop irrelevant events. Forward everything else, including errors,
+        // so that the loop still sees a watch failure.
         if let Ok(event) = &res
             && !watch_event_is_relevant(
                 event,
@@ -1282,17 +1358,18 @@ fn watch_loop(
             tracing::info!(library = %library.display(), "watching library for changes");
             Some(watcher)
         }
-        // Couldn't establish the watch (e.g. the inotify watch limit). Still run the
-        // initial scan and mark ready below — the server must not hang on
-        // "Scanning…" — we just lose auto-refresh.
+        // The watch could not be established (e.g. the inotify watch limit).
+        // Still run the initial scan and mark ready below; the server must not
+        // hang on "Scanning…". Only auto-refresh is lost.
         Err(err) => {
             tracing::error!(error = %err, "could not watch the library — auto-refresh disabled");
             None
         }
     };
 
-    // Initial reconcile: index new/changed books and prune ones removed while the
-    // server was down. Runs after the watch is live so no in-window change is lost.
+    // Initial reconcile: index new/changed books, and prune books removed
+    // while the server was down. It runs after the watch is live, so no
+    // in-window change is lost.
     let s = reconcile(library, data_dir, &index, opts);
     tracing::info!(
         indexed = s.indexed,
@@ -1303,14 +1380,14 @@ fn watch_loop(
     // The first scan is done: the server leaves its "Scanning…" holding state.
     on_initial_scan();
 
-    // Nothing to loop on if the watch never came up.
+    // If the watch never came up, there is nothing to loop on.
     let Some(_watcher) = watcher else {
         return Ok(());
     };
 
-    // Block for an event, then drain the burst until it's quiet for the debounce
-    // window, then reconcile once. `_watcher` stays alive in scope, so `rx` never
-    // disconnects and the loop runs for the process lifetime.
+    // Block for an event. Then drain the burst until it is quiet for the
+    // debounce window. Then reconcile once. `_watcher` stays alive in scope,
+    // so `rx` never disconnects and the loop runs for the process lifetime.
     while rx.recv().is_ok() {
         while rx.recv_timeout(WATCH_DEBOUNCE).is_ok() {}
         tracing::info!("library changed — reconciling");
@@ -1326,11 +1403,12 @@ fn watch_loop(
 }
 
 /// Whether a watch event should trigger a reconcile. Reads (open/close/access,
-/// including the atime bumps another app makes while streaming the files) never
-/// change content, so they're dropped; otherwise the event is relevant if *any* of
-/// its paths is a real library path (notify batches related paths, e.g. a rename's
-/// from+to). An event with no paths (a rescan hint) is treated as relevant — we
-/// can't judge it, so err toward reconciling.
+/// including the atime bumps another app makes while it streams the files)
+/// never change content, so the filter drops them. Otherwise the event is
+/// relevant if *any* of its paths is a real library path (notify batches
+/// related paths, e.g. a rename's from+to). An event with no paths (a rescan
+/// hint) counts as relevant: the filter cannot judge it, so it errs toward a
+/// reconcile.
 fn watch_event_is_relevant(
     event: &notify::Event,
     library_root: &Path,
@@ -1349,12 +1427,13 @@ fn watch_event_is_relevant(
         .any(|p| watch_path_is_relevant(p, library_root, data_dir, data_canon))
 }
 
-/// Whether a changed path is a real library source rather than something the walk
-/// ignores. Mirrors discovery so the watch and the walk agree: skip podspine's own
-/// output under `data_dir` (a nested `--data-dir` writing an episode must not read
-/// as a library change) and any path with an ignored component — dotdirs,
-/// `@eaDir`, `lost+found` — below the library root. Purely lexical (no fs calls):
-/// a `Remove` event's path is already gone, and this runs in the hot event handler.
+/// Whether a changed path is a real library source, not something the walk
+/// ignores. This mirrors discovery, so the watch and the walk agree. Skip
+/// podspine's own output under `data_dir` (an episode that a nested
+/// `--data-dir` writes must not read as a library change). Also skip any path
+/// with an ignored component (dotdirs, `@eaDir`, `lost+found`) below the
+/// library root. The check is purely lexical (no fs calls): a `Remove` event's
+/// path is already gone, and this runs in the hot event handler.
 fn watch_path_is_relevant(
     path: &Path,
     library_root: &Path,
@@ -1364,8 +1443,9 @@ fn watch_path_is_relevant(
     if path.starts_with(data_dir) || data_canon.is_some_and(|d| path.starts_with(d)) {
         return false;
     }
-    // Only inspect components *below* the root, so a library that itself lives under
-    // a dot-path (e.g. `…/.local/share/books`) isn't wholly ignored.
+    // Only inspect components *below* the root, so that a library that itself
+    // lives under a dot-path (e.g. `…/.local/share/books`) is not wholly
+    // ignored.
     let rel = path.strip_prefix(library_root).unwrap_or(path);
     !rel.components().any(|c| match c {
         std::path::Component::Normal(name) => name.to_str().is_some_and(is_ignored_name),
@@ -1373,15 +1453,16 @@ fn watch_path_is_relevant(
     })
 }
 
-/// Discover book sources one level under `library`, in a deterministic
-/// (path-sorted) order so slug disambiguation is stable across re-scans.
+/// Discover book sources under `library`, in a deterministic (path-sorted)
+/// order, so that slug disambiguation is stable across re-scans.
 fn discover(library: &Path, data_dir: &Path) -> Vec<BookSource> {
-    // Podspine's own output must never be walked. A `--data-dir` nested inside the
-    // library (a perfectly reasonable `-v /books:/library -e DATA_DIR=/library/.podspine`)
-    // holds extracted episodes, which a recursive walk would otherwise index as
-    // books and then re-split — feeding its own output back in.
+    // The walk must never enter Podspine's own output. A `--data-dir` nested
+    // inside the library (a perfectly reasonable
+    // `-v /books:/library -e DATA_DIR=/library/.podspine`) holds extracted
+    // episodes. A recursive walk would otherwise index them as books and then
+    // re-split them: it would feed its own output back in.
     let data_root = data_dir.canonicalize().ok();
-    // Containment is judged against the canonical root, but the walk descends the
+    // The containment check uses the canonical root, but the walk descends the
     // path as given, so discovered sources keep the caller's spelling.
     let root = library
         .canonicalize()
@@ -1402,15 +1483,15 @@ fn discover(library: &Path, data_dir: &Path) -> Vec<BookSource> {
 /// One level of the library walk.
 ///
 /// At every level: files are books in their own right, and a subdirectory is
-/// either a book (it holds audio *directly*) or a container to walk — an author,
-/// a series, a shelf. That is what makes an `Author/Title/book.m4b` library work
-/// without rearranging it, which is the layout Audiobookshelf, Plex and Jellyfin
-/// all produce.
+/// either a book (it holds audio *directly*) or a container to walk (an
+/// author, a series, a shelf). That rule makes an `Author/Title/book.m4b`
+/// library work without a rearrange, and that is the layout Audiobookshelf,
+/// Plex, and Jellyfin all produce.
 ///
-/// A directory that classifies as a book is **not** descended into: the first
-/// level holding audio wins. (Consequence, documented: a multi-disc book laid out
-/// as `Title/CD1/*.mp3` + `Title/CD2/*.mp3` becomes two books, since `Title/`
-/// itself holds no audio.)
+/// The walk does **not** descend into a directory that classifies as a book:
+/// the first level that holds audio wins. (Documented consequence: a
+/// multi-disc book laid out as `Title/CD1/*.mp3` + `Title/CD2/*.mp3` becomes
+/// two books, because `Title/` itself holds no audio.)
 fn walk_library(
     dir: &Path,
     depth: usize,
@@ -1427,17 +1508,18 @@ fn walk_library(
         );
         return;
     }
-    // Canonicalize for the loop guard: a symlink pointing back up the tree (or at
-    // a sibling already walked) would otherwise recurse until the depth cap, and
-    // index the same book twice on the way.
+    // Canonicalize for the loop guard. A symlink that points back up the tree
+    // (or at a sibling already walked) would otherwise recurse until the depth
+    // cap, and index the same book twice on the way.
     //
-    // Below the root, containment is enforced too ([`resolve_inside`]): `is_dir`
-    // follows symlinks, so a link inside the library pointing at audio elsewhere
-    // on the host would be walked and indexed — and then be unplayable, because
-    // the serve layer canonicalizes an episode's source and refuses anything
-    // outside the library root (TAD §7). A feed whose audio 404s is worse than a
-    // book that never appears, so the walk refuses to leave the tree. The root
-    // itself is exempt (it defines the tree).
+    // Below the root, the walk also enforces containment ([`resolve_inside`]).
+    // `is_dir` follows symlinks, so the walk would otherwise index a link
+    // inside the library that points at audio elsewhere on the host. That book
+    // would then be unplayable, because the serve layer canonicalizes an
+    // episode's source and refuses anything outside the library root (TAD §7).
+    // A feed whose audio 404s is worse than a book that never appears, so the
+    // walk refuses to leave the tree. The root itself is exempt (it defines
+    // the tree).
     let real = if depth == 0 {
         dir.canonicalize().unwrap_or_else(|_| dir.to_path_buf())
     } else {
@@ -1456,9 +1538,9 @@ fn walk_library(
     let mut entries = match std::fs::read_dir(dir) {
         Ok(entries) => entries.flatten().map(|e| e.path()).collect::<Vec<_>>(),
         Err(err) => {
-            // The root failing is an operator error worth shouting about; a
-            // subdirectory failing (permissions, a race with a move) is one book
-            // lost, not a broken scan.
+            // A root failure is an operator error worth a loud log. A
+            // subdirectory failure (permissions, a race with a move) is one
+            // book lost, not a broken scan.
             if depth == 0 {
                 tracing::error!(error = %err, library = %dir.display(), "cannot read library");
             } else {
@@ -1467,14 +1549,15 @@ fn walk_library(
             return;
         }
     };
-    // Sorted, so slug assignment (and therefore collision suffixes) is identical
-    // on every scan regardless of what the filesystem hands back.
+    // Sort, so that slug assignment (and therefore collision suffixes) is
+    // identical on every scan, independent of what the filesystem hands back.
     entries.sort();
 
-    // Below the root, a directory that holds audio IS a book (or several) and is
-    // not descended into: the first level with audio wins. That keeps a book's own
-    // `extras/` or `bonus/` folder from being ingested as another book. The cost,
-    // documented: a mixed `Author/{loose.m4b, Title/…}` yields only `loose.m4b`.
+    // Below the root, a directory that holds audio IS a book (or several), and
+    // the walk does not descend into it: the first level with audio wins. That
+    // rule keeps a book's own `extras/` or `bonus/` folder from becoming
+    // another book. The documented cost: a mixed `Author/{loose.m4b, Title/…}`
+    // yields only `loose.m4b`.
     if depth > 0 {
         let books: Vec<BookSource> = classify_dir(dir)
             .into_iter()
@@ -1486,16 +1569,18 @@ fn walk_library(
         }
     }
 
-    // The root, or a container. Files and subdirectories are emitted in one
-    // path-sorted pass, which is exactly the order discovery has always produced.
-    // It matters: the order decides which of two same-named books gets the bare
-    // slug and which gets the `-2` suffix, and that slug is the book id whose
-    // capability feed id is preserved across re-scans. Emitting all files ahead of
-    // all directories would swap `Dracula.m4b` and `Dracula/` — handing each subscriber
+    // This is the root, or a container. The loop emits files and
+    // subdirectories in one path-sorted pass, which is exactly the order
+    // discovery has always produced. It matters: the order decides which of
+    // two same-named books gets the bare slug and which gets the `-2` suffix,
+    // and that slug is the book id whose capability feed id is preserved
+    // across re-scans. A pass that emitted all files ahead of all directories
+    // would swap `Dracula.m4b` and `Dracula/`: it would hand each subscriber
     // the other audiobook under the URL they already have.
     //
-    // A root file is a book in its own right (never grouped: several loose `.mp3`
-    // at the root are separate books, not one book's tracks), again as before.
+    // A root file is a book in its own right, never grouped (several loose
+    // `.mp3` at the root are separate books, not one book's tracks), again as
+    // before.
     for path in entries {
         if path.is_file() {
             if depth > 0 {
@@ -1520,21 +1605,21 @@ fn walk_library(
 
 /// Whether a discovered source really lives inside the library.
 ///
-/// A symlinked *file* escapes the directory guard in [`walk_library`], and would
-/// be indexed into a feed the serve layer then refuses to play. Rejected sources
-/// are logged, not silently dropped: a book missing from the UI with nothing in
-/// the log is the worst version of this.
+/// A symlinked *file* escapes the directory guard in [`walk_library`], and it
+/// would land in a feed that the serve layer then refuses to play. The check
+/// logs rejected sources; it never drops them silently. A book missing from
+/// the UI with nothing in the log is the worst version of this.
 fn source_is_inside(src: &BookSource, library_root: &Path) -> bool {
     resolve_inside(src.path(), library_root).is_some()
 }
 
-/// Canonicalize `path` and keep it only if it resolves inside `root` — the
-/// symlink-containment rule shared by the walk, source vetting, and MP3-track
-/// collection: the serve layer canonicalizes every source and refuses anything
-/// outside the library root (TAD §7), so indexing an escapee would publish audio
-/// that 404s. A path that resolves outside the root, or can't be resolved at all,
-/// is dropped with a warning — a book missing from the UI with nothing in the log
-/// is the worst version of this.
+/// Canonicalize `path` and keep it only if it resolves inside `root`. This is
+/// the symlink-containment rule shared by the walk, source vetting, and
+/// MP3-track collection. The serve layer canonicalizes every source and
+/// refuses anything outside the library root (TAD §7), so an indexed escapee
+/// would publish audio that 404s. The check drops, with a warning, a path that
+/// resolves outside the root or cannot be resolved at all. A book missing from
+/// the UI with nothing in the log is the worst version of this.
 fn resolve_inside(path: &Path, root: &Path) -> Option<PathBuf> {
     match path.canonicalize() {
         Ok(real) if real.starts_with(root) => Some(real),
@@ -1553,9 +1638,10 @@ fn resolve_inside(path: &Path, root: &Path) -> Option<PathBuf> {
     }
 }
 
-/// Directories the walk never enters: dotfiles (`.stfolder`, `.git`, …) and the
-/// thumbnail caches NAS software scatters through a share. None of them hold
-/// audiobooks, and walking them is pure cost on a large library.
+/// Directories that the walk never enters: dotfiles (`.stfolder`, `.git`, …)
+/// and the thumbnail caches that NAS software scatters through a share. None
+/// of them hold audiobooks, and a walk of them is pure cost on a large
+/// library.
 fn is_ignored_dir(dir: &Path) -> bool {
     dir.file_name()
         .and_then(|s| s.to_str())
@@ -1563,14 +1649,15 @@ fn is_ignored_dir(dir: &Path) -> bool {
 }
 
 /// The single ignore rule shared by the walk ([`is_ignored_dir`]) and the
-/// watch-event filter ([`watch_path_is_relevant`]), so the two never disagree on
-/// what to skip: dotfiles/dotdirs and the NAS junk caches `@eaDir` / `lost+found`.
+/// watch-event filter ([`watch_path_is_relevant`]), so that the two never
+/// disagree on what to skip: dotfiles/dotdirs and the NAS junk caches
+/// `@eaDir` / `lost+found`.
 fn is_ignored_name(name: &str) -> bool {
     name.starts_with('.') || name == "@eaDir" || name == "lost+found"
 }
 
-/// Classify a per-book subfolder: prefer a splittable `.m4b`/`.m4a`; a lone
-/// `.mp3` is a single-file book; several `.mp3`s are a multi-track folder
+/// Classify a per-book subfolder. Prefer a splittable `.m4b`/`.m4a`. A lone
+/// `.mp3` is a single-file book. Several `.mp3`s are a multi-track folder
 /// (Task 3.3). A folder with no audio yields nothing.
 fn classify_dir(dir: &Path) -> Vec<BookSource> {
     let Ok(entries) = std::fs::read_dir(dir) else {
@@ -1578,16 +1665,18 @@ fn classify_dir(dir: &Path) -> Vec<BookSource> {
     };
     let mut m4x = Vec::new();
     let mut mp3 = Vec::new();
-    // Tier-2 containers (Ogg/Opus/FLAC): a lone one is a book in its own folder,
-    // exactly as it would be at the library root. A folder holding several is not
-    // a Tier-2 equivalent of an MP3 folder — that path only reads `.mp3` tracks —
-    // so it stays unclassified rather than being half-ingested.
+    // Tier-2 containers (Ogg/Opus/FLAC): a lone one is a book in its own
+    // folder, exactly as it would be at the library root. A folder that holds
+    // several is not a Tier-2 equivalent of an MP3 folder (that path only
+    // reads `.mp3` tracks). So it stays unclassified; a half-ingest would be
+    // worse.
     let mut tier2 = Vec::new();
     for path in entries.flatten().map(|e| e.path()) {
         if !path.is_file() {
             continue;
         }
-        // DRM is refused wherever it turns up in the tree, loudly (PRD W5).
+        // The scan refuses DRM wherever it turns up in the tree, loudly
+        // (PRD W5).
         if is_drm(&path) {
             tracing::warn!(
                 path = %path.display(),
@@ -1601,7 +1690,7 @@ fn classify_dir(dir: &Path) -> Vec<BookSource> {
         match ext_lower(&path).as_deref() {
             Some("m4b") | Some("m4a") => m4x.push(path),
             Some("mp3") => mp3.push(path),
-            // Everything else `is_audio` admits is Tier-2.
+            // Everything else that `is_audio` admits is Tier-2.
             _ => tier2.push(path),
         }
     }
@@ -1610,9 +1699,10 @@ fn classify_dir(dir: &Path) -> Vec<BookSource> {
     tier2.sort();
 
     if !m4x.is_empty() {
-        // One `.m4b`/`.m4a` is one whole book, so a folder holding several holds
-        // several books — an author folder of single-file audiobooks, typically.
-        // (`.mp3` is the opposite: several of those are usually one book's tracks.)
+        // One `.m4b`/`.m4a` is one whole book, so a folder that holds several
+        // holds several books: typically an author folder of single-file
+        // audiobooks. (`.mp3` is the opposite: several of those are usually
+        // one book's tracks.)
         m4x.into_iter().map(BookSource::File).collect()
     } else if mp3.len() == 1 {
         vec![BookSource::File(mp3.into_iter().next().unwrap())]
@@ -1632,23 +1722,26 @@ fn classify_dir(dir: &Path) -> Vec<BookSource> {
     }
 }
 
-/// Reserve `base` if free, else `base-2`, `base-3`, … Inserts the chosen slug
-/// into `seen` and returns it.
-/// Choose this source's slug, which becomes its `book.id`.
+/// Choose this source's slug, which becomes its `book.id`: reserve `base` if
+/// it is free, else `base-2`, `base-3`, … Insert the chosen slug into `seen`
+/// and return it.
 ///
-/// Two constraints, both about not stealing an identity:
+/// Two constraints apply, both about identity theft:
 ///
-/// - unique within this scan, so two same-named books get `x` and `x-2`;
-/// - **never a slug the index already holds for a different source that still
-///   exists.** `upsert_book` preserves a book's capability `feed_id` per id, so
-///   handing an existing id to another file keeps the subscriber's URL alive and
-///   swaps the audiobook underneath it. That is the one failure this crate must
-///   never produce, and dedup within a single scan cannot see it: the colliding
-///   book may not be discovered until later in the same walk, or may not be
-///   rediscovered at all.
+/// - The slug is unique within this scan, so two same-named books get `x` and
+///   `x-2`.
+/// - **The slug is never one that a live index row holds for a different
+///   source.** `upsert_book` preserves a book's capability `feed_id` per id.
+///   A hand-over of an existing id to another file would keep the
+///   subscriber's URL alive and swap the audiobook underneath it. That is the
+///   one failure this crate must never produce, and dedup within a single
+///   scan cannot see it: the walk may discover the colliding book later, or
+///   may not rediscover it at all.
 ///
-/// A row whose source no longer exists is fair game — that is a moved or renamed
-/// library, and the stale row is pruned in the same reconcile.
+/// A row whose source no longer exists still owns its id during this scan
+/// (see [`owns_a_different_source`] for why the guard never frees an id
+/// early). The same reconcile prunes that row afterwards ([`prune_orphans`]),
+/// so the id frees up for the next scan.
 fn assign_slug(base: &str, source: &Path, index: &Index, seen: &mut HashSet<String>) -> String {
     let mut n = 1;
     loop {
@@ -1657,10 +1750,11 @@ fn assign_slug(base: &str, source: &Path, index: &Index, seen: &mut HashSet<Stri
         } else {
             format!("{base}-{n}")
         };
-        // A candidate refused because someone else owns it is NOT consumed: the
-        // rightful owner is often discovered later in the same walk and must still
-        // be able to claim it. Consuming it here would push that book onto a fresh
-        // id — a new capability feed, and a stale row still serving the old one.
+        // A candidate refused because someone else owns it is NOT consumed.
+        // The walk often discovers the rightful owner later in the same scan,
+        // and that book must still be able to claim its slug. If this loop
+        // consumed the slug, it would push that book onto a fresh id: a new
+        // capability feed, plus a stale row that still serves the old one.
         if !seen.contains(&candidate) && !owns_a_different_source(index, &candidate, source) {
             seen.insert(candidate.clone());
             return candidate;
@@ -1669,27 +1763,31 @@ fn assign_slug(base: &str, source: &Path, index: &Index, seen: &mut HashSet<Stri
     }
 }
 
-/// Whether `slug` is an indexed book built from a *different* file than `source`.
+/// Whether `slug` is an indexed book built from a *different* file than
+/// `source`.
 ///
-/// Existence of that book's file is deliberately NOT consulted. An earlier version
-/// freed the id when the stored source was gone (to let a moved book reclaim it),
-/// but that reopened the exact theft this guard exists to stop: a newcomer sorting
-/// before a moved book's new location would inherit the vacated id — and its
-/// preserved capability feed — while the moved book was pushed onto a fresh feed
-/// (Greptile). There is no content identity to tell "the moved book" from "a
-/// different book of the same name" apart, so the safe rule is uniform: a live
-/// index row owns its id until [`prune_orphans`] retires it, one reconcile later.
-/// A book therefore keeps its feed across an in-place re-ingest (same path) but not
-/// across a move — the same feed-rotates-on-rename contract the flat scanner had.
+/// The guard deliberately does NOT consult the existence of that book's file.
+/// An earlier version freed the id when the stored source was gone (to let a
+/// moved book reclaim it). But that reopened the exact theft this guard
+/// exists to stop: a newcomer that sorts before a moved book's new location
+/// would inherit the vacated id, and its preserved capability feed, while the
+/// moved book was pushed onto a fresh feed (Greptile). No content identity
+/// can tell "the moved book" from "a different book of the same name". So the
+/// safe rule is uniform: a live index row owns its id until [`prune_orphans`]
+/// retires it, one reconcile later. A book therefore keeps its feed across an
+/// in-place re-ingest (same path) but not across a move. That is the same
+/// feed-rotates-on-rename contract the flat scanner had.
 ///
-/// Index errors count as "not owned": a failed lookup must not rename every book.
+/// Index errors count as "not owned": a failed lookup must not rename every
+/// book.
 fn owns_a_different_source(index: &Index, slug: &str, source: &Path) -> bool {
     let Ok(Some(existing)) = index.get_book(slug) else {
         return false;
     };
-    // Compare canonically where both resolve (the stored path is canonical, a
-    // discovered one need not be — `/tmp` is a symlink to `/private/var` on macOS);
-    // fall back to the raw strings when the stored file is gone.
+    // Compare canonically where both paths resolve. The stored path is
+    // canonical; a discovered one need not be (`/tmp` is a symlink to
+    // `/private/var` on macOS). Fall back to the raw strings when the stored
+    // file is gone.
     match (
         Path::new(&existing.source_path).canonicalize(),
         source.canonicalize(),
@@ -1699,7 +1797,6 @@ fn owns_a_different_source(index: &Index, slug: &str, source: &Path) -> bool {
     }
 }
 
-/// Whether a path has a recognized top-level audio extension.
 /// A path's extension, lowercased.
 fn ext_lower(p: &Path) -> Option<String> {
     p.extension()
@@ -1707,9 +1804,10 @@ fn ext_lower(p: &Path) -> Option<String> {
         .map(|e| e.to_ascii_lowercase())
 }
 
-/// Stream-copy output container extension for an audio codec. Each Tier-2 codec
-/// needs its own container (mp4 can't hold FLAC/Vorbis); unknown codecs default
-/// to `m4a` (the Tier-1 case). No re-encode — this only names the muxer.
+/// Stream-copy output container extension for an audio codec. Each Tier-2
+/// codec needs its own container (mp4 cannot hold FLAC/Vorbis). Unknown codecs
+/// default to `m4a` (the Tier-1 case). There is no re-encode; this only names
+/// the muxer.
 fn output_ext(codec: Option<&str>) -> &'static str {
     match codec {
         Some("mp3") => "mp3",
@@ -1720,18 +1818,18 @@ fn output_ext(codec: Option<&str>) -> &'static str {
     }
 }
 
-/// Whether a probed codec is one podcatchers can be relied on to play.
+/// Whether a probed codec is one that podcatchers play reliably.
 ///
-/// MP3 and AAC are the two every client handles. An unknown codec (`None` — a
-/// probe that named no audio codec) counts as safe: guessing wrong there would
-/// burn a whole re-encode on a file that probably plays fine.
+/// MP3 and AAC are the two that every client handles. An unknown codec
+/// (`None`: a probe that named no audio codec) counts as safe. A wrong guess
+/// there would burn a whole re-encode on a file that probably plays fine.
 fn is_podcast_safe(codec: Option<&str>) -> bool {
     matches!(codec, Some("mp3" | "aac") | None)
 }
 
-/// The [`Encoding`] this book's episodes are produced with (Task 5.2): a
-/// re-encode only when transcoding is on *and* the source codec isn't
-/// podcast-safe. Everything else is a stream copy.
+/// The [`Encoding`] that produces this book's episodes (Task 5.2): a re-encode
+/// only when transcoding is on *and* the source codec is not podcast-safe.
+/// Everything else is a stream copy.
 fn encoding_for(codec: Option<&str>, mode: TranscodeMode) -> Encoding {
     if is_podcast_safe(codec) {
         return Encoding::Copy;
@@ -1743,8 +1841,8 @@ fn encoding_for(codec: Option<&str>, mode: TranscodeMode) -> Encoding {
     }
 }
 
-/// The container extension for one produced episode: the transcode target's when
-/// re-encoding, else one matching the source codec (Task 3.9).
+/// The container extension for one produced episode: the transcode target's
+/// for a re-encode, else one that matches the source codec (Task 3.9).
 fn episode_ext(codec: Option<&str>, enc: Encoding) -> &'static str {
     match enc {
         Encoding::Copy => output_ext(codec),
@@ -1753,16 +1851,17 @@ fn episode_ext(codec: Option<&str>, enc: Encoding) -> &'static str {
     }
 }
 
-/// The `book.transcode` value an already-indexed book *should* carry under the
-/// current setting, judged from its file extension alone — the idempotency guard
-/// runs before the probe and must not force one.
+/// The `book.transcode` value that an already-indexed book *should* carry
+/// under the current setting, judged from its file extension alone. The
+/// idempotency guard runs before the probe and must not force one.
 ///
-/// `None` means "can't be known without probing, so accept whatever is stored":
-/// an `.m4a`/`.m4b` may hold AAC (podcast-safe, copied) or ALAC (re-encoded), and
-/// guessing either way would make the guard either miss a real toggle or re-ingest
-/// the book on every single scan. An ALAC book therefore keeps its existing
-/// episodes until its source changes; `force_reingest = true` in its
-/// `.podspine.toml` picks up the new setting immediately.
+/// `None` means "this cannot be known without a probe, so accept whatever is
+/// stored". An `.m4a`/`.m4b` may hold AAC (podcast-safe, copied) or ALAC
+/// (re-encoded). A guess either way would make the guard either miss a real
+/// toggle, or re-ingest the book on every single scan. An ALAC book therefore
+/// keeps its existing episodes until its source changes.
+/// `force_reingest = true` in its `.podspine.toml` picks up the new setting
+/// immediately.
 fn expected_transcode(input: &Path, mode: TranscodeMode) -> Option<TranscodeMode> {
     if !mode.is_on() {
         // Nothing may stay transcoded once the flag is off.
@@ -1771,7 +1870,7 @@ fn expected_transcode(input: &Path, mode: TranscodeMode) -> Option<TranscodeMode
     match ext_lower(input).as_deref() {
         // Tier-2 containers: never podcast-safe, so they get the target codec.
         Some("flac" | "ogg" | "oga" | "opus") => Some(mode),
-        // MP3 is podcast-safe and never re-encoded.
+        // MP3 is podcast-safe; the scan never re-encodes it.
         Some("mp3") => Some(TranscodeMode::Off),
         _ => None,
     }
@@ -1793,7 +1892,7 @@ fn is_audio(p: &Path) -> bool {
         .unwrap_or(false)
 }
 
-/// Whether a path has a DRM extension we refuse to ingest.
+/// Whether a path has a DRM extension that Podspine refuses to ingest.
 fn is_drm(p: &Path) -> bool {
     p.extension()
         .and_then(|e| e.to_str())
@@ -1808,8 +1907,8 @@ fn file_stem(p: &Path) -> String {
         .unwrap_or_else(|| "book".to_string())
 }
 
-/// Lowercase ASCII slug: alphanumerics kept, runs of anything else become a
-/// single `-`; falls back to `"book"`.
+/// Lowercase ASCII slug: keep alphanumerics; each run of anything else becomes
+/// a single `-`. The fallback is `"book"`.
 fn slugify(s: &str) -> String {
     let mut out = String::new();
     let mut prev_dash = false;
@@ -1852,16 +1951,17 @@ mod tests {
     };
     use std::process::Command;
 
-    /// Crate-prefixed [`podspine_test_support::scratch`], so scanner test dirs
-    /// can't collide with another crate's over a shared short name.
+    /// Crate-prefixed [`podspine_test_support::scratch`], so that scanner test
+    /// dirs cannot collide with another crate's over a shared short name.
     fn scratch(name: &str) -> ScratchDir {
         podspine_test_support::scratch(&format!("scan-{name}"))
     }
 
     #[test]
     fn an_mp3_folder_with_no_tracks_is_a_typed_error() {
-        // A folder of cover art and metadata with no audio is a user mistake, not
-        // a crash and not a silently empty book: it must surface as EmptyFolder.
+        // A folder of cover art and metadata with no audio is a user mistake.
+        // It must surface as `EmptyFolder`, not as a crash, and not as a
+        // silently empty book.
         let dir = scratch("empty-mp3-folder");
         std::fs::write(dir.join("cover.jpg"), b"img").unwrap();
         std::fs::write(dir.join("notes.txt"), b"no audio here").unwrap();
@@ -1881,7 +1981,8 @@ mod tests {
         assert!(matches!(err, ScanError::EmptyFolder(_)), "got {err:?}");
     }
 
-    /// Synthesize an AAC file; `chapters` true embeds three 10s chapters.
+    /// Synthesize an AAC file. When `chapters` is true, embed three 10-second
+    /// chapters.
     fn synth(dir: &Path, chapters: bool) -> PathBuf {
         if chapters {
             synth_three_chapters(dir, "chapters.m4a")
@@ -1895,8 +1996,8 @@ mod tests {
         std::fs::write(path, b"x").unwrap();
     }
 
-    /// Synthesize a real MP3 with an optional `track` tag. Returns `None` if the
-    /// ffmpeg build has no MP3 encoder (test then skips).
+    /// Synthesize a real MP3 with an optional `track` tag. Return `None` if
+    /// the ffmpeg build has no MP3 encoder (the test then skips).
     fn synth_mp3(dir: &Path, name: &str, track: Option<u32>, dur: u32) -> Option<PathBuf> {
         std::fs::create_dir_all(dir).unwrap();
         let out = dir.join(name);
@@ -1942,7 +2043,8 @@ mod tests {
         let eps = index.episodes_for_book(&books[0].id).unwrap();
         assert_eq!(eps.len(), 3, "one episode per MP3");
 
-        // Track order (1,2,3) => durations ~2,4,2. Filename order would be ~4,2,2.
+        // Track order (1,2,3) gives durations of ~2,4,2 seconds. Filename
+        // order would give ~4,2,2.
         assert!(
             (eps[1].duration_sec - 4.0).abs() < 0.6,
             "middle is track 2 (4s)"
@@ -1968,7 +2070,7 @@ mod tests {
             assert!(w[0].pubdate_epoch < w[1].pubdate_epoch, "pubDates increase");
         }
 
-        // No per-track copies were written under <data>/books/<id>/.
+        // The scan wrote no per-track copies under `<data>/books/<id>/`.
         let book_out = data.join("books").join(&books[0].id);
         for i in 1..=eps.len() {
             assert!(
@@ -1985,7 +2087,8 @@ mod tests {
         skip_unless_ffmpeg!();
         let root = scratch("mp3-fallback");
         let book = root.join("Mixed Book");
-        // One track tagged, one missing -> mixed -> filename sort (01 before 02).
+        // One track is tagged and one is not. The mixed set falls back to the
+        // filename sort (01 before 02).
         let a = synth_mp3(&book, "01-intro.mp3", None, 2);
         let b = synth_mp3(&book, "02-body.mp3", Some(5), 4);
         if a.is_none() || b.is_none() {
@@ -2011,8 +2114,8 @@ mod tests {
     #[test]
     fn cue_sidecar_overrides_embedded_chapters() {
         skip_unless_ffmpeg!();
-        // synth() embeds THREE 10s chapters. A sibling .cue defines only TWO
-        // chapters (0–5s, 5–30s), which must win.
+        // synth() embeds THREE 10-second chapters. A sibling .cue defines only
+        // TWO chapters (0–5s, 5–30s). The cue chapters must win.
         let dir = scratch("cue-sidecar");
         let input = synth(&dir, true); // chapters.m4a, 3 embedded chapters
         std::fs::write(
@@ -2030,7 +2133,8 @@ mod tests {
         assert_eq!(eps[0].title, "Front");
         assert_eq!(eps[1].title, "Back");
 
-        // force_embedded ignores the sidecar -> back to 3 embedded chapters.
+        // `force_embedded` ignores the sidecar; the scan is back to 3 embedded
+        // chapters.
         let data2 = dir.join("data2");
         let index2 = Index::open_in_memory().unwrap();
         let book2 = scan_book_as(
@@ -2079,16 +2183,19 @@ mod tests {
         let eps = index.episodes_for_book(&book.id).unwrap();
         assert_eq!(eps.len(), 3);
         for (i, e) in eps.iter().enumerate() {
-            // The real enclosure length is recorded even though the file is gone.
+            // The scan records the real enclosure length even though the file
+            // is gone.
             assert!(e.byte_length > 0, "byte_length recorded for chapter {i}");
-            // The chapter start offset is persisted so http can regenerate it.
+            // The scan persists the chapter start offset, so that http can
+            // regenerate the file.
             assert!(
                 (e.start_sec - (i as f64) * 10.0).abs() < 0.5,
                 "start_sec ~= {}s, got {}",
                 i * 10,
                 e.start_sec
             );
-            // saver mode deleted the split file (peak disk = one chapter).
+            // Saver mode deleted the split file (the peak extra disk usage is
+            // one chapter).
             assert!(
                 !Path::new(&e.file_path).exists(),
                 "saver deletes the split file: {}",
@@ -2096,8 +2203,9 @@ mod tests {
             );
         }
 
-        // Idempotent: re-scanning at the same mtime is a no-op despite the files
-        // being absent (the index entry alone satisfies the check in saver mode).
+        // Idempotency: a re-scan at the same mtime is a no-op even though the
+        // files are absent (the index entry alone satisfies the check in saver
+        // mode).
         let again = scan_book_as(
             &input,
             "saver-book",
@@ -2125,7 +2233,8 @@ mod tests {
         let data = dir.join("data");
         let index = Index::open_in_memory().unwrap();
 
-        // A normal full-mode ingest first: files on disk, real offsets recorded.
+        // Run a normal full-mode ingest first: files land on disk, and the
+        // scan records real offsets.
         let book = scan_book_as(
             &input,
             "mig",
@@ -2141,7 +2250,8 @@ mod tests {
             "full ingest records real chapter offsets"
         );
 
-        // Simulate a pre-5.1 -> 5.1 migration: back-fill start_sec = 0 everywhere.
+        // Simulate a pre-5.1 -> 5.1 migration: back-fill `start_sec` = 0
+        // everywhere.
         for e in &eps {
             let mut zeroed = e.clone();
             zeroed.start_sec = 0.0;
@@ -2177,8 +2287,8 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    /// Synthesize an audio file with a specific encoder. `None` if the ffmpeg
-    /// build lacks that encoder (test then skips).
+    /// Synthesize an audio file with a specific encoder. Return `None` if the
+    /// ffmpeg build lacks that encoder (the test then skips).
     fn synth_encoded(dir: &Path, name: &str, enc: &[&str], dur: u32) -> Option<PathBuf> {
         std::fs::create_dir_all(dir).unwrap();
         let out = dir.join(name);
@@ -2216,19 +2326,22 @@ mod tests {
     #[test]
     fn transcoding_only_touches_non_podcast_safe_codecs() {
         use TranscodeMode::{Aac, Mp3, Off};
-        // Off is the default: nothing is ever re-encoded.
+        // `Off` is the default: the scan never re-encodes anything.
         for codec in ["mp3", "aac", "flac", "vorbis", "opus", "alac"] {
             assert_eq!(encoding_for(Some(codec), Off), Encoding::Copy, "{codec}");
         }
-        // On: MP3/AAC sources are still stream-copied — they already play everywhere.
+        // On: the scan still stream-copies MP3/AAC sources; they already play
+        // everywhere.
         assert_eq!(encoding_for(Some("mp3"), Aac), Encoding::Copy);
         assert_eq!(encoding_for(Some("aac"), Aac), Encoding::Copy);
-        // On: the formats podcatchers choke on are re-encoded to the chosen target.
+        // On: the scan re-encodes the formats that podcatchers do not play to
+        // the chosen target.
         for codec in ["flac", "vorbis", "opus", "alac"] {
             assert_eq!(encoding_for(Some(codec), Aac), Encoding::Aac, "{codec}");
             assert_eq!(encoding_for(Some(codec), Mp3), Encoding::Mp3, "{codec}");
         }
-        // An unnamed codec is left alone rather than re-encoded on a guess.
+        // The scan leaves an unnamed codec alone; it does not re-encode on a
+        // guess.
         assert_eq!(encoding_for(None, Aac), Encoding::Copy);
     }
 
@@ -2249,7 +2362,7 @@ mod tests {
         let flac = Path::new("/lib/book.flac");
         let m4b = Path::new("/lib/book.m4b");
         let mp3 = Path::new("/lib/book.mp3");
-        // Flag off: nothing may stay transcoded, whatever the container.
+        // Flag off: nothing may stay transcoded, independent of the container.
         assert_eq!(
             expected_transcode(flac, TranscodeMode::Off),
             Some(TranscodeMode::Off)
@@ -2258,7 +2371,7 @@ mod tests {
             expected_transcode(m4b, TranscodeMode::Off),
             Some(TranscodeMode::Off)
         );
-        // Flag on: a Tier-2 container is definitely re-encoded...
+        // Flag on: the scan always re-encodes a Tier-2 container.
         assert_eq!(
             expected_transcode(flac, TranscodeMode::Aac),
             Some(TranscodeMode::Aac)
@@ -2267,19 +2380,20 @@ mod tests {
             expected_transcode(Path::new("/lib/b.opus"), TranscodeMode::Mp3),
             Some(TranscodeMode::Mp3)
         );
-        // ...MP3 definitely isn't...
+        // Flag on: the scan never re-encodes MP3.
         assert_eq!(
             expected_transcode(mp3, TranscodeMode::Aac),
             Some(TranscodeMode::Off)
         );
-        // ...and an mp4-family file is unknowable without a probe (AAC or ALAC), so
-        // the guard abstains rather than re-ingesting the book on every scan.
+        // Flag on: an mp4-family file is unknowable without a probe (AAC or
+        // ALAC). The guard abstains; it does not re-ingest the book on every
+        // scan.
         assert_eq!(expected_transcode(m4b, TranscodeMode::Aac), None);
     }
 
-    /// Acceptance: a FLAC source produces a playable AAC feed when transcoding is
-    /// on — right container, right codec, and an `enclosure length` that is the
-    /// real output size.
+    /// Acceptance: a FLAC source produces a playable AAC feed when transcoding
+    /// is on. That means the right container, the right codec, and an
+    /// `enclosure length` that is the real output size.
     #[test]
     fn flac_with_cue_transcodes_to_aac_when_enabled() {
         skip_unless_ffmpeg!();
@@ -2339,8 +2453,9 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    /// A chapterless non-podcast-safe file can't be served in place once it's
-    /// re-encoded: the bytes clients get only exist under `<data_dir>`.
+    /// The server cannot serve a chapterless non-podcast-safe file in place
+    /// once it is re-encoded: the bytes clients get exist only under
+    /// `<data_dir>`.
     #[test]
     fn chapterless_flac_transcodes_into_the_data_dir_instead_of_serving_in_place() {
         skip_unless_ffmpeg!();
@@ -2380,8 +2495,8 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    /// The MP3 fallback target, for clients that still choke on AAC. Skipped when
-    /// this ffmpeg has no `libmp3lame`.
+    /// The MP3 fallback target, for clients that still do not play AAC. The
+    /// test skips when this ffmpeg has no `libmp3lame`.
     #[test]
     fn flac_transcodes_to_mp3_when_that_target_is_chosen() {
         skip_unless_ffmpeg!();
@@ -2425,9 +2540,9 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    /// `saver` is deliberately overridden for a transcoded book: a re-encode is not
-    /// byte-reproducible, so its episodes must stay on disk (the serve layer refuses
-    /// to regenerate or evict them).
+    /// The scan deliberately overrides `saver` for a transcoded book. A
+    /// re-encode is not byte-reproducible, so its episodes must stay on disk
+    /// (the serve layer refuses to regenerate or evict them).
     #[test]
     fn a_transcoded_saver_book_keeps_its_episodes_on_disk() {
         skip_unless_ffmpeg!();
@@ -2473,10 +2588,10 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    /// Changing the target rewrites every episode into a new container. The files
-    /// in the old one are unreferenced from that moment, and nothing else reclaims
-    /// them — the cache eviction only touches regenerable books, and a transcoded
-    /// book is never regenerable — so the ingest must sweep them.
+    /// A target change rewrites every episode into a new container. The files
+    /// in the old one are unreferenced from that moment, and nothing else
+    /// reclaims them (the cache eviction only touches regenerable books, and a
+    /// transcoded book is never regenerable). So the ingest must sweep them.
     #[test]
     fn only_episode_files_and_their_temporaries_are_swept() {
         let dir = scratch("sweep-predicate");
@@ -2495,11 +2610,12 @@ mod tests {
         remove_episode_files_in_other_containers(&dir, "m4a");
 
         let left = |name: &str| dir.join(name).exists();
-        // The previous container's episodes and temporaries go.
+        // The sweep removes the previous container's episodes and temporaries.
         assert!(!left("001.flac"));
         assert!(!left("002.flac"));
         assert!(!left("003.part.flac"));
-        // The new container's files are left for the ingest to overwrite.
+        // The sweep leaves the new container's files for the ingest to
+        // overwrite.
         assert!(left("001.m4a"));
         // An extracted cover is not an episode file and must survive.
         assert!(left("cover.jpg"));
@@ -2555,7 +2671,8 @@ mod tests {
             );
         }
         let mp3 = scan(TranscodeMode::Mp3);
-        // No libmp3lame is a skip, not a failure: the sweep is what's under test.
+        // A missing libmp3lame is a skip, not a failure: the sweep is what is
+        // under test.
         if mp3.iter().all(|p| p.ends_with(".mp3")) {
             for old in &aac {
                 assert!(
@@ -2573,10 +2690,11 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    /// The sweep runs after the index is updated, never before. Until then the old
-    /// files are the ones being served — and this scan can sit inside a re-encode
-    /// for minutes. A failed re-ingest must therefore leave the previous episodes
-    /// playable rather than deleting them and then failing to replace them.
+    /// The sweep runs after the index update, never before. Until then the
+    /// server still serves the old files, and this scan can sit inside a
+    /// re-encode for minutes. A failed re-ingest must therefore leave the
+    /// previous episodes playable; it must not delete them and then fail to
+    /// replace them.
     #[test]
     fn a_failed_reingest_leaves_the_previous_episodes_in_place() {
         skip_unless_ffmpeg!();
@@ -2646,9 +2764,10 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    /// A book indexed before Task 5.2 carries `transcode = None`. It was necessarily
-    /// stream-copied, which is what `Off` means — so it must NOT be re-ingested
-    /// on upgrade, while a genuinely stale mode must be.
+    /// A book indexed before Task 5.2 carries `transcode = None`. Such a book
+    /// was necessarily stream-copied, and that is what `Off` means. So an
+    /// upgrade must NOT re-ingest it, while a genuinely stale mode must force
+    /// a re-ingest.
     #[test]
     fn a_pre_transcode_row_is_not_reingested_but_a_stale_mode_is() {
         skip_unless_ffmpeg!();
@@ -2656,8 +2775,9 @@ mod tests {
         let Some(flac) = synth_encoded(&dir, "book.flac", &["-c:a", "flac"], 12) else {
             skip!("no flac encoder");
         };
-        // Chaptered, so the episodes are extracted under the data dir — a
-        // chapterless book is served in place and `file_path` is the library file.
+        // The book is chaptered, so the episodes land under the data dir. (A
+        // chapterless book is served in place, and its `file_path` is the
+        // library file.)
         std::fs::write(
             flac.with_extension("cue"),
             "TRACK 01 AUDIO\n  TITLE \"One\"\n  INDEX 01 00:00:00\n\
@@ -2686,8 +2806,9 @@ mod tests {
                 })
                 .unwrap();
         };
-        // A sentinel in the episode file: an early return leaves it, a re-ingest
-        // overwrites it. (Nothing else in a `full`-mode scan rewrites the file.)
+        // A sentinel in the episode file: an early return leaves it, and a
+        // re-ingest overwrites it. (Nothing else in a `full`-mode scan
+        // rewrites the file.)
         let sentinel = |ep: &str| std::fs::write(ep, b"sentinel").unwrap();
         let survived = |ep: &str| std::fs::read(ep).unwrap() == b"sentinel";
 
@@ -2697,7 +2818,8 @@ mod tests {
             .file_path
             .clone();
 
-        // Pre-5.2 row: `None` means the same thing as `Off` — no re-split.
+        // Pre-5.2 row: `None` means the same thing as `Off`, so there is no
+        // re-split.
         stored_mode(None);
         sentinel(&ep);
         scan();
@@ -2706,7 +2828,8 @@ mod tests {
             "an upgraded database must not re-split every stream-copied book"
         );
 
-        // A row claiming a transcode while the flag is off is genuinely stale.
+        // A row that claims a transcode while the flag is off is genuinely
+        // stale.
         stored_mode(Some(TranscodeMode::Aac));
         sentinel(&ep);
         let back = scan();
@@ -2718,9 +2841,9 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    /// Flipping the flag changes the container and every byte length, and touches no
-    /// source mtime — so the idempotency guard must re-ingest instead of serving
-    /// stale rows. And an unchanged setting must NOT re-ingest.
+    /// A flag flip changes the container and every byte length, and touches no
+    /// source mtime. So the idempotency guard must re-ingest instead of
+    /// serving stale rows. And an unchanged setting must NOT re-ingest.
     #[test]
     fn toggling_transcode_reingests_a_flac_book() {
         skip_unless_ffmpeg!();
@@ -2740,7 +2863,7 @@ mod tests {
         let before = index.episodes_for_book(&off.id).unwrap();
         assert!(before[0].file_path.ends_with(".flac"));
 
-        // Flag on -> re-ingest, even though the source is untouched.
+        // Flag on: the scan re-ingests, even though the source is untouched.
         let on = scan(ScanOptions {
             transcode: TranscodeMode::Aac,
             ..Default::default()
@@ -2752,8 +2875,9 @@ mod tests {
             "expected a re-ingest, got {}",
             after[0].file_path
         );
-        // This book is chapterless, so with the flag off it was served in place:
-        // `before` pointed at the library file itself, which must never be touched.
+        // This book is chapterless, so with the flag off it was served in
+        // place: `before` pointed at the library file itself, and that file
+        // must never be touched.
         assert_eq!(before[0].file_path, before[0].source_path);
         assert!(Path::new(&before[0].source_path).exists());
         assert!(
@@ -2769,8 +2893,9 @@ mod tests {
             "guid is mtime-keyed, so clients don't re-download the whole feed"
         );
 
-        // And back off -> re-ingest to a stream copy again, in place, with the
-        // transcoded copy under the data dir reclaimed rather than orphaned.
+        // Flag back off: the scan re-ingests to a stream copy again, in place.
+        // It reclaims the transcoded copy under the data dir; the copy is not
+        // orphaned.
         let transcoded_copy = after[0].file_path.clone();
         let back = scan(ScanOptions::default());
         assert_eq!(back.transcode, Some(TranscodeMode::Off));
@@ -2791,7 +2916,8 @@ mod tests {
     fn flac_with_cue_splits_by_sidecar_no_reencode() {
         skip_unless_ffmpeg!();
         let dir = scratch("flac-cue");
-        // FLAC has no titled embedded chapters, so it leans on a .cue (PRD S7).
+        // FLAC has no titled embedded chapters, so it relies on a .cue
+        // (PRD S7).
         let Some(flac) = synth_encoded(&dir, "book.flac", &["-c:a", "flac"], 20) else {
             skip!("no flac encoder");
         };
@@ -2832,8 +2958,8 @@ mod tests {
         let eps = index.episodes_for_book(&book.id).unwrap();
         assert_eq!(eps.len(), 1, "no chapters/cue -> single episode");
         assert!(eps[0].file_path.ends_with(".flac"));
-        // Chapterless single file → served in place from the library (the stored
-        // path is canonical/absolute), not copied.
+        // A chapterless single file is served in place from the library (the
+        // stored path is canonical/absolute); it is not copied.
         let flac_c = flac.canonicalize().unwrap();
         assert_eq!(eps[0].source_path, flac_c.to_string_lossy());
         assert_eq!(eps[0].file_path, flac_c.to_string_lossy());
@@ -2861,8 +2987,8 @@ mod tests {
             "got {}",
             eps[0].file_path
         );
-        // Served in place from the library (the original `.opus`), not remuxed
-        // into a data-dir container.
+        // The server serves the original `.opus` in place from the library; it
+        // is not remuxed into a data-dir container.
         assert_eq!(
             eps[0].source_path,
             opus.canonicalize().unwrap().to_string_lossy()
@@ -2911,8 +3037,9 @@ mod tests {
 
     // ---- recursive library discovery ----
 
-    /// End to end on the layout Audiobookshelf produces: real files, real ffprobe,
-    /// real index rows — the case that returned `indexed=0` before this walk.
+    /// End to end on the layout Audiobookshelf produces: real files, real
+    /// ffprobe, real index rows. This is the case that returned `indexed=0`
+    /// before this walk existed.
     #[test]
     fn scan_library_indexes_an_author_title_tree() {
         skip_unless_ffmpeg!();
@@ -2995,8 +3122,8 @@ mod tests {
 
     #[test]
     fn discover_walks_author_title_libraries() {
-        // The layout Audiobookshelf, Plex and Jellyfin all produce, and the one a
-        // large library is least likely to rearrange.
+        // This is the layout that Audiobookshelf, Plex, and Jellyfin all
+        // produce, and the one a large library is least likely to rearrange.
         let root = scratch("discover-nested");
         touch(
             &root.join("Jules Verne/The Mysterious Island/Jules Verne - The Mysterious Island.m4b"),
@@ -3040,8 +3167,8 @@ mod tests {
         let name = |src: &BookSource| slugify(&src.base_name(&root));
         let found = discover(&root, &root.join("data"));
         let names: Vec<String> = found.iter().map(name).collect();
-        // Files and directories interleaved, path-sorted, capitals first — the
-        // order discovery has always produced (see
+        // Files and directories are interleaved, path-sorted, capitals first:
+        // the order discovery has always produced (see
         // `root_files_and_directories_keep_their_historical_order`).
         assert_eq!(
             names,
@@ -3049,10 +3176,10 @@ mod tests {
                 // Nested: named by the path, not by an unhelpful file stem.
                 "jules-verne-the-mysterious-island",
                 "mary-shelley-frankenstein",
-                // Unchanged: a root file keeps its stem...
+                // Unchanged: a root file keeps its stem.
                 "top-book",
-                // ...and a book directly below the root keeps its FILE stem, not
-                // its folder name. Changing this would re-key the book and rotate
+                // A book directly below the root keeps its FILE stem, not its
+                // folder name. A change here would re-key the book and rotate
                 // its capability feed id.
                 "inner-name",
                 // An MP3 folder directly below the root keeps its folder name.
@@ -3062,19 +3189,24 @@ mod tests {
         let _ = std::fs::remove_dir_all(&root);
     }
 
-    /// The order books are discovered in decides which of two same-named books
-    /// gets the bare slug and which gets `-2`. That slug is the book id, and a
-    /// book's capability feed id is preserved per id across re-scans — so a
-    /// reordering hands each subscriber the *other* audiobook under the URL they
-    /// already have. Root files and directories must stay interleaved by name.
-    /// A newly discovered file must not take the id of a book that already exists,
-    /// because `upsert_book` preserves the capability `feed_id` per id: the URL
-    /// would keep working and start serving a different audiobook. This is the
-    /// case a folder of several `.m4b` files opened up — its second file was never
-    /// discovered before, and its stem can collide with an existing book.
-    /// A database that already holds two rows for one source (an older build, a
-    /// manual edit) must heal to a single row — otherwise the book stays under two
-    /// capability feeds across every future reconcile, since both survive pruning.
+    /// Discovery order decides which of two same-named books gets the bare
+    /// slug and which gets `-2`. That slug is the book id, and a book's
+    /// capability feed id is preserved per id across re-scans. A reordering
+    /// would therefore hand each subscriber the *other* audiobook under the
+    /// URL they already have. Root files and directories must stay
+    /// interleaved by name.
+    ///
+    /// A newly discovered file must not take the id of a book that already
+    /// exists, because `upsert_book` preserves the capability `feed_id` per
+    /// id: the URL would keep working and start serving a different
+    /// audiobook. A folder of several `.m4b` files opened this case up: its
+    /// second file was never discovered before, and its stem can collide with
+    /// an existing book.
+    ///
+    /// A database that already holds two rows for one source (an older build,
+    /// a manual edit) must heal to a single row. Otherwise the book stays
+    /// under two capability feeds across every future reconcile, because both
+    /// rows survive pruning.
     #[test]
     fn duplicate_source_rows_collapse_to_one() {
         let root = scratch("collapse-dups");
@@ -3102,11 +3234,11 @@ mod tests {
             force_embedded: false,
             transcode: Some(TranscodeMode::Off),
         };
-        // The ESTABLISHED feed is the suffixed `book-2` (indexed first, so earlier
-        // created_at); the later duplicate is the base `book`. The survivor must be
-        // chosen by age, not by id — an id sort would delete the very feed
-        // subscribers use (Greptile). A few ms between inserts makes created_at
-        // distinct on any real clock.
+        // The ESTABLISHED feed is the suffixed `book-2` (indexed first, so it
+        // has the earlier `created_at`); the later duplicate is the base
+        // `book`. Age must choose the survivor, not the id: an id sort would
+        // delete the very feed subscribers use (Greptile). A few ms between
+        // inserts makes `created_at` distinct on any real clock.
         index.upsert_book(&row("book-2", "cap-book-2")).unwrap();
         std::thread::sleep(std::time::Duration::from_millis(5));
         index.upsert_book(&row("book", "cap-book")).unwrap();
@@ -3137,9 +3269,9 @@ mod tests {
         let _ = std::fs::remove_dir_all(&root);
     }
 
-    /// Two rows sharing a source whose file is GONE are prune_orphans' job, not
-    /// this one — and an unmounted library (every source missing) must collapse
-    /// nothing, so a mount blip can't wipe the index.
+    /// Two rows that share a source whose file is GONE are `prune_orphans`'
+    /// job, not this one. And an unmounted library (every source missing)
+    /// must collapse nothing, so that a mount blip cannot wipe the index.
     #[test]
     fn collapse_leaves_gone_sources_for_pruning() {
         let root = scratch("collapse-gone");
@@ -3173,11 +3305,11 @@ mod tests {
         let _ = std::fs::remove_dir_all(&root);
     }
 
-    /// The two-scan hazard: a newcomer suffixed because a stale row held its base
-    /// id must not, once that stale row is pruned, be re-indexed under the freed
-    /// base id on the next scan — that is one audiobook under two feeds. Reusing an
-    /// already-indexed source'"'"'s id closes it. Exercised through `reconcile`, which
-    /// is scan-then-prune, run twice.
+    /// The two-scan hazard: a stale row held the base id, so the newcomer got
+    /// a suffix. Once that stale row is pruned, the next scan must not
+    /// re-index the newcomer under the freed base id: that is one audiobook
+    /// under two feeds. Reuse of an already-indexed source's id closes the
+    /// hazard. The test exercises `reconcile` (scan-then-prune), run twice.
     #[test]
     fn a_source_keeps_one_id_across_consecutive_reconciles() {
         skip_unless_ffmpeg!();
@@ -3209,9 +3341,10 @@ mod tests {
         }
         let newcomer = root.join("Foo.m4b").canonicalize().unwrap();
 
-        // Reconcile #1: newcomer is suffixed to `foo-2`, stale `foo` is pruned.
+        // Reconcile 1 suffixes the newcomer to `foo-2` and prunes the stale
+        // `foo`.
         reconcile(&root, &data, &index, ScanOptions::default());
-        // Reconcile #2: `foo` is free now, but the newcomer must keep `foo-2`.
+        // Reconcile 2: `foo` is free now, but the newcomer must keep `foo-2`.
         reconcile(&root, &data, &index, ScanOptions::default());
 
         let books = index.list_books().unwrap();
@@ -3267,16 +3400,17 @@ mod tests {
             })
             .unwrap();
 
-        // The newcomer is refused the slug even though it is processed first.
+        // `assign_slug` refuses the newcomer even though it runs first.
         let mut seen = HashSet::new();
         assert_eq!(assign_slug("b", &newcomer, &index, &mut seen), "b-2");
         // And the book that owns it still gets it.
         assert_eq!(assign_slug("b", &established, &index, &mut seen), "b");
 
-        // Even when the owner's file is gone (a move), the live index row still
-        // holds the id — a newcomer must NOT inherit its capability feed. The row
-        // is retired by `prune_orphans` in the same reconcile, freeing the id for a
-        // LATER scan; within this one, the newcomer stays on `b-2`.
+        // Even when the owner's file is gone (a move), the live index row
+        // still holds the id: a newcomer must NOT inherit its capability feed.
+        // `prune_orphans` retires the row in the same reconcile, which frees
+        // the id for a LATER scan. Within this one, the newcomer stays on
+        // `b-2`.
         std::fs::remove_file(&established).unwrap();
         let mut seen = HashSet::new();
         assert_eq!(assign_slug("b", &newcomer, &index, &mut seen), "b-2");
@@ -3286,9 +3420,9 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn an_mp3_track_that_links_outside_the_library_is_dropped() {
-        // The folder is inside the library, but a track within it symlinks out.
-        // `source_is_inside` only vetted the folder, so the track has to be caught
-        // where the tracks are gathered, or it 404s at serve time.
+        // The folder is inside the library, but a track within it symlinks
+        // out. `source_is_inside` only vetted the folder, so the collection
+        // step must catch the track; otherwise it 404s at serve time.
         let outside = scratch("mp3-outside");
         std::fs::write(outside.join("external.mp3"), b"x").unwrap();
 
@@ -3312,8 +3446,8 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn a_broken_link_is_skipped_rather_than_indexed() {
-        // `canonicalize` fails on a dangling link, which must not be treated as
-        // "inside the library" — nor panic the scan.
+        // `canonicalize` fails on a dangling link. The scan must not treat
+        // that as "inside the library", and it must not panic.
         let root = scratch("discover-broken-link");
         touch(&root.join("Author/Real/real.m4b"));
         let dangling_dir = root.join("Author/Dangling");
@@ -3414,9 +3548,10 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn links_that_leave_the_library_are_not_indexed() {
-        // The serve layer canonicalizes an episode's source and refuses anything
-        // outside the library root, so indexing these would publish feeds whose
-        // audio 404s. Both a linked directory and a linked file must be refused.
+        // The serve layer canonicalizes an episode's source and refuses
+        // anything outside the library root, so an index of these would
+        // publish feeds whose audio 404s. The walk must refuse both a linked
+        // directory and a linked file.
         let outside = scratch("discover-outside");
         touch(&outside.join("Elsewhere/external.m4b"));
         touch(&outside.join("loose-external.m4b"));
@@ -3504,7 +3639,8 @@ mod tests {
             .iter()
             .map(|s| assign_slug(&slugify(&s.base_name(&root)), s.path(), &index, &mut seen))
             .collect();
-        // Not `dracula` and `dracula-2`, whose assignment would hinge on walk order.
+        // Not `dracula` and `dracula-2`; that assignment would hinge on walk
+        // order.
         assert_eq!(slugs, vec!["author-one-dracula", "author-two-dracula"]);
         let _ = std::fs::remove_dir_all(&root);
     }
@@ -3515,8 +3651,9 @@ mod tests {
         // audio files in numbered folders, so a naive walk would index podspine's
         // own output as books and re-split it.
         let root = scratch("discover-datadir");
-        // Deliberately NOT a dot-directory: those are skipped by name, which would
-        // let this test pass without the data-dir guard ever running.
+        // Deliberately NOT a dot-directory: those are skipped by name, and
+        // that skip would let this test pass without the data-dir guard ever
+        // running.
         let data = root.join("podspine-data");
         touch(&root.join("Author/Title/book.m4b"));
         touch(&data.join("books/author-title/001.m4a"));
@@ -3588,8 +3725,8 @@ mod tests {
         let root = scratch("discover-tier2");
         touch(&root.join("Author/A FLAC Book/book.flac"));
         touch(&root.join("Author/An Opus Book/book.opus"));
-        // Several Tier-2 files is NOT an MP3-folder equivalent: that path reads
-        // only `.mp3`, so half-ingesting these would be worse than skipping them.
+        // Several Tier-2 files are NOT an MP3-folder equivalent: that path
+        // reads only `.mp3`. A half-ingest would be worse than a skip.
         touch(&root.join("Author/Multi FLAC/01.flac"));
         touch(&root.join("Author/Multi FLAC/02.flac"));
 
@@ -3648,8 +3785,8 @@ mod tests {
     fn library_scan_disambiguates_same_named_books() {
         skip_unless_ffmpeg!();
         // Two books that slugify identically, in separate folders. The folder
-        // names must differ by more than case so they stay distinct on
-        // case-insensitive filesystems (Windows/macOS) — `Dracula` and
+        // names must differ by more than case, so that they stay distinct on
+        // case-insensitive filesystems (Windows/macOS). `Dracula` and
         // `Dracula!` both slugify to "dracula" but are two real directories.
         let root = scratch("dup-lib");
         let b1 = synth(
@@ -3746,7 +3883,8 @@ mod tests {
 
         let eps = index.episodes_for_book(&book.id).unwrap();
         assert_eq!(eps.len(), 3, "3 chapters -> 3 episodes");
-        // idx order, positive sizes, files on disk, strictly increasing pubDates.
+        // Check: idx order, positive sizes, files on disk, strictly increasing
+        // pubDates.
         for (i, e) in eps.iter().enumerate() {
             assert_eq!(e.idx, i as i64);
             assert!(e.byte_length > 0);
@@ -3773,7 +3911,8 @@ mod tests {
     fn non_faststart_single_file_is_flagged_and_optionally_remuxed() {
         skip_unless_ffmpeg!();
         let dir = scratch("faststart");
-        // ffmpeg's mp4 muxer writes `moov` at the END by default → non-faststart.
+        // ffmpeg's mp4 muxer writes `moov` at the END by default, so the file
+        // is non-faststart.
         let input = synth(&dir, false);
         assert!(
             needs_faststart(&input),
@@ -3781,7 +3920,8 @@ mod tests {
         );
         let input_c = input.canonicalize().unwrap();
 
-        // remux OFF (default): flagged, but still streamed in place.
+        // remux OFF (default): the episode is flagged, but still streamed in
+        // place.
         {
             let data = dir.join("data-off");
             let index = Index::open_in_memory().unwrap();
@@ -3806,8 +3946,9 @@ mod tests {
             );
         }
 
-        // remux ON: remuxed to a faststart cache file under the data dir; measured
-        // then deleted at ingest (regenerated on demand, like a saver chapter).
+        // remux ON: the scan remuxes to a faststart cache file under the data
+        // dir. It measures the file, then deletes it at ingest (the http layer
+        // regenerates it on demand, like a saver chapter).
         {
             let data = dir.join("data-on");
             let index = Index::open_in_memory().unwrap();
@@ -3906,7 +4047,7 @@ mod tests {
         let data = dir.join("data");
         let index = Index::open_in_memory().unwrap();
 
-        // remux OFF → in place.
+        // remux OFF: served in place.
         scan_book_as(
             &input,
             "t",
@@ -3939,7 +4080,7 @@ mod tests {
             "remux on → served from the cache copy"
         );
 
-        // Flip back OFF: re-ingest again, back to in place.
+        // Flip back OFF: the scan re-ingests again, back to in place.
         scan_book_as(
             &input,
             "t",
@@ -3997,13 +4138,13 @@ mod tests {
         let data = root.join("data");
         let index = Index::open_in_memory().unwrap();
 
-        // First scan: no sidecar → default title, `full`.
+        // First scan: no sidecar, so the default title and `full` apply.
         scan_library(&root, &data, &index, ScanOptions::default());
         let before = index.list_books().unwrap().remove(0);
         assert_eq!(before.storage_mode, Some(StorageMode::Full));
         let guid_before = index.episodes_for_book(&before.id).unwrap()[0].guid.clone();
 
-        // Edit the sidecar — the AUDIO file is untouched (same mtime). The edit
+        // Edit the sidecar; the AUDIO file is untouched (same mtime). The edit
         // must still take effect on the next scan (Greptile 6.4 P1).
         let side = input
             .canonicalize()
@@ -4019,8 +4160,8 @@ mod tests {
             Some(StorageMode::Saver),
             "sidecar storage_mode applied"
         );
-        // source_mtime is unchanged, so the episode guid is stable — a metadata
-        // edit doesn't make podcast clients re-download.
+        // `source_mtime` is unchanged, so the episode guid is stable: a
+        // metadata edit does not make podcast clients re-download.
         let guid_after = index.episodes_for_book(&before.id).unwrap()[0].guid.clone();
         assert_eq!(
             guid_before, guid_after,
@@ -4059,12 +4200,12 @@ mod tests {
         let _ = std::fs::remove_dir_all(&root);
     }
 
-    /// A database failure mid-reconcile is survived and logged, never a panic —
-    /// fault-inject by dropping the `book` table out from under a live [`Index`]
-    /// via a second connection. One reconcile then exercises every
-    /// skipped-with-a-warn arm: the duplicate-row collapse, the id-reuse map, the
-    /// disabled-book prune (the disabled path never probes, so no ffmpeg is
-    /// needed), the orphan prune, and the metrics book count.
+    /// The scan survives and logs a database failure mid-reconcile; it never
+    /// panics. The fault injection drops the `book` table out from under a
+    /// live [`Index`] via a second connection. One reconcile then exercises
+    /// every skipped-with-a-warn arm: the duplicate-row collapse, the id-reuse
+    /// map, the disabled-book prune (the disabled path never probes, so no
+    /// ffmpeg is needed), the orphan prune, and the metrics book count.
     #[test]
     fn scan_survives_a_broken_index() {
         let root = scratch("scan-broken-index");
@@ -4088,8 +4229,9 @@ mod tests {
     }
 
     /// The duplicate-row collapse must survive a DELETE that fails while reads
-    /// still work — fault-inject with a second connection holding a write lock
-    /// (WAL keeps reads serving; the delete gets SQLITE_BUSY immediately).
+    /// still work. The fault injection holds a write lock on a second
+    /// connection (WAL keeps reads serving; the delete gets `SQLITE_BUSY`
+    /// immediately).
     #[test]
     fn collapse_survives_a_failing_delete() {
         let root = scratch("collapse-delete-fail");
@@ -4129,8 +4271,8 @@ mod tests {
         );
     }
 
-    /// Symlinks that leave the library root, and dangling symlinks, are skipped
-    /// with a warning — never followed, never fatal.
+    /// The walk skips, with a warning, symlinks that leave the library root
+    /// and dangling symlinks. It never follows them, and they are never fatal.
     #[cfg(unix)]
     #[test]
     fn walk_skips_escaping_and_dangling_symlinks() {
@@ -4148,8 +4290,9 @@ mod tests {
         assert!(index.list_books().unwrap().is_empty());
     }
 
-    /// A DB that can't open must still fire the ready callback — otherwise the
-    /// server wedges on the "Scanning…" page forever (issue 159's failure mode).
+    /// A DB that cannot open must still fire the ready callback. Otherwise the
+    /// server hangs on the "Scanning…" page forever (issue 159's failure
+    /// mode).
     #[test]
     fn watch_loop_fires_ready_even_when_the_db_cannot_open() {
         let root = scratch("watch-bad-db");
@@ -4196,7 +4339,8 @@ mod tests {
         scan_library(&root, &data, &index, ScanOptions::default());
         assert_eq!(index.list_books().unwrap().len(), 1, "indexed first");
 
-        // A disabling sidecar removes it from the index on the next scan.
+        // A disabling sidecar removes the book from the index on the next
+        // scan.
         let side = input
             .canonicalize()
             .unwrap()
@@ -4251,8 +4395,8 @@ mod tests {
     #[test]
     fn sidecar_global_key_is_ignored_and_a_typo_is_non_fatal() {
         skip_unless_ffmpeg!();
-        // A server-global key in a sidecar is ignored (warned); the per-book key
-        // still applies.
+        // The scan ignores a server-global key in a sidecar and warns; the
+        // per-book key still applies.
         let root = scratch("perbook-global");
         let input = synth(&root, false);
         let side = input
@@ -4269,7 +4413,8 @@ mod tests {
         assert_eq!(index.list_books().unwrap().remove(0).title, "Kept");
         let _ = std::fs::remove_dir_all(&root);
 
-        // A typo (unknown key) is a per-book warning, not fatal — still indexes.
+        // A typo (an unknown key, here a stray plural) is a per-book warning,
+        // not fatal. The scan still indexes the book.
         let root2 = scratch("perbook-typo");
         let input2 = synth(&root2, false);
         std::fs::write(
@@ -4277,7 +4422,7 @@ mod tests {
                 .canonicalize()
                 .unwrap()
                 .with_extension("podspine.toml"),
-            b"stroage_mode = \"saver\"",
+            b"storage_modes = \"saver\"",
         )
         .unwrap();
         let data2 = root2.join("data");
@@ -4299,8 +4444,9 @@ mod tests {
         let root = scratch("mp3-unprobeable");
         let book = root.join("Broken");
         std::fs::create_dir_all(&book).unwrap();
-        // Several `.mp3` files that aren't real audio → a folder book whose tracks
-        // all fail to probe → EmptyFolder → skipped, not fatal.
+        // Several `.mp3` files that are not real audio give a folder book
+        // whose tracks all fail to probe. That is `EmptyFolder`: skipped, not
+        // fatal.
         std::fs::write(book.join("01.mp3"), b"not audio at all").unwrap();
         std::fs::write(book.join("02.mp3"), b"also not audio").unwrap();
         let data = root.join("data");
@@ -4315,7 +4461,8 @@ mod tests {
     fn library_watcher_indexes_a_book_added_after_startup() {
         skip_unless_ffmpeg!();
         // `keep()`: the watcher below must outlive this test body (see the
-        // teardown note at the bottom), so the drop-cleanup guard is defused.
+        // teardown note at the bottom), so the test defuses the drop-cleanup
+        // guard.
         let root = scratch("watcher-lib").keep();
         let data = scratch("watcher-data").keep();
         let db_path = data.join("podspine.db");
@@ -4329,13 +4476,15 @@ mod tests {
             ScanOptions::default(),
             || {},
         );
-        // Let the watcher establish its filesystem watch before we add a file.
+        // Let the watcher establish its filesystem watch before the test adds
+        // a file.
         std::thread::sleep(std::time::Duration::from_millis(300));
 
-        // Add a book — the watcher should notice, reconcile, and index it.
+        // Add a book. The watcher should notice it, reconcile, and index it.
         let _input = synth(&root, false);
 
-        // Poll (debounce + reconcile + ffmpeg split take a moment); generous cap.
+        // Poll: debounce, reconcile, and the ffmpeg split take a moment. The
+        // cap is generous.
         let mut indexed = false;
         for _ in 0..100 {
             std::thread::sleep(std::time::Duration::from_millis(100));
@@ -4348,27 +4497,29 @@ mod tests {
         }
         assert!(indexed, "the watcher indexed the book added after startup");
 
-        // Deliberately do NOT tear down `root`/`data` here. `spawn_library_watcher`
-        // is a detached, process-lifetime daemon with no shutdown hook (by design),
-        // so deleting its watched dir + WAL db out from under the live thread would
-        // make it churn on removed paths and could race later tests. `scratch()`
-        // already wipes these unique paths at the START of the next run, so nothing
-        // leaks across runs; the parked thread sees no further events and dies with
-        // the process.
+        // Deliberately do NOT tear down `root`/`data` here.
+        // `spawn_library_watcher` is a detached, process-lifetime daemon with
+        // no shutdown hook (by design). A delete of its watched dir and WAL db
+        // out from under the live thread would make it churn on removed paths,
+        // and it could race later tests. `scratch()` already wipes these
+        // unique paths at the START of the next run, so nothing leaks across
+        // runs. The parked thread sees no further events and dies with the
+        // process.
     }
 
     #[test]
     fn watch_filter_ignores_output_and_junk_keeps_real_changes() {
         let lib = Path::new("/lib");
         let data = Path::new("/lib/.podspine"); // a nested --data-dir
-        // Our own split output under the data dir — ignored (else it self-triggers).
+        // Our own split output under the data dir is ignored (otherwise it
+        // self-triggers).
         assert!(!watch_path_is_relevant(
             Path::new("/lib/.podspine/BookX/001.m4a"),
             lib,
             data,
             None
         ));
-        // NAS junk / thumbnail caches — ignored anywhere below the root.
+        // NAS junk and thumbnail caches are ignored anywhere below the root.
         assert!(!watch_path_is_relevant(
             Path::new("/lib/Author/@eaDir/thumb.jpg"),
             lib,
@@ -4387,7 +4538,7 @@ mod tests {
             data,
             None
         ));
-        // A real book file — relevant.
+        // A real book file is relevant.
         assert!(watch_path_is_relevant(
             Path::new("/lib/Author/Title/book.m4b"),
             lib,
@@ -4411,14 +4562,14 @@ mod tests {
         let lib = Path::new("/lib");
         let data = Path::new("/data");
         let paths = || vec![PathBuf::from("/lib/Author/Title/book.m4b")];
-        // A read (another app streaming) — dropped.
+        // A read (another app streams the file) is dropped.
         let read = notify::Event {
             kind: EventKind::Access(AccessKind::Any),
             paths: paths(),
             attrs: Default::default(),
         };
         assert!(!watch_event_is_relevant(&read, lib, data, None));
-        // A write to a real book file — relevant.
+        // A write to a real book file is relevant.
         let write = notify::Event {
             kind: EventKind::Modify(ModifyKind::Any),
             paths: paths(),
@@ -4506,10 +4657,10 @@ mod tests {
         assert!(cover.exists(), "cover on disk");
         let book_out = cover.parent().unwrap().to_path_buf();
 
-        // Block the atomic publish of any *replacement* cover: a directory sitting at
-        // the `.part` target makes ffmpeg's write fail, so `extract_cover` errors while
-        // the previously-published `cover.jpg` stays intact on disk — the exact case
-        // the fallback below must survive.
+        // Block the atomic publish of any *replacement* cover: a directory at
+        // the `.part` target makes ffmpeg's write fail. `extract_cover` then
+        // errors while the previously published `cover.jpg` stays intact on
+        // disk. That is the exact case the fallback below must survive.
         std::fs::create_dir_all(book_out.join("cover.part.jpg")).unwrap();
 
         // Force a re-ingest (a distinct source mtime, not the idempotent early return).
@@ -4522,8 +4673,9 @@ mod tests {
             )
             .unwrap();
 
-        // The re-ingest keeps the still-present cover instead of orphaning it to None —
-        // otherwise both cover routes 404 and the thumbnail backfill can't recover it.
+        // The re-ingest keeps the still-present cover; it does not orphan it
+        // to `None`. Otherwise both cover routes 404, and the thumbnail
+        // backfill cannot recover it.
         let reingested = scan().unwrap();
         assert_eq!(
             reingested.cover_path.as_deref(),
@@ -4537,10 +4689,11 @@ mod tests {
 
     #[test]
     fn watch_filter_ignores_output_under_the_canonical_data_dir() {
-        // The configured data dir can be spelled differently from where it resolves
-        // (a symlinked mount), so the filter also checks the canonical path. A write
-        // under the CANONICAL data dir is still our own split output and must be
-        // ignored even when it doesn't match the raw spelling.
+        // The configured data dir can be spelled differently from where it
+        // resolves (a symlinked mount), so the filter also checks the
+        // canonical path. A write under the CANONICAL data dir is still our
+        // own split output, and the filter must ignore it even when it does
+        // not match the raw spelling.
         let lib = Path::new("/lib");
         let raw = Path::new("/lib/.podspine"); // as configured
         let canon = Path::new("/mnt/real/podspine"); // where it resolves to
@@ -4606,8 +4759,9 @@ mod tests {
         let first = index.episodes_for_book(&id).unwrap();
         assert!(first.iter().all(|e| !e.source_path.is_empty()));
 
-        // Re-scan the unchanged folder: the `source_path` idempotency guard takes
-        // the early return — episodes are unchanged and still served in place.
+        // Re-scan the unchanged folder: the `source_path` idempotency guard
+        // takes the early return. Episodes are unchanged and still served in
+        // place.
         scan_library(&root, &data, &index, ScanOptions::default());
         let second = index.episodes_for_book(&id).unwrap();
         assert_eq!(first.len(), second.len());
@@ -4644,9 +4798,10 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    // Two distinctly-named top-level books in `root`; `data` is kept OUTSIDE the
-    // library so emptying `root` genuinely empties it (for the guard test). `tag`
-    // keeps each test's scratch dirs distinct so parallel runs don't collide.
+    // Two distinctly named top-level books in `root`. `data` is kept OUTSIDE
+    // the library, so that an emptied `root` is genuinely empty (for the guard
+    // test). `tag` keeps each test's scratch dirs distinct, so parallel runs
+    // do not collide.
     fn two_book_library(tag: &str) -> (ScratchDir, ScratchDir, Index) {
         let root = scratch(&format!("{tag}-lib"));
         let data = scratch(&format!("{tag}-data"));
@@ -4661,8 +4816,9 @@ mod tests {
     #[test]
     fn prune_orphans_removes_a_deleted_source_and_its_split_output() {
         skip_unless_ffmpeg!();
-        // Chaptered books (not whole-file) so each materializes a per-chapter
-        // split dir under <data> — that's the "split output" prune must remove.
+        // Chaptered books (not whole-file), so each materializes a per-chapter
+        // split dir under `<data>`. That dir is the "split output" the prune
+        // must remove.
         let root = scratch("prune-removes-lib");
         let data = scratch("prune-removes-data");
         let a = synth(&root, true);
@@ -4723,7 +4879,7 @@ mod tests {
         assert_eq!(index.list_books().unwrap().len(), 2);
         assert_eq!(s.pruned, 0);
 
-        // Remove one source, reconcile again -> it is pruned.
+        // Remove one source and reconcile again: the book is pruned.
         std::fs::remove_file(root.join("beta.m4a")).unwrap();
         let s = reconcile(&root, &data, &index, ScanOptions::default());
         assert_eq!(s.pruned, 1);

--- a/crates/splitter/Cargo.toml
+++ b/crates/splitter/Cargo.toml
@@ -18,3 +18,6 @@ wait-timeout = { workspace = true }
 # Integration tests probe the real fixture to get chapters and verify output durations.
 podspine-prober = { path = "../prober" }
 podspine-test-support = { path = "../test-support" }
+
+[lints]
+workspace = true

--- a/crates/splitter/src/lib.rs
+++ b/crates/splitter/src/lib.rs
@@ -1,8 +1,9 @@
-//! `splitter` — `ffmpeg` wrapper that cuts one audiobook file into per-chapter
-//! episode files by **stream copy** (no re-encode), or — opt-in, for sources no
-//! podcatcher can play — by **re-encoding** to AAC/MP3 (Task 5.2).
+//! `splitter` — `ffmpeg` wrapper that cuts one audiobook file into
+//! per-chapter episode files by **stream copy** (no re-encode). Opt-in, for
+//! sources that no podcatcher can play, it cuts by a **re-encode** to AAC/MP3
+//! (Task 5.2).
 //!
-//! Per chapter it runs, as an **argv vector** (never a shell string — chapter
+//! Per chapter it runs, as an **argv vector** (never a shell string: chapter
 //! metadata is untrusted):
 //!
 //! ```text
@@ -12,21 +13,23 @@
 //! ```
 //!
 //! ## Invariants (the reason this crate exists)
-//! - `-ss` goes **before** `-i` (fast index seek) and duration is `-t <end-start>`.
-//!   Using `-to` after `-i` together with `-ss` before `-i` does **not** subtract
-//!   the offset and yields a ~2× file — so we never emit `-to`. `build_encode_args`
-//!   encodes this and is unit-tested without invoking ffmpeg.
-//! - `byte_length` is read from the **actual output file** (`fs::metadata().len()`),
-//!   never prorated from a bitrate.
+//! - `-ss` goes **before** `-i` (fast index seek), and the duration is
+//!   `-t <end-start>`. `-to` after `-i`, together with `-ss` before `-i`,
+//!   does **not** subtract the offset and yields a ~2× file. So the splitter
+//!   never emits `-to`. `build_encode_args` encodes this rule, and a unit
+//!   test checks it without an ffmpeg invocation.
+//! - `byte_length` comes from the **actual output file**
+//!   (`fs::metadata().len()`); it is never prorated from a bitrate.
 //! - The source file is only ever read; every output lands in `out_dir`.
 //!
 //! ## Hardening (Task 3.5)
-//! Every ffmpeg spawn goes through [`run_ffmpeg`], which (a) acquires a permit
-//! from a process-wide counting semaphore sized to the CPU count, so concurrent
-//! ffmpeg jobs are bounded, and (b) enforces a per-child wall-clock timeout,
-//! killing a hung child. The splitter is **synchronous** (`std::process`), so
-//! this uses a `std`-built semaphore + the `wait-timeout` crate rather than the
-//! `tokio` primitives the TAD sketched — same guarantees, no async ripple.
+//! Every ffmpeg spawn goes through [`run_ffmpeg`], which does two things:
+//! (a) it acquires a permit from a process-wide counting semaphore sized to
+//! the CPU count, so the number of concurrent ffmpeg jobs is bounded; and
+//! (b) it enforces a per-child wall-clock timeout and kills a hung child. The
+//! splitter is **synchronous** (`std::process`), so this uses a `std`-built
+//! semaphore plus the `wait-timeout` crate, not the `tokio` primitives the
+//! TAD sketched. The guarantees are the same, with no async ripple.
 
 use std::ffi::OsString;
 use std::fs;
@@ -39,37 +42,39 @@ use std::time::Duration;
 
 use wait_timeout::ChildExt;
 
-/// Per-child ffmpeg wall-clock timeout. A stream-copy of one chapter is seconds;
-/// splitting a whole 10h book is ≤2min (NFR-P1), so any single child running
-/// past this is hung, not slow.
+/// Per-child ffmpeg wall-clock timeout. A stream copy of one chapter takes
+/// seconds, and a split of a whole 10h book takes ≤2min (NFR-P1). So any
+/// single child that runs past this limit is hung, not slow.
 const FFMPEG_TIMEOUT: Duration = Duration::from_secs(300);
 
-/// Per-child ffmpeg wall-clock timeout for a **re-encode** ([`Encoding::Aac`] /
-/// [`Encoding::Mp3`], Task 5.2). A re-encode is bounded by CPU, not by the index:
-/// a whole chapterless 10h FLAC is a single child that runs for tens of minutes
-/// on a Raspberry Pi, so [`FFMPEG_TIMEOUT`] would kill honest work. Still a hard
-/// bound — a child past this is hung, not slow.
+/// Per-child ffmpeg wall-clock timeout for a **re-encode** ([`Encoding::Aac`]
+/// / [`Encoding::Mp3`], Task 5.2). CPU bounds a re-encode, not the index: a
+/// whole chapterless 10h FLAC is a single child that runs for tens of minutes
+/// on a Raspberry Pi, so [`FFMPEG_TIMEOUT`] would kill honest work. This is
+/// still a hard bound: a child past it is hung, not slow.
 const TRANSCODE_TIMEOUT: Duration = Duration::from_secs(7200);
 
 /// How an episode's audio is produced from the source.
 ///
 /// [`Encoding::Copy`] is the default and the only mode used for podcast-safe
-/// sources (MP3/AAC): the bytes are copied out of the container untouched. The
-/// re-encode modes exist for Tier-2 sources (FLAC/Vorbis/Opus/ALAC) that most
-/// podcatchers refuse to play, and are opt-in per server (`PODSPINE_TRANSCODE`).
+/// sources (MP3/AAC): the bytes are copied out of the container untouched.
+/// The re-encode modes exist for Tier-2 sources (FLAC/Vorbis/Opus/ALAC) that
+/// most podcatchers refuse to play; they are opt-in per server
+/// (`PODSPINE_TRANSCODE`).
 ///
-/// A re-encode is **not** byte-reproducible across ffmpeg builds, so a transcoded
-/// book is always materialized once at ingest and never regenerated on demand —
-/// that is what keeps `enclosure length` equal to the file actually served.
+/// A re-encode is **not** byte-reproducible across ffmpeg builds. So a
+/// transcoded book is always materialized once at ingest and never
+/// regenerated on demand. That rule keeps `enclosure length` equal to the
+/// file actually served.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Encoding {
-    /// Stream copy (`-c copy`) — no re-encode, the default everywhere.
+    /// Stream copy (`-c copy`): no re-encode, the default everywhere.
     #[default]
     Copy,
     /// Re-encode to AAC 128 kbps (ffmpeg's built-in `aac` encoder, `.m4a`).
     Aac,
-    /// Re-encode to MP3 128 kbps (`libmp3lame`, `.mp3`) — the fallback target for
-    /// clients that still choke on AAC.
+    /// Re-encode to MP3 128 kbps (`libmp3lame`, `.mp3`): the fallback target
+    /// for clients that still do not play AAC.
     Mp3,
 }
 
@@ -105,7 +110,8 @@ impl Encoding {
 /// A chapter to cut: its position and its `[start, end)` in seconds.
 ///
 /// Deliberately independent of where the chapters came from (embedded ffprobe
-/// markers, a `.cue` sidecar, …) so the splitter doesn't depend on the prober.
+/// markers, a `.cue` sidecar, …), so that the splitter does not depend on the
+/// prober.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ChapterCut {
     /// Zero-based chapter position (episode N in the feed is `idx + 1`).
@@ -123,7 +129,8 @@ pub struct SplitEpisode {
     pub idx: usize,
     /// Path to the written episode file (container matches `out_ext`).
     pub path: PathBuf,
-    /// Real output size in bytes (`fs::metadata().len()`) — for `enclosure length`.
+    /// Real output size in bytes (`fs::metadata().len()`), used for
+    /// `enclosure length`.
     pub byte_length: u64,
     /// Requested chapter duration in seconds (`end - start`).
     pub duration_sec: f64,
@@ -142,7 +149,7 @@ pub enum SplitError {
         idx: usize,
     },
     /// `ffmpeg` ran but exited non-zero. `stderr` is captured for logs (never
-    /// surface it to HTTP clients — that leak is the http layer's guard).
+    /// surface it to HTTP clients; the http layer guards that leak).
     #[error("ffmpeg failed on chapter {idx} (exit {code:?}): {stderr}")]
     Ffmpeg {
         /// Zero-based chapter position.
@@ -197,8 +204,9 @@ pub enum SplitError {
     },
 }
 
-/// Failure modes of a cover extraction. A book with no cover is *not* an error —
-/// the caller checks `has_cover` first; these only cover a genuine ffmpeg failure.
+/// Failure modes of a cover extraction. A book with no cover is *not* an
+/// error (the caller checks `has_cover` first); these only cover a genuine
+/// ffmpeg failure.
 #[derive(Debug, thiserror::Error)]
 pub enum CoverError {
     /// `ffmpeg` could not be launched.
@@ -269,9 +277,10 @@ impl Drop for Permit<'_> {
     }
 }
 
-/// How many ffmpeg jobs may run at once: the CPU count (fallback 4 when the OS
-/// won't say). The single source of truth for both the process-wide [`ffmpeg_gate`]
-/// and the per-book split worker pool ([`split_book_encoded`]), so they agree.
+/// How many ffmpeg jobs may run at once: the CPU count (fallback 4 when the
+/// OS will not say). This is the single source of truth for both the
+/// process-wide [`ffmpeg_gate`] and the per-book split worker pool
+/// ([`split_book_encoded`]), so they agree.
 fn ffmpeg_parallelism() -> usize {
     std::thread::available_parallelism()
         .map(|n| n.get())
@@ -304,12 +313,13 @@ enum RunError {
 
 /// Run one ffmpeg invocation under the concurrency gate with a per-child
 /// timeout+kill. stdout is discarded; stderr is captured (small under
-/// `-loglevel error`) so a failure can be logged without leaking it to clients.
+/// `-loglevel error`), so that a failure can be logged without a leak to
+/// clients.
 fn run_ffmpeg(args: &[OsString]) -> Result<(), RunError> {
     run_ffmpeg_within(args, FFMPEG_TIMEOUT)
 }
 
-/// As [`run_ffmpeg`], with an explicit per-child timeout — a re-encode needs a
+/// As [`run_ffmpeg`], with an explicit per-child timeout: a re-encode needs a
 /// far longer bound than a stream copy ([`Encoding::timeout`]).
 fn run_ffmpeg_within(args: &[OsString], timeout: Duration) -> Result<(), RunError> {
     let _permit = ffmpeg_gate().acquire();
@@ -322,8 +332,9 @@ fn run_ffmpeg_within(args: &[OsString], timeout: Duration) -> Result<(), RunErro
         .spawn()
         .map_err(RunError::Spawn)?;
 
-    // Drain stderr on a side thread so a chatty child can't fill the pipe buffer
-    // and stall before exit (which would masquerade as a timeout).
+    // Drain stderr on a side thread, so that a chatty child cannot fill the
+    // pipe buffer and stall before exit (that stall would masquerade as a
+    // timeout).
     let stderr_drain = child.stderr.take().map(|mut pipe| {
         std::thread::spawn(move || {
             let mut s = String::new();
@@ -346,8 +357,8 @@ fn run_ffmpeg_within(args: &[OsString], timeout: Duration) -> Result<(), RunErro
             stderr: stderr(),
         }),
         None => {
-            // Hung child: kill and reap so we don't leak a zombie; the drain
-            // thread then hits EOF and its handle is dropped.
+            // Hung child: kill and reap it, so that no zombie leaks. The drain
+            // thread then hits EOF, and its handle is dropped.
             let _ = child.kill();
             let _ = child.wait();
             Err(RunError::TimedOut)
@@ -356,42 +367,47 @@ fn run_ffmpeg_within(args: &[OsString], timeout: Duration) -> Result<(), RunErro
 }
 
 /// Extract the embedded cover image of `input` into `out_dir/cover.<ext>` by
-/// **stream copy** (no re-encode), returning the written path. `ext` should match
-/// the cover codec (`"jpg"` for mjpeg, `"png"` for png). The source is only read.
+/// **stream copy** (no re-encode). Return the written path. `ext` should
+/// match the cover codec (`"jpg"` for mjpeg, `"png"` for png). The source is
+/// only read.
 ///
-/// Maps only the first video (attached-picture) stream, so no audio is written. The
-/// write is atomic ([`extract_image`]), so a `/cover` or `/thumb` reader never sees
-/// a half-written cover while a rescan re-extracts it.
+/// This maps only the first video (attached-picture) stream, so no audio is
+/// written. The write is atomic ([`extract_image`]), so a `/cover` or
+/// `/thumb` reader never sees a half-written cover while a rescan re-extracts
+/// it.
 pub fn extract_cover(input: &Path, out_dir: &Path, ext: &str) -> Result<PathBuf, CoverError> {
     let out_path = out_dir.join(format!("cover.{ext}"));
     extract_image(out_path, |part| build_cover_args(input, part))
 }
 
-/// Long-edge cap (px) for the cover thumbnail. 400 covers every browse-UI use —
-/// the grid (~150px), the detail cover (~200px) and the subscribe subcover (~96px)
-/// — at 2× density, while the full-res `/cover` is what the RSS feed advertises for
-/// podcatcher artwork.
+/// Long-edge cap (px) for the cover thumbnail. 400 covers every browse-UI use
+/// at 2× density: the grid (~150px), the detail cover (~200px), and the
+/// subscribe subcover (~96px). The full-res `/cover` is what the RSS feed
+/// advertises for podcatcher artwork.
 const COVER_THUMB_PX: u32 = 400;
 
-/// The path of a book's browse-UI cover thumbnail under `out_dir`. Centralized so
-/// the generator, the serve layer, and the scanner's invalidation all agree on it.
+/// The path of a book's browse-UI cover thumbnail under `out_dir`.
+/// Centralized, so that the generator, the serve layer, and the scanner's
+/// invalidation all agree on it.
 pub fn cover_thumb_path(out_dir: &Path) -> PathBuf {
     out_dir.join("cover_thumb.jpg")
 }
 
-/// Downscale an already-extracted cover into a small [`cover_thumb_path`] JPEG for
-/// the browse UI (the RSS feed keeps the full-res `/cover`). Bounded to
-/// [`COVER_THUMB_PX`] on the long edge and never upscaled; the source cover file is
-/// only read, and the write is atomic ([`extract_image`]).
+/// Downscale an already-extracted cover into a small [`cover_thumb_path`]
+/// JPEG for the browse UI (the RSS feed keeps the full-res `/cover`). The
+/// output is bounded to [`COVER_THUMB_PX`] on the long edge and never
+/// upscaled. The source cover file is only read, and the write is atomic
+/// ([`extract_image`]).
 pub fn extract_cover_thumb(cover: &Path, out_dir: &Path) -> Result<PathBuf, CoverError> {
     let out_path = cover_thumb_path(out_dir);
     extract_image(out_path, |part| build_cover_thumb_args(cover, part))
 }
 
-/// Run ffmpeg to produce an image at `out_path` **atomically**: create the parent
-/// dir, write to a `.part` sibling, validate it's non-empty, then rename into place.
-/// A concurrent reader sees the old file or the new one, never a half-written one —
-/// which is what lets a rescan re-extract a cover while `/cover` and `/thumb` serve.
+/// Run ffmpeg to produce an image at `out_path` **atomically**: create the
+/// parent dir, write to a `.part` sibling, validate that it is non-empty,
+/// then rename it into place. A concurrent reader sees the old file or the
+/// new one, never a half-written one. That rule lets a rescan re-extract a
+/// cover while `/cover` and `/thumb` serve.
 fn extract_image(
     out_path: PathBuf,
     args_for: impl FnOnce(&Path) -> Vec<OsString>,
@@ -440,7 +456,8 @@ fn build_cover_args(input: &Path, output: &Path) -> Vec<OsString> {
         "error".into(),
         "-i".into(),
         input.as_os_str().to_os_string(),
-        // First (attached-picture) video stream only — drops audio, one frame.
+        // First (attached-picture) video stream only: this drops audio and
+        // writes one frame.
         "-map".into(),
         "0:v:0".into(),
         "-frames:v".into(),
@@ -451,10 +468,11 @@ fn build_cover_args(input: &Path, output: &Path) -> Vec<OsString> {
     ]
 }
 
-/// Build the ffmpeg argv for the cover thumbnail: read the cover image, one frame,
-/// scale so the long edge is at most [`COVER_THUMB_PX`] (aspect preserved, never
-/// upscaled — `min(px, iw/ih)`), re-encode as JPEG. Argv vector, never a shell
-/// string. Factored out for a hermetic unit test.
+/// Build the ffmpeg argv for the cover thumbnail: read the cover image, take
+/// one frame, scale so that the long edge is at most [`COVER_THUMB_PX`]
+/// (aspect preserved, never upscaled: `min(px, iw/ih)`), and re-encode as
+/// JPEG. Argv vector, never a shell string. Factored out for a hermetic unit
+/// test.
 fn build_cover_thumb_args(input: &Path, output: &Path) -> Vec<OsString> {
     vec![
         "-nostdin".into(),
@@ -489,18 +507,19 @@ pub fn episode_file_name(idx: usize, ext: &str) -> String {
     format!("{:03}.{ext}", idx + 1)
 }
 
-/// Whether a file stem marks a produced episode file — the stem side of the
-/// [`episode_file_name`] contract: all digits and nothing else. A `.part`
-/// temporary keeps `.part` in its stem ([`part_path`]) so it never matches,
-/// which is what lets the cache eviction and the scanner's sweeps skip it.
+/// Whether a file stem marks a produced episode file: the stem side of the
+/// [`episode_file_name`] contract, all digits and nothing else. A `.part`
+/// temporary keeps `.part` in its stem ([`part_path`]), so it never matches.
+/// That rule lets the cache eviction and the scanner's sweeps skip it.
 pub fn is_episode_stem(stem: &str) -> bool {
     !stem.is_empty() && stem.bytes().all(|b| b.is_ascii_digit())
 }
 
-/// Split every chapter of `input` into `out_dir`, returning one [`SplitEpisode`]
-/// per chapter (fails fast on the first error). Creates `out_dir` if needed and
-/// never modifies `input`. `out_ext` selects the stream-copy output container to
-/// match the source codec (e.g. `"m4a"`, `"mp3"`, `"flac"`, `"ogg"`, `"opus"`).
+/// Split every chapter of `input` into `out_dir`. Return one [`SplitEpisode`]
+/// per chapter (this fails fast on the first error). It creates `out_dir` if
+/// needed and never modifies `input`. `out_ext` selects the stream-copy
+/// output container to match the source codec (e.g. `"m4a"`, `"mp3"`,
+/// `"flac"`, `"ogg"`, `"opus"`).
 pub fn split_book(
     input: &Path,
     out_dir: &Path,
@@ -510,9 +529,9 @@ pub fn split_book(
     split_book_encoded(input, out_dir, chapters, out_ext, Encoding::Copy)
 }
 
-/// As [`split_book`], with an explicit [`Encoding`] — [`Encoding::Copy`] is the
-/// stream-copy default; the re-encode modes serve Task 5.2's opt-in transcoding
-/// of sources podcatchers can't play.
+/// As [`split_book`], with an explicit [`Encoding`]. [`Encoding::Copy`] is
+/// the stream-copy default; the re-encode modes serve Task 5.2's opt-in
+/// transcoding of sources that podcatchers do not play.
 pub fn split_book_encoded(
     input: &Path,
     out_dir: &Path,
@@ -534,16 +553,17 @@ pub fn split_book_encoded(
             .collect();
     }
 
-    // Two phases so a multi-chapter split is all-or-nothing.
+    // Two phases, so that a multi-chapter split is all-or-nothing.
     //
-    // Phase 1 — produce every chapter's `.part` in PARALLEL. Each is an independent
-    // ffmpeg stream-copy (or re-encode) to its own `{idx+1:03}.part.<ext>`, so the
-    // only shared state is the per-index result slot each worker writes exactly
-    // once. Actual ffmpeg concurrency is bounded by the process-wide `ffmpeg_gate`;
-    // the pool is capped at the same CPU count so extra workers wouldn't just park.
-    // (This is the first-scan speed-up: splitting was serial while the gate sat
-    // unused.) Nothing is published yet, so the previously-served episodes are
-    // untouched no matter what happens here.
+    // Phase 1: produce every chapter's `.part` in PARALLEL. Each is an
+    // independent ffmpeg stream copy (or re-encode) to its own
+    // `{idx+1:03}.part.<ext>`, so the only shared state is the per-index
+    // result slot that each worker writes exactly once. The process-wide
+    // `ffmpeg_gate` bounds the actual ffmpeg concurrency; the pool is capped
+    // at the same CPU count, because extra workers would only park. (This is
+    // the first-scan speed-up: the split was serial while the gate sat
+    // unused.) Nothing is published yet, so the previously served episodes
+    // stay untouched no matter what happens here.
     let out_path_for = |ch: &ChapterCut| out_dir.join(episode_file_name(ch.idx, out_ext));
     let slots: Vec<Mutex<Option<Result<ProducedPart, SplitError>>>> =
         (0..n).map(|_| Mutex::new(None)).collect();
@@ -579,10 +599,11 @@ pub fn split_book_encoded(
         })
         .collect();
 
-    // If ANY chapter failed, publish NONE: delete every produced part (so the old
-    // episode files stay in place) and return the lowest-index error, matching the
-    // old serial `?`. This is what keeps a failed re-ingest from leaving a chapter's
-    // new bytes over the index's old enclosure length.
+    // If ANY chapter failed, publish NONE: delete every produced part (the
+    // old episode files then stay in place) and return the lowest-index
+    // error, which matches the old serial `?`. This rule keeps a failed
+    // re-ingest from leaving a chapter's new bytes over the index's old
+    // enclosure length.
     if produced.iter().any(Result::is_err) {
         for p in produced.iter().flatten() {
             let _ = fs::remove_file(&p.part);
@@ -595,18 +616,19 @@ pub fn split_book_encoded(
             .expect("a failed result exists in this branch"));
     }
 
-    // Phase 2 — every chapter produced: publish each `.part` into place.
+    // Phase 2: every chapter produced, so publish each `.part` into place.
     let parts: Vec<ProducedPart> = produced
         .into_iter()
         .map(|r| r.expect("all parts are Ok in this branch"))
         .collect();
     let part_paths: Vec<PathBuf> = parts.iter().map(|p| p.part.clone()).collect();
 
-    // A same-dir rename is atomic and, in practice, only fails when a directory sits
-    // at the target (the "blocked rename" case). Check EVERY target before renaming
-    // any, so a late block can't leave earlier chapters published over the index's
-    // now-stale enclosure lengths. If any is blocked, publish nothing and delete all
-    // the produced parts — the previously-served episodes stay intact.
+    // A same-dir rename is atomic and, in practice, only fails when a
+    // directory sits at the target (the "blocked rename" case). Check EVERY
+    // target before any rename, so that a late block cannot leave earlier
+    // chapters published over the index's now-stale enclosure lengths. If any
+    // target is blocked, publish nothing and delete all the produced parts;
+    // the previously served episodes stay intact.
     for ch in chapters {
         let out_path = out_path_for(ch);
         if out_path.is_dir() {
@@ -625,10 +647,11 @@ pub fn split_book_encoded(
     }
 
     // Targets are clear: publish each part in chapter order. A rename that still
-    // fails here is a catastrophic I/O error (e.g. the disk filled between producing
-    // the parts and this rename); delete the parts not yet published so nothing is
-    // left half-done, then error. Renames that already succeeded can't be rolled
-    // back — POSIX has no cross-file rename transaction — but the next scan re-splits.
+    // fails here is a catastrophic I/O error (e.g. the disk filled between the part
+    // production and this rename). Delete the parts not yet published, so
+    // that nothing is left half-done, then error. Renames that already
+    // succeeded cannot be rolled back (POSIX has no cross-file rename
+    // transaction), but the next scan re-splits.
     let mut episodes = Vec::with_capacity(n);
     for (i, (ch, part)) in chapters.iter().zip(parts).enumerate() {
         match publish_part(part, out_path_for(ch), ch.idx, ch.end_sec - ch.start_sec) {
@@ -678,11 +701,12 @@ pub fn split_chapter_encoded(
 /// Produce one episode file, atomically: run ffmpeg into the [`part_path`]
 /// sibling of `out_path`, validate what it wrote, then rename it into place.
 ///
-/// `args_for` builds the argv against the temporary — callers never name the
-/// final path themselves, so nothing can write directly over a published episode.
-/// Every failure removes the temporary and returns without touching `out_path`,
-/// so a re-ingest that dies mid-encode leaves the previously served file, and its
-/// recorded `byte_length`, exactly as they were.
+/// `args_for` builds the argv against the temporary; callers never name the
+/// final path themselves, so nothing can write directly over a published
+/// episode. Every failure removes the temporary and returns without a touch
+/// of `out_path`. A re-ingest that dies mid-encode therefore leaves the
+/// previously served file, and its recorded `byte_length`, exactly as they
+/// were.
 fn produce_episode(
     out_path: PathBuf,
     idx: usize,
@@ -694,23 +718,25 @@ fn produce_episode(
     publish_part(produced, out_path, idx, duration_sec)
 }
 
-/// One episode's audio, produced into its `.part` file and validated but **not yet
-/// published** (renamed into place). Splitting produce from publish lets
-/// [`split_book_encoded`] make a multi-chapter split all-or-nothing: it produces
-/// every chapter's part first, and only publishes them if all succeeded — so a
-/// failing chapter never leaves a sibling's new bytes over the old index length.
+/// One episode's audio, produced into its `.part` file and validated but
+/// **not yet published** (renamed into place). The produce/publish split lets
+/// [`split_book_encoded`] make a multi-chapter split all-or-nothing: it
+/// produces every chapter's part first, and it publishes them only when all
+/// succeeded. So a failed chapter never leaves a sibling's new bytes over the
+/// old index length.
 struct ProducedPart {
     /// The validated `.part` file (awaiting a rename to its final path).
     part: PathBuf,
-    /// Real output size in bytes (`fs::metadata().len()`) — the enclosure length.
+    /// Real output size in bytes (`fs::metadata().len()`), used as the
+    /// enclosure length.
     byte_length: u64,
     /// ffmpeg wall-clock, recorded into the split histogram only on publish.
     elapsed: Duration,
 }
 
-/// Run ffmpeg for one episode into its `.part` file and validate the output, but do
-/// **not** rename it into place. On any failure the `.part` is removed and the
-/// already-published episode (if any) is left untouched.
+/// Run ffmpeg for one episode into its `.part` file and validate the output,
+/// but do **not** rename it into place. On any failure, the `.part` is
+/// removed, and the already-published episode (if any) is left untouched.
 fn produce_part(
     out_path: &Path,
     idx: usize,
@@ -720,10 +746,10 @@ fn produce_part(
     let part = part_path(out_path);
     let args = args_for(&part);
 
-    // Timed around the ffmpeg call only. The observation is recorded on publish,
-    // once the output has been validated: a failed or timed-out split would
-    // otherwise pollute the latency distribution with a duration that reflects
-    // the failure rather than the work.
+    // The timer wraps the ffmpeg call only. The observation is recorded on
+    // publish, once the output has been validated. A failed or timed-out
+    // split would otherwise pollute the latency distribution with a duration
+    // that reflects the failure, not the work.
     let started = std::time::Instant::now();
     let run = run_ffmpeg_within(&args, enc.timeout());
     let elapsed = started.elapsed();
@@ -761,12 +787,13 @@ fn produce_part(
     })
 }
 
-/// Publish a produced `.part` into its final path — a same-directory atomic replace
-/// (readers see the old file or the new one, never a mix) — and record the split
-/// metric. An ffmpeg that "succeeds" into a missing or zero-byte file was already
-/// rejected by [`produce_part`], so reaching here means real, published work: a
-/// re-encode is observed here too (the same unit of work, and the slowest ingest an
-/// operator can have — hiding it would make the histogram lie about the tail).
+/// Publish a produced `.part` into its final path (a same-directory atomic
+/// replace: readers see the old file or the new one, never a mix) and record
+/// the split metric. [`produce_part`] already rejected an ffmpeg that
+/// "succeeds" into a missing or zero-byte file, so this point means real,
+/// published work. A re-encode is observed here too: it is the same unit of
+/// work, and the slowest ingest an operator can have. A hidden re-encode
+/// would make the histogram lie about the tail.
 fn publish_part(
     produced: ProducedPart,
     out_path: PathBuf,
@@ -787,16 +814,17 @@ fn publish_part(
     })
 }
 
-/// Remux a whole (chapterless) MP4 to **faststart** — stream-copied, `moov`
-/// relocated to the front — so podcast clients seek immediately. Serves a
-/// non-faststart whole-file episode from the cache when `PODSPINE_REMUX_NON_FASTSTART`
-/// is on (Sprint 6.3); the source is never touched. Like [`split_chapter`] it is a
-/// deterministic `-c copy`, so the output size is a stable `enclosure length`, and
-/// it publishes through the same atomic [`produce_episode`] path (`.part` then
-/// rename, observed in the split histogram) — a failed remux never touches a
-/// previously cached copy. `idx`/`out_ext` name the cache file (`NNN.<ext>`);
-/// `duration_sec` is the whole file's duration (the enclosure duration, carried
-/// through unchanged).
+/// Remux a whole (chapterless) MP4 to **faststart**: stream-copied, with
+/// `moov` relocated to the front, so that podcast clients seek immediately.
+/// This serves a non-faststart whole-file episode from the cache when
+/// `PODSPINE_REMUX_NON_FASTSTART` is on (Sprint 6.3); the source is never
+/// touched. Like [`split_chapter`], it is a deterministic `-c copy`, so the
+/// output size is a stable `enclosure length`. It publishes through the same
+/// atomic [`produce_episode`] path (`.part`, then rename, observed in the
+/// split histogram), so a failed remux never touches a previously cached
+/// copy. `idx`/`out_ext` name the cache file (`NNN.<ext>`). `duration_sec` is
+/// the whole file's duration (the enclosure duration, carried through
+/// unchanged).
 pub fn remux_faststart(
     input: &Path,
     out_dir: &Path,
@@ -810,12 +838,13 @@ pub fn remux_faststart(
     })
 }
 
-/// Re-encode a whole (chapterless) file into one episode under `out_dir` —
-/// Task 5.2's transcode path for a source no podcatcher will play (a FLAC with no
-/// `.cue`, say). Unlike [`split_chapter_encoded`] this emits **no `-ss`/`-t`**: the
-/// episode is the entire file, so a probed duration that is a hair short must not
-/// clip the ending. `duration_sec` is carried through to the enclosure unchanged
-/// (the ffprobe duration), while `byte_length` is read from the real output.
+/// Re-encode a whole (chapterless) file into one episode under `out_dir`:
+/// Task 5.2's transcode path for a source that no podcatcher will play (a
+/// FLAC with no `.cue`, say). Unlike [`split_chapter_encoded`], this emits
+/// **no `-ss`/`-t`**: the episode is the entire file, so a probed duration
+/// that is a hair short must not clip the ending. `duration_sec` is carried
+/// through to the enclosure unchanged (the ffprobe duration), while
+/// `byte_length` comes from the real output.
 ///
 /// `enc` must be a re-encode mode; [`Encoding::Copy`] here would just be a
 /// container rewrite, which is [`remux_faststart`]'s job.
@@ -838,9 +867,10 @@ pub fn transcode_whole(
     })
 }
 
-/// argv for a whole-file faststart remux: keep audio only, drop chapters, copy
-/// codecs (no re-encode), relocate `moov`. No `-ss`/`-t` — the whole file. An
-/// argument vector, never a shell string (untrusted paths).
+/// argv for a whole-file faststart remux: keep audio only, drop chapters,
+/// copy codecs (no re-encode), relocate `moov`. No `-ss`/`-t`: the remux
+/// covers the whole file. An argument vector, never a shell string (paths are
+/// untrusted).
 fn build_remux_args(input: &Path, output: &Path) -> Vec<OsString> {
     vec![
         "-nostdin".into(),
@@ -891,7 +921,8 @@ fn build_encode_args(
     args.push("-i".into());
     args.push(input.as_os_str().to_os_string());
     if let Some((start_sec, end_sec)) = range {
-        // -t <duration>, NEVER -to (which with a pre-input -ss makes a 2x file).
+        // -t <duration>, NEVER -to (with a pre-input -ss, -to makes a 2x
+        // file).
         args.push("-t".into());
         args.push(fmt_secs((end_sec - start_sec).max(0.0)).into());
     }
@@ -911,17 +942,18 @@ fn build_encode_args(
 /// The temporary path an episode is encoded into before it is renamed over
 /// `out_path`.
 ///
-/// Every episode is written **out of place and then renamed**, because a rename
-/// within one directory is atomic: a request that arrives mid-encode is served the
-/// previous complete file (or 404s), never a half-written one, and an ffmpeg that
-/// fails or is killed leaves the already-published episode untouched. That matters
-/// most for a re-encode, which holds the output open for minutes rather than
-/// milliseconds — but it costs nothing to do for a stream copy too.
+/// Every episode is written **out of place and then renamed**, because a
+/// rename within one directory is atomic. A request that arrives mid-encode
+/// is served the previous complete file (or 404s), never a half-written one.
+/// And an ffmpeg that fails or is killed leaves the already-published episode
+/// untouched. That matters most for a re-encode, which holds the output open
+/// for minutes, not milliseconds; but it costs nothing for a stream copy too.
 ///
-/// The extension is **preserved** (`001.m4a` → `001.part.m4a`): ffmpeg picks its
-/// muxer from it, and [`is_mp4_family`] reads it to decide `+faststart`. The stem
-/// is no longer a bare `NNN`, so the cache-eviction and stale-copy sweeps — which
-/// both match an all-digit stem ([`is_episode_stem`]) — skip a temporary.
+/// The extension is **preserved** (`001.m4a` → `001.part.m4a`): ffmpeg picks
+/// its muxer from it, and [`is_mp4_family`] reads it to decide `+faststart`.
+/// The stem is no longer a bare `NNN`, so the cache-eviction and stale-copy
+/// sweeps (both match an all-digit stem, [`is_episode_stem`]) skip a
+/// temporary.
 fn part_path(out_path: &Path) -> PathBuf {
     let stem = out_path
         .file_stem()
@@ -1051,7 +1083,8 @@ mod tests {
         let pair = |a: &str, b: &str| args.windows(2).any(|w| w[0] == a && w[1] == b);
         assert!(pair("-c:a", "libmp3lame"));
         assert!(pair("-b:a", "128k"));
-        // Without a Xing/LAME header a client can't read the duration (TAD §5.4).
+        // Without a Xing/LAME header a client cannot read the duration
+        // (TAD §5.4).
         assert!(pair("-write_xing", "1"));
         assert!(
             !args.iter().any(|a| a == "-movflags"),
@@ -1080,8 +1113,9 @@ mod tests {
 
     #[test]
     fn a_reencode_gets_the_longer_timeout() {
-        // A stream copy of one chapter is seconds; a whole-book re-encode is tens
-        // of minutes, so it must not run under the stream-copy bound.
+        // A stream copy of one chapter takes seconds; a whole-book re-encode
+        // takes tens of minutes, so it must not run under the stream-copy
+        // bound.
         assert_eq!(Encoding::Copy.timeout(), FFMPEG_TIMEOUT);
         assert_eq!(Encoding::Aac.timeout(), TRANSCODE_TIMEOUT);
         assert_eq!(Encoding::Mp3.timeout(), TRANSCODE_TIMEOUT);
@@ -1206,9 +1240,9 @@ mod tests {
     #[test]
     fn cover_extraction_reports_publish_when_a_directory_blocks_the_target() {
         skip_unless_ffmpeg!();
-        // ffmpeg produces the `.part` fine, but a directory sitting at the final path
-        // blocks the atomic rename → CoverError::Publish (the image is never
-        // half-published; the blocker is left as-is).
+        // ffmpeg produces the `.part` fine, but a directory at the final path
+        // blocks the atomic rename, which gives `CoverError::Publish`. The
+        // image is never half-published; the blocker is left as-is.
         let dir = scratch("cover-publish");
         let cover = synth_cover_png(&dir, 64);
 
@@ -1229,10 +1263,11 @@ mod tests {
             assert_eq!(*sem.permits.lock().unwrap(), 0, "permit taken");
         }
         assert_eq!(*sem.permits.lock().unwrap(), 1, "permit released on drop");
-        // The gate is sized to at least one CPU. Assert the sizing source, not the
-        // global gate's live free-permit count — since split_book_encoded now runs
-        // ffmpeg through that same process-wide gate in parallel, a concurrent test
-        // can legitimately hold every permit, so reading the live count here races.
+        // The gate is sized to at least one CPU. Assert the sizing source, not
+        // the global gate's live free-permit count. `split_book_encoded` now
+        // runs ffmpeg through that same process-wide gate in parallel, so a
+        // concurrent test can legitimately hold every permit, and a read of
+        // the live count here races.
         assert!(ffmpeg_parallelism() >= 1);
     }
 
@@ -1240,8 +1275,9 @@ mod tests {
     fn hung_ffmpeg_is_killed_by_the_timeout() {
         skip_unless_ffmpeg!();
         // A real-time, unbounded encode that never terminates on its own; the
-        // per-child timeout must kill it. Uses a deliberately tiny timeout via a
-        // direct argv, bypassing the 5-min production constant.
+        // per-child timeout must kill it. The test uses a deliberately tiny
+        // timeout via a direct argv, which bypasses the 5-min production
+        // constant.
         let args: Vec<OsString> = [
             "-nostdin",
             "-loglevel",
@@ -1277,8 +1313,8 @@ mod tests {
 
     #[test]
     fn zero_length_chapter_errors_without_spawning_ffmpeg() {
-        // end == start -> caught before any ffmpeg spawn, so the (missing) input
-        // path is irrelevant.
+        // end == start is caught before any ffmpeg spawn, so the (missing)
+        // input path is irrelevant.
         let ch = ChapterCut {
             idx: 3,
             start_sec: 5.0,
@@ -1297,8 +1333,9 @@ mod tests {
     #[test]
     fn split_maps_a_nonzero_ffmpeg_exit_to_a_split_error() {
         skip_unless_ffmpeg!();
-        // A positive-duration cut on a non-audio input: ffmpeg fails to read it
-        // and exits non-zero, exercising run_ffmpeg's failure path + the mapping.
+        // A positive-duration cut on a non-audio input: ffmpeg fails to read
+        // it and exits non-zero, which exercises run_ffmpeg's failure path and
+        // the mapping.
         let dir = scratch("split-fail");
         let bad = dir.join("notaudio.m4a");
         std::fs::write(&bad, b"definitely not an audio stream").unwrap();
@@ -1315,9 +1352,9 @@ mod tests {
     #[test]
     fn parallel_split_returns_every_chapter_in_index_order() {
         skip_unless_ffmpeg!();
-        // Many chapters (> the worker pool on most CPUs) so the parallel path runs
-        // and we can prove the results come back in chapter order regardless of
-        // which worker finished first.
+        // Many chapters (> the worker pool on most CPUs), so the parallel path
+        // runs and the test can prove that the results come back in chapter
+        // order, independent of which worker finished first.
         let dir = scratch("parallel-split");
         let input = synth_sine(&dir, "book.m4a", 24.0);
 
@@ -1343,9 +1380,10 @@ mod tests {
     #[test]
     fn a_failing_chapter_publishes_none_of_a_multi_chapter_split() {
         skip_unless_ffmpeg!();
-        // All-or-nothing: if one chapter of a re-ingest fails, the chapters that DID
-        // succeed must not be published over the already-served files — otherwise the
-        // index's old enclosure length would point at new bytes.
+        // All-or-nothing: if one chapter of a re-ingest fails, the chapters
+        // that DID succeed must not be published over the already-served
+        // files. Otherwise the index's old enclosure length would point at new
+        // bytes.
         let dir = scratch("atomic-book");
         let out = dir.join("out");
         std::fs::create_dir_all(&out).unwrap();
@@ -1361,8 +1399,9 @@ mod tests {
             .map(|p| std::fs::read(p).unwrap())
             .collect();
 
-        // Chapters 0 and 1 are valid; chapter 2 is empty (end == start) → fails
-        // before ffmpeg, so 0/1 produce real parts but nothing is published.
+        // Chapters 0 and 1 are valid; chapter 2 is empty (end == start) and
+        // fails before ffmpeg. So 0/1 produce real parts, but nothing is
+        // published.
         let cuts = [
             ChapterCut {
                 idx: 0,
@@ -1410,9 +1449,10 @@ mod tests {
     #[test]
     fn a_blocked_publish_target_publishes_none_of_a_multi_chapter_split() {
         skip_unless_ffmpeg!();
-        // Both chapters produce fine, but a directory sits where chapter 2's episode
-        // must land, so its publish (rename) can't happen. The pre-check must catch
-        // that before publishing chapter 1 — nothing half-published, no parts left.
+        // Both chapters produce fine, but a directory sits where chapter 2's
+        // episode must land, so its publish (rename) cannot happen. The
+        // pre-check must catch that before chapter 1 is published: nothing
+        // half-published, no parts left.
         let dir = scratch("atomic-block");
         let out = dir.join("out");
         std::fs::create_dir_all(&out).unwrap();
@@ -1471,8 +1511,8 @@ mod tests {
     #[test]
     fn a_temporary_keeps_the_extension_and_hides_from_the_sweeps() {
         let p = part_path(Path::new("/data/books/b/001.m4a"));
-        // ffmpeg picks its muxer from the extension, and `is_mp4_family` reads it
-        // to decide `+faststart` — so the extension has to survive.
+        // ffmpeg picks its muxer from the extension, and `is_mp4_family` reads
+        // it to decide `+faststart`. So the extension has to survive.
         assert_eq!(p, Path::new("/data/books/b/001.part.m4a"));
         assert!(is_mp4_family(&p), "a temporary must still look mp4-family");
         // Both the cache eviction and the stale-copy sweep match an episode stem.
@@ -1531,9 +1571,10 @@ mod tests {
     #[test]
     fn a_failed_encode_leaves_the_published_episode_untouched() {
         skip_unless_ffmpeg!();
-        // The re-ingest hazard: an episode is already published and being served
-        // when a new encode of it fails. The old bytes — and the byte_length the
-        // feed advertises for them — must survive, and no temporary may be left.
+        // The re-ingest hazard: an episode is already published and served
+        // when a new encode of it fails. The old bytes, and the byte_length
+        // the feed advertises for them, must survive, and no temporary may be
+        // left.
         let dir = scratch("atomic-fail");
         let out = dir.join("out");
         std::fs::create_dir_all(&out).unwrap();
@@ -1583,7 +1624,8 @@ mod tests {
     fn split_chapter_maps_a_nonzero_ffmpeg_exit_to_an_error() {
         skip_unless_ffmpeg!();
         // `split_chapter` (the saver/regen entry point) on a non-audio input:
-        // ffmpeg exits non-zero → the error arm, carrying the chapter index.
+        // ffmpeg exits non-zero and hits the error arm, which carries the
+        // chapter index.
         let dir = scratch("splitchap-fail");
         let out = dir.join("out");
         std::fs::create_dir_all(&out).unwrap();
@@ -1602,8 +1644,8 @@ mod tests {
     fn remux_faststart_produces_a_deterministic_faststart_file() {
         skip_unless_ffmpeg!();
         let dir = scratch("remux-ft");
-        // ffmpeg's mp4 muxer writes `moov` at the END unless +faststart is asked,
-        // so a plain encode gives us a non-faststart source.
+        // ffmpeg's mp4 muxer writes `moov` at the END unless +faststart is
+        // asked, so a plain encode gives a non-faststart source.
         let src = synth_sine(&dir, "src.m4a", 3.0);
 
         let out = dir.join("out");
@@ -1639,10 +1681,10 @@ mod tests {
     #[test]
     fn remux_maps_a_nonzero_ffmpeg_exit_to_a_split_error() {
         skip_unless_ffmpeg!();
-        // A non-audio input makes ffmpeg exit non-zero → the remux error arm.
-        // A remux publishes through the same atomic `.part` path as every other
-        // producer, so a previously cached copy being served must survive the
-        // failure byte-for-byte, and no temporary may be left.
+        // A non-audio input makes ffmpeg exit non-zero and hit the remux error
+        // arm. A remux publishes through the same atomic `.part` path as every
+        // other producer, so a previously cached copy that is served must
+        // survive the failure byte-for-byte, and no temporary may be left.
         let dir = scratch("remux-fail");
         let out = dir.join("out");
         std::fs::create_dir_all(&out).unwrap();
@@ -1689,7 +1731,7 @@ mod tests {
             !done.load(std::sync::atomic::Ordering::SeqCst),
             "second acquirer is still blocked while the permit is held"
         );
-        drop(p1); // release → wakes the waiter
+        drop(p1); // The release wakes the waiter.
         handle.join().unwrap();
         assert!(done.load(std::sync::atomic::Ordering::SeqCst));
     }
@@ -1697,7 +1739,8 @@ mod tests {
     #[test]
     fn extract_cover_maps_a_nonzero_ffmpeg_exit_to_a_cover_error() {
         skip_unless_ffmpeg!();
-        // No video stream to map -> ffmpeg exits non-zero -> CoverError::Ffmpeg.
+        // There is no video stream to map, so ffmpeg exits non-zero:
+        // `CoverError::Ffmpeg`.
         let dir = scratch("cover-fail");
         let bad = dir.join("notaudio.m4a");
         std::fs::write(&bad, b"no video here").unwrap();
@@ -1709,8 +1752,8 @@ mod tests {
     #[test]
     fn extract_cover_thumb_maps_a_bad_input_to_a_cover_error() {
         skip_unless_ffmpeg!();
-        // A non-image input -> ffmpeg can't decode it -> CoverError (Ffmpeg or the
-        // empty-output guard), never a panic.
+        // ffmpeg cannot decode a non-image input: a `CoverError` (Ffmpeg or
+        // the empty-output guard), never a panic.
         let dir = scratch("thumb-fail");
         let bad = dir.join("notanimage.png");
         std::fs::write(&bad, b"definitely not an image").unwrap();
@@ -1726,8 +1769,9 @@ mod tests {
 
     #[test]
     fn extract_cover_reports_create_dir_when_out_dir_is_a_file() {
-        // out_dir is an existing regular file -> create_dir_all fails BEFORE any
-        // ffmpeg spawn -> CoverError::CreateDir. ffmpeg-free, so it runs everywhere.
+        // out_dir is an existing regular file, so create_dir_all fails BEFORE
+        // any ffmpeg spawn: `CoverError::CreateDir`. The test is ffmpeg-free,
+        // so it runs everywhere.
         let dir = scratch("cover-createdir");
         let file_as_dir = dir.join("iam-a-file");
         std::fs::write(&file_as_dir, b"x").unwrap();
@@ -1738,8 +1782,9 @@ mod tests {
 
     #[test]
     fn split_book_reports_create_dir_when_out_dir_is_a_file() {
-        // Same guard on the chaptered path: out_dir is a file -> SplitError::CreateDir
-        // before any chapter is cut (ffmpeg-free).
+        // The same guard on the chaptered path: out_dir is a file, so
+        // `SplitError::CreateDir` fires before any chapter is cut
+        // (ffmpeg-free).
         let dir = scratch("split-createdir");
         let file_as_dir = dir.join("iam-a-file");
         std::fs::write(&file_as_dir, b"x").unwrap();

--- a/crates/splitter/tests/split_real.rs
+++ b/crates/splitter/tests/split_real.rs
@@ -1,10 +1,10 @@
-//! Real ffmpeg split of a real audiobook — the POC's core proof.
+//! Real ffmpeg split of a real audiobook: the POC's core proof.
 //!
 //! Existence-gated on the local golden-path fixture (or `$PODSPINE_TEST_M4B`);
-//! quietly skips in CI where the large file is absent. Splits the first few
-//! chapters and asserts each output's *actual* duration matches the requested
-//! duration within ±1 s — which is exactly what a `-to`/`-t` mistake (the 2×
-//! bug) would violate.
+//! it quietly skips in CI, where the large file is absent. It splits the
+//! first few chapters and asserts that each output's *actual* duration
+//! matches the requested duration within ±1 s. That is exactly what a
+//! `-to`/`-t` mistake (the 2× bug) would violate.
 
 use std::path::{Path, PathBuf};
 
@@ -35,8 +35,8 @@ fn splits_real_chapters_without_2x_bug_and_leaves_source_untouched() {
     let book = probe(&input).expect("probe fixture");
     assert!(book.chapters.len() >= 3, "need at least 3 chapters to test");
 
-    // First 3 chapters (a real fixture typically includes a short one — a
-    // useful tiny-segment case).
+    // The first 3 chapters (a real fixture typically includes a short one:
+    // a useful tiny-segment case).
     let cuts: Vec<ChapterCut> = book.chapters[..3]
         .iter()
         .map(|c| ChapterCut {
@@ -74,7 +74,7 @@ fn splits_real_chapters_without_2x_bug_and_leaves_source_untouched() {
         assert!(ep.byte_length > 0, "output not empty");
 
         // The anti-2x proof: probe the produced file and compare its actual
-        // duration to what we asked for (±1 s, per NFR-P1).
+        // duration to the requested one (±1 s, per NFR-P1).
         let requested = cut.end_sec - cut.start_sec;
         let actual = probe(&ep.path).expect("probe output").duration_sec;
         assert!(

--- a/crates/test-support/Cargo.toml
+++ b/crates/test-support/Cargo.toml
@@ -10,3 +10,6 @@ authors.workspace = true
 publish = false
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -25,15 +25,16 @@ pub fn ffmpeg_available() -> bool {
 /// encoder for the format the test needs.
 ///
 /// The `eprintln!` and the `return` live here, once, instead of at every call
-/// site. Wherever ffmpeg IS installed — CI, most dev machines — they cannot
-/// execute, and 62 copies of them dominated the uncovered-line count (35 of the
-/// 56 lines in PR 152's diff).
+/// site. Wherever ffmpeg IS installed (CI, most dev machines), they cannot
+/// execute, and 62 copies of them dominated the uncovered-line count (35 of
+/// the 56 lines in PR 152's diff).
 ///
-/// Measured, not assumed: llvm-cov attributes a macro body to each **expansion**,
-/// not to the definition, so a call site still reports one unreachable line —
-/// one instead of two, which took 63 lines off the report (scanner 158 → 105
-/// misses, splitter 45 → 35). One line per skip is the floor for deciding at
-/// runtime; something has to stand for "this didn't run".
+/// Measured, not assumed: llvm-cov attributes a macro body to each
+/// **expansion**, not to the definition, so a call site still reports one
+/// unreachable line. One line instead of two took 63 lines off the report
+/// (scanner 158 → 105 misses, splitter 45 → 35). One line per skip is the
+/// floor for a runtime decision; something has to stand for "this did not
+/// run".
 #[macro_export]
 macro_rules! skip {
     ($($why:tt)*) => {{
@@ -42,7 +43,7 @@ macro_rules! skip {
     }};
 }
 
-/// [`skip!`] the test unless ffmpeg is invocable — the opener of every
+/// [`skip!`] the test unless ffmpeg is invocable: the opener of every
 /// ffmpeg-gated test.
 #[macro_export]
 macro_rules! skip_unless_ffmpeg {
@@ -54,9 +55,9 @@ macro_rules! skip_unless_ffmpeg {
 }
 
 /// A per-test scratch directory under the system temp dir, wiped on creation
-/// and removed again on drop — so a panicking test leaves no litter behind.
-/// Derefs to [`Path`], so call sites use it exactly like the `PathBuf` the
-/// old hand-rolled dances produced.
+/// and removed again on drop, so that a test that panics leaves no litter
+/// behind. It derefs to [`Path`], so call sites use it exactly like the
+/// `PathBuf` that the old hand-rolled code produced.
 pub struct ScratchDir {
     path: PathBuf,
 }
@@ -67,9 +68,9 @@ impl ScratchDir {
         &self.path
     }
 
-    /// Defuse the drop cleanup and hand the path over — for the rare test
+    /// Defuse the drop cleanup and hand the path over, for the rare test
     /// that must leave the directory alive past its body (e.g. one that
-    /// spawned a detached watcher thread still holding the dir open).
+    /// spawned a detached watcher thread that still holds the dir open).
     pub fn keep(self) -> PathBuf {
         let path = self.path.clone();
         std::mem::forget(self);

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -13,3 +13,6 @@ publish = false
 maud = { workspace = true }
 qrcode = { workspace = true }
 tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -16,9 +16,9 @@ use qrcode::render::svg;
 
 /// One book as shown in the grid on `GET /`.
 pub struct BookCard {
-    /// URL slug — the human `/book/{slug}` key (browse UI only).
+    /// URL slug: the human `/book/{slug}` key (browse UI only).
     pub slug: String,
-    /// Capability id — the `/cover/{feed_id}` key (unguessable).
+    /// Capability id: the `/cover/{feed_id}` key (unguessable).
     pub feed_id: String,
     /// Human title.
     pub title: String,
@@ -30,10 +30,10 @@ pub struct BookCard {
 
 /// A single book's detail page (`GET /book/{slug}`).
 pub struct BookDetail {
-    /// URL slug — the human `/book/{slug}` key (also the base for the
+    /// URL slug: the human `/book/{slug}` key (also the base for the
     /// regenerate POST action).
     pub slug: String,
-    /// Capability id — the `/cover/{feed_id}` key (unguessable).
+    /// Capability id: the `/cover/{feed_id}` key (unguessable).
     pub feed_id: String,
     /// Human title.
     pub title: String,
@@ -54,11 +54,11 @@ pub struct BookDetail {
 /// The palette is chosen for WCAG AA contrast (NFR-C3): `#18181b` text on white
 /// (~16:1), `#52525b` muted (~7:1), and white on the `#1d4ed8` accent (~5.3:1).
 /// Everything is driven through the `--*` custom properties, so a theme is just an
-/// override of those same variables — no per-rule duplication. The default (no
+/// override of those same variables, with no per-rule duplication. The default (no
 /// `data-theme`) follows the OS via `prefers-color-scheme`; an explicit choice from
 /// the header picker sets `<html data-theme="light|dark">` (persisted in a cookie,
 /// read server-side) which wins over the media query. `color-scheme` keeps native
-/// controls/scrollbars in step. AA-contrast dark palette — `#f4f4f5` text on
+/// controls/scrollbars in step. The AA-contrast dark palette: `#f4f4f5` text on
 /// `#18181b` (~16:1), `#a1a1aa` muted (~7:1), `#0b1120` on the lighter `#60a5fa`
 /// accent (~7:1). The QR SVGs keep their own white background (`.appqr svg`) so a
 /// phone can still scan in dark mode.
@@ -266,7 +266,7 @@ fn page(title: &str, theme: Theme, body: Markup) -> Markup {
 }
 
 /// A cover `<img>` when available, else an accessible lettered placeholder.
-/// `id` is the book's capability `feed_id` — covers are served at
+/// `id` is the book's capability `feed_id`: covers are served at
 /// `/cover/{feed_id}`, never the guessable slug.
 fn cover(id: &str, title: &str, has_cover: bool, class: &str) -> Markup {
     let initial = title
@@ -395,7 +395,7 @@ pub fn book_page(book: &BookDetail, theme: Theme) -> Markup {
 /// The "private link" controls: regenerate the capability URL (leak recovery).
 /// A plain `POST` form — no JS required. `slug` is the (LAN-only) UI key the
 /// route acts on; `feed_id` never appears in the action URL. Feeds are always
-/// kept out of podcast directories, so there's nothing to toggle.
+/// kept out of podcast directories, so there is nothing to toggle.
 fn private_panel(slug: &str) -> Markup {
     html! {
         section.private {
@@ -423,16 +423,17 @@ pub struct AppLink {
     pub url: String,
 }
 
-/// Strip the URL scheme (`http://` / `https://`) — the `feedURL` form most app
-/// subscribe schemes expect.
+/// Strip the URL scheme (`http://` / `https://`): the `feedURL` form that
+/// most app subscribe schemes expect.
 fn strip_scheme(url: &str) -> &str {
     url.strip_prefix("https://")
         .or_else(|| url.strip_prefix("http://"))
         .unwrap_or(url)
 }
 
-/// Percent-encode per RFC 3986 (unreserved chars pass through) — for embedding the
-/// feed URL as a query parameter (Overcast's `?url=`). Avoids a url-encoding dep.
+/// Percent-encode per RFC 3986 (unreserved chars pass through), used to embed
+/// the feed URL as a query parameter (Overcast's `?url=`). This avoids a
+/// url-encoding dependency.
 fn percent_encode(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     for b in s.bytes() {
@@ -482,12 +483,12 @@ pub fn subscribe_links(feed_url: &str) -> Vec<AppLink> {
     ]
 }
 
-/// The `/subscribe/{feed_id}` helper page: big per-app "Open in…" buttons (deep
-/// links), each app's QR code tucked behind its own `<details>` expand — a shared
-/// `name` makes them an exclusive accordion, so only one code is ever on screen to
-/// scan (desktop→phone handoff) — and a copy-the-URL fallback. This is what the
-/// book-page QR points at, so an iOS Camera scan lands on real app links instead of
-/// raw feed XML.
+/// The `/subscribe/{feed_id}` helper page: big per-app "Open in…" buttons
+/// (deep links), each app's QR code behind its own `<details>` expand, and a
+/// copy-the-URL fallback. A shared `name` makes the sections an exclusive
+/// accordion, so only one code is ever on screen to scan (desktop→phone
+/// handoff). The book-page QR points here, so an iOS Camera scan lands on
+/// real app links instead of raw feed XML.
 pub fn subscribe_page(book: &BookDetail, theme: Theme) -> Markup {
     let apps = subscribe_links(&book.feed_url);
     page(
@@ -508,23 +509,26 @@ pub fn subscribe_page(book: &BookDetail, theme: Theme) -> Markup {
                         }
                     }
 
-                    // One collapsible <details> per app, not a grid of all codes at
-                    // once: with every QR on screen a phone camera readily locks onto
-                    // an adjacent app's code and opens the wrong app. A collapsed
-                    // section shows nothing scannable, so expanding one puts exactly
-                    // that app's code on screen. Native <details> — no JS. For the
-                    // desktop→phone case: expand an app and scan to open it on a phone.
+                    // One collapsible <details> per app, not a grid of all
+                    // codes at once: with every QR on screen, a phone camera
+                    // readily locks onto an adjacent app's code and opens the
+                    // wrong app. A collapsed section shows nothing scannable,
+                    // so one expanded section puts exactly that app's code on
+                    // screen. Native <details>, no JS. For the desktop→phone
+                    // case: expand an app and scan to open it on a phone.
                     section.qrpanel {
                         h2 { "Scan a code from another device" }
                         p.qrhint { "On a computer? Expand an app and point your phone's camera at just that code." }
                         ul.qraccordion {
                             @for app in &apps {
                                 li {
-                                    // Shared `name` makes these an exclusive accordion
-                                    // group (like radio buttons): opening one closes
-                                    // any other — enforcing one-code-on-screen without
-                                    // JS. Browsers without `<details name>` support just
-                                    // treat them as independent (still collapsed by
+                                    // A shared `name` makes these an
+                                    // exclusive accordion group (like radio
+                                    // buttons): to open one closes any other,
+                                    // which enforces one-code-on-screen
+                                    // without JS. Browsers without
+                                    // `<details name>` support treat them as
+                                    // independent (still collapsed by
                                     // default), so it degrades safely.
                                     details.qrapp name="podcatcher-qr" {
                                         summary { (app.name) }
@@ -561,8 +565,9 @@ fn qr_svg(data: &str) -> String {
     qr_svg_sized(data, 180)
 }
 
-/// Render `data` as an inline SVG QR code at `px` minimum size. Empty string if
-/// the data can't be encoded (never panics on the request path).
+/// Render `data` as an inline SVG QR code at `px` minimum size. Return an
+/// empty string if the data cannot be encoded (this never panics on the
+/// request path).
 fn qr_svg_sized(data: &str, px: u32) -> String {
     match QrCode::new(data.as_bytes()) {
         Ok(code) => code
@@ -570,8 +575,9 @@ fn qr_svg_sized(data: &str, px: u32) -> String {
             .min_dimensions(px, px)
             .quiet_zone(true)
             .build(),
-        // Practically unreachable (QR capacity ~2.9 KB; feed URLs are far
-        // shorter) — logged so the impossible is noticed if it ever happens.
+        // Practically unreachable (QR capacity is ~2.9 KB; feed URLs are far
+        // shorter). It is logged, so the impossible is noticed if it ever
+        // happens.
         Err(err) => {
             tracing::warn!(error = %err, "QR encoding failed; rendering without a code");
             String::new()
@@ -596,8 +602,8 @@ mod tests {
     #[test]
     fn an_unencodable_qr_yields_an_empty_string_not_a_panic() {
         // QR capacity tops out around 2953 bytes; a longer base_url would
-        // otherwise panic on a page request. Empty string = the page still
-        // renders, just without a code.
+        // otherwise panic on a page request. An empty string means the page
+        // still renders, only without a code.
         let too_long = "u".repeat(4000);
         assert!(qr_svg_sized(&too_long, 180).is_empty());
         // Sanity: a normal URL still produces a code, so the assert above is

--- a/deny.toml
+++ b/deny.toml
@@ -8,7 +8,7 @@ yanked = "deny"
 [bans]
 multiple-versions = "warn"
 wildcards = "deny"
-# Internal workspace crates are path deps with no version requirement — a
+# Internal workspace crates are path deps with no version requirement: a
 # "wildcard" to cargo-deny, but expected and correct. Only EXTERNAL wildcard
 # deps are the smell this rule is meant to catch.
 allow-wildcard-paths = true
@@ -16,8 +16,9 @@ allow-wildcard-paths = true
 [licenses]
 version = 2
 confidence-threshold = 0.9
-# Silence "license was not encountered" for the forward-looking allow-list below
-# (we list licenses we'll hit once real deps land, before they're in the tree).
+# Silence "license was not encountered" for the forward-looking allow-list
+# below (it names licenses that will arrive once real deps land, before they
+# are in the tree).
 unused-allowed-license = "allow"
 allow = [
     "AGPL-3.0-only",

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -228,7 +228,7 @@ title = "The Correct Title"
 Server-wide keys (`bind`, `base_url`, `library`, `data_dir`, `cache_size`,
 `cache_ttl`, `transcode`, …) are **ignored with a log warning** if they appear in a
 per-book file — they only make sense server-wide. (`transcode` is server-wide for
-now: it is decided from the source codec, so a per-book key would buy little.) An unparseable sidecar is logged and
+now: it is decided from the source codec, so a per-book key would buy little.) An unparsable sidecar is logged and
 skipped for that book; it never aborts the scan.
 
 ## Exposing Podspine safely

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,7 +1,7 @@
 # cargo-fuzz harnesses for Podspine's untrusted-input parsers. This is its OWN
 # workspace (the `[workspace]` table below detaches it from the root), so the
-# normal `cargo build/test/clippy --workspace` and coverage never touch it — only
-# ClusterFuzzLite / `cargo +nightly fuzz` build it.
+# normal `cargo build/test/clippy --workspace` and coverage never touch it.
+# Only ClusterFuzzLite / `cargo +nightly fuzz` build it.
 [package]
 name = "podspine-fuzz"
 version = "0.0.0"

--- a/fuzz/fuzz_targets/parse_cue.rs
+++ b/fuzz/fuzz_targets/parse_cue.rs
@@ -1,6 +1,7 @@
 #![no_main]
-//! Fuzz the `.cue` sidecar parser — an attacker-influenceable file parsed into
-//! chapter cut points (75 fps `INDEX 01`). Must never panic on arbitrary bytes.
+//! Fuzz the `.cue` sidecar parser: an attacker-influenceable file parsed
+//! into chapter cut points (75 fps `INDEX 01`). It must never panic on
+//! arbitrary bytes.
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzz_targets/parse_ffmeta.rs
+++ b/fuzz/fuzz_targets/parse_ffmeta.rs
@@ -1,7 +1,8 @@
 #![no_main]
-//! Fuzz the `.ffmeta` sidecar parser — the ffmpeg-metadata `[CHAPTER]` format
-//! parsed from an attacker-influenceable file. Must never panic on arbitrary
-//! bytes (TIMEBASE arithmetic, malformed sections, huge numbers, …).
+//! Fuzz the `.ffmeta` sidecar parser: the ffmpeg-metadata `[CHAPTER]` format
+//! parsed from an attacker-influenceable file. It must never panic on
+//! arbitrary bytes (TIMEBASE arithmetic, malformed sections, huge
+//! numbers, …).
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzz_targets/parse_probe_json.rs
+++ b/fuzz/fuzz_targets/parse_probe_json.rs
@@ -1,7 +1,7 @@
 #![no_main]
-//! Fuzz the ffprobe-JSON parser — Podspine parses whatever `ffprobe` prints for
-//! an input file into a `ProbedBook`. Must return a typed error, never panic, on
-//! arbitrary/hostile JSON.
+//! Fuzz the ffprobe-JSON parser: Podspine parses whatever `ffprobe` prints
+//! for an input file into a `ProbedBook`. It must return a typed error, and
+//! never panic, on arbitrary/hostile JSON.
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {

--- a/install.ps1
+++ b/install.ps1
@@ -72,8 +72,9 @@ function Install-Podspine {
     New-Item -ItemType Directory -Path $work -Force | Out-Null
 
     try {
-        # checksums.txt is the authoritative list of published binaries - gate on it so
-        # an arch with no binary falls back cleanly instead of 404-ing on download.
+        # checksums.txt is the authoritative list of published binaries. Gate
+        # on it, so that an arch with no binary falls back cleanly; it does
+        # not 404 on download.
         $sumsPath = Join-Path $work 'checksums.txt'
         Invoke-WebRequest -Uri "$base/checksums.txt" -OutFile $sumsPath -UseBasicParsing
         # Exact field-2 (filename) match, mirroring install.sh's awk. sha256sum text
@@ -113,12 +114,13 @@ function Install-Podspine {
         New-Item -ItemType Directory -Path $dir -Force | Out-Null
         $dest = Join-Path $dir "$Tool.exe"
         Move-Item -Path $exePath -Destination $dest -Force
-        # The download carries a mark-of-the-web zone tag; clear it now that the
-        # checksum is verified so the user isn't blocked on first run.
+        # The download carries a mark-of-the-web zone tag. Clear it now that
+        # the checksum is verified, so that the user is not blocked on first
+        # run.
         Unblock-File -Path $dest -ErrorAction SilentlyContinue
         Write-Ok "Installed $dest"
 
-        # Add the install dir to the user PATH if it isn't already there.
+        # Add the install dir to the user PATH when it is not already there.
         $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
         if ($null -eq $userPath) { $userPath = '' }
         if (($userPath -split ';') -notcontains $dir) {
@@ -147,9 +149,10 @@ function Install-Podspine {
         Write-Info "Run it with:  $Tool --library C:\path\to\audiobooks"
         Write-Info 'The binary is Sigstore-signed but not authenticode-signed, so SmartScreen may warn on first run.'
         Write-Ok 'Installation complete!'
-        # Only reached on success. The `--version` probe above can leave $LASTEXITCODE
-        # non-zero without throwing; normalize so a successful install reports 0 to a
-        # piped `iex` caller / CI. (Failure paths return/throw before here with 1.)
+        # Only reached on success. The `--version` probe above can leave
+        # $LASTEXITCODE non-zero without a throw; normalize it, so that a
+        # successful install reports 0 to a piped `iex` caller / CI. (Failure
+        # paths return/throw before here with 1.)
         $global:LASTEXITCODE = 0
     }
     finally {

--- a/install.sh
+++ b/install.sh
@@ -10,9 +10,9 @@ set -euo pipefail
 # from the latest GitHub release, verifies its SHA-256 against the release's
 # signed checksums.txt, and installs it onto your PATH.
 #
-# Podspine shells out to `ffmpeg`/`ffprobe` at runtime but does not vendor them —
-# install them separately and keep them on PATH (this script warns if they're
-# missing).
+# Podspine shells out to `ffmpeg`/`ffprobe` at runtime but does not vendor
+# them. Install them separately and keep them on PATH (this script warns when
+# they are missing).
 #
 # Environment overrides:
 #   PODSPINE_VERSION       pin a specific release tag (e.g. X.Y.Z); default: latest release
@@ -23,8 +23,9 @@ REPO_OWNER="schubydoo"
 REPO_NAME="podspine"
 TOOL_NAME="podspine"
 
-# Scratch dir, cleaned up on exit. Global so the EXIT trap can see it even after
-# main() returns (a `local` would be out of scope and trip `set -u`).
+# A scratch dir, cleaned up on exit. It is global, so that the EXIT trap can
+# see it even after main() returns (a `local` would be out of scope and trip
+# `set -u`).
 WORKDIR=""
 cleanup() { [ -n "$WORKDIR" ] && rm -rf "$WORKDIR"; }
 trap cleanup EXIT
@@ -75,9 +76,10 @@ detect_arch() {
     esac
 }
 
-# Map (os, arch, ver) -> release asset basename, or empty for an unknown arch.
-# Whether the named asset actually exists in a given release is decided later,
-# against that release's checksums.txt (the authoritative list of built binaries).
+# Map (os, arch, ver) to the release asset basename, or to empty for an
+# unknown arch. Whether the named asset actually exists in a given release is
+# decided later, against that release's checksums.txt (the authoritative list
+# of built binaries).
 asset_for() {
     local os="$1" arch="$2" ver="$3"
     case "${os}-${arch}" in
@@ -107,8 +109,9 @@ resolve_latest() {  # echo the latest version (tag minus leading v)
         url="$(curl -fsSLI -o /dev/null -w '%{url_effective}' \
             "https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/latest")"
     elif have wget; then
-        # HTTP headers are CRLF-terminated, so strip the trailing CR — otherwise the
-        # version carries a \r into the asset URL and 404s on wget-only hosts.
+        # HTTP headers are CRLF-terminated, so strip the trailing CR.
+        # Otherwise the version carries a \r into the asset URL and 404s on
+        # wget-only hosts.
         url="$(wget -q -S -O /dev/null \
             "https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/latest" 2>&1 \
             | awk '/^[[:space:]]*Location:/ {print $2}' | tail -n1 | tr -d '\r')"
@@ -182,13 +185,15 @@ main() {
     local base="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download/v${ver}"
     WORKDIR="$(mktemp -d)" || die "Could not create a temporary directory."
 
-    # The release's checksums.txt is the authoritative list of published binaries.
-    # If our target isn't listed, no binary was built for this arch in this
-    # release — fail cleanly with alternatives rather than 404 on download.
+    # The release's checksums.txt is the authoritative list of published
+    # binaries. If the target is not listed, no binary was built for this arch
+    # in this release: fail cleanly with alternatives, not with a 404 on
+    # download.
     http_to "${base}/checksums.txt" "${WORKDIR}/checksums.txt"
     local expected actual
-    # Exact field-2 (filename) match; TrimStart('*') tolerates a binary-mode marker
-    # ("<hash> *<name>"). Our releases use text mode ("<hash>  <name>").
+    # An exact field-2 (filename) match; TrimStart('*') tolerates a
+    # binary-mode marker ("<hash> *<name>"). These releases use text mode
+    # ("<hash>  <name>").
     expected="$(awk -v a="$asset" '{n=$2; sub(/^\*/,"",n); if (n==a) print $1}' "${WORKDIR}/checksums.txt")"
     if [ -z "$expected" ]; then
         err "Release v${ver} has no ${os}-${arch} binary (${asset} not in checksums.txt)."
@@ -210,7 +215,7 @@ main() {
     mkdir -p "$dir" || die "Cannot create install directory: $dir"
     local dest="${dir}/${TOOL_NAME}"
 
-    # Write atomically; use sudo only if the directory is not writable.
+    # Write atomically; use sudo only when the directory is not writable.
     chmod +x "${WORKDIR}/${asset}"
     if [ -w "$dir" ]; then
         mv -f "${WORKDIR}/${asset}" "$dest"
@@ -229,8 +234,9 @@ main() {
            warn "  echo 'export PATH=\"${dir}:\$PATH\"' >> ~/.bashrc && source ~/.bashrc" ;;
     esac
 
-    # Verify: require a zero exit AND a 'podspine' identity banner — not merely
-    # non-empty output (a failing binary could still print something to stdout).
+    # Verify: require a zero exit AND a 'podspine' identity banner, not
+    # merely non-empty output (a failing binary could still print something
+    # to stdout).
     local got_ver=""
     if got_ver="$("$dest" --version 2>/dev/null)" && printf '%s' "$got_ver" | grep -qi '^podspine'; then
         ok "${got_ver} installed"

--- a/knope.toml
+++ b/knope.toml
@@ -1,11 +1,12 @@
 # Release automation for Podspine — knope (CHANGESETS model).
 #
-# Model: every user-facing change ships a `.changeset/*.md` fragment; those
-# fragments — not commit messages — drive BOTH the version bump and the changelog
-# (full section control, no commit/fragment duplication). `knope document-change`
-# scaffolds one; see the changeset section in CONTRIBUTING.md. Conventional-commit
-# titles are still enforced (pr-title.yml) for a clean history, but are ignored
-# for release purposes.
+# Model: every user-facing change ships a `.changeset/*.md` fragment. Those
+# fragments (not commit messages) drive BOTH the version bump and the
+# changelog (full section control, no commit/fragment duplication).
+# `knope document-change` scaffolds one; see the changeset section in
+# CONTRIBUTING.md. Conventional-commit titles are still enforced
+# (pr-title.yml) for a clean history, but they are ignored for release
+# purposes.
 #
 # The two halves live in .github/workflows/knope-{prepare,release}.yml and are
 # gated OFF behind the `KNOPE_ENABLED` repo variable until the flow is proven.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,7 +60,7 @@ markdown_extensions:
   - pymdownx.snippets
   - pymdownx.highlight:
       anchor_linenums: true
-  # `:material-*:` / `:fontawesome-*:` icon shortcodes -> inline SVGs.
+  # `:material-*:` / `:fontawesome-*:` icon shortcodes become inline SVGs.
   - pymdownx.emoji:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg

--- a/packaging/downstream/sync-formula.yml
+++ b/packaging/downstream/sync-formula.yml
@@ -1,12 +1,13 @@
 # INSTALL THIS INTO the schubydoo/homebrew-podspine repo at
 # .github/workflows/sync-formula.yml  (it does NOT run from the main podspine repo).
 #
-# The canonical podspine formula lives in the main repo (schubydoo/podspine), where its
-# version/url/hash are regenerated on every release by packaging-bump.yml. This tap just
-# mirrors that file: on a schedule (and on demand, dispatched by the main repo's
-# tap-sync-trigger.yml) it fetches Formula/podspine.rb from the public main repo and
-# commits it here if it changed. Auth-free: reads a public raw file over TLS, pushes with
-# this repo's own GITHUB_TOKEN.
+# The canonical podspine formula lives in the main repo (schubydoo/podspine),
+# where packaging-bump.yml regenerates its version/url/hash on every release.
+# This tap only mirrors that file: on a schedule (and on demand, dispatched by
+# the main repo's tap-sync-trigger.yml), it fetches Formula/podspine.rb from
+# the public main repo and commits it here when it changed. Auth-free: it
+# reads a public raw file over TLS and pushes with this repo's own
+# GITHUB_TOKEN.
 name: Sync formula from podspine
 
 on:
@@ -36,13 +37,15 @@ jobs:
         run: |
           set -euo pipefail
           tmp="$(mktemp)"
-          # Soft no-op if the source isn't fetchable yet (not on main, transient blip):
-          # keep the current valid formula and retry next run.
+          # A soft no-op when the source is not fetchable yet (not on main,
+          # or a transient blip): keep the current valid formula and retry on
+          # the next run.
           if ! curl -fsSL "$SRC" -o "$tmp"; then
             echo "::notice::could not fetch $SRC (not on main yet?) — skipping this run"
             exit 0
           fi
-          # Fail closed if the fetch returned a non-formula (e.g. a 200 error page).
+          # Fail closed when the fetch returned a non-formula (e.g. a 200
+          # error page).
           if ! grep -q '^class Podspine < Formula' "$tmp"; then
             echo "::error::fetched content is not the podspine formula"
             exit 1

--- a/packaging/downstream/sync-manifest.yml
+++ b/packaging/downstream/sync-manifest.yml
@@ -1,10 +1,11 @@
 # INSTALL THIS INTO the schubydoo/scoop-podspine repo at
 # .github/workflows/sync-manifest.yml  (it does NOT run from the main podspine repo).
 #
-# The canonical Scoop manifest lives in the main repo (schubydoo/podspine) at
-# packaging/scoop/podspine.json, regenerated on every release by packaging-bump.yml.
-# This bucket mirrors it to bucket/podspine.json so `scoop bucket add podspine
-# https://github.com/schubydoo/scoop-podspine; scoop install podspine` works. Auth-free.
+# The canonical Scoop manifest lives in the main repo (schubydoo/podspine)
+# at packaging/scoop/podspine.json; packaging-bump.yml regenerates it on
+# every release. This bucket mirrors it to bucket/podspine.json, so that
+# `scoop bucket add podspine https://github.com/schubydoo/scoop-podspine;
+# scoop install podspine` works. Auth-free.
 name: Sync manifest from podspine
 
 on:
@@ -38,7 +39,8 @@ jobs:
             echo "::notice::could not fetch $SRC (not on main yet?) — skipping this run"
             exit 0
           fi
-          # Fail closed unless it parses as JSON with a version (never commit garbage).
+          # Fail closed unless it parses as JSON with a version (never commit
+          # garbage).
           if ! python3 -c "import json,sys; d=json.load(open('$tmp')); sys.exit(0 if d.get('version') else 1)"; then
             echo "::error::fetched content is not a valid podspine Scoop manifest"
             exit 1

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -1,19 +1,20 @@
 #!/usr/bin/env bash
-# Podspine performance harness (Task 5.3 — measurement half).
+# Podspine performance harness (Task 5.3, the measurement half).
 #
-# Measures the four v2 NFR targets (PRD §5.1, tad.md §5) against a synthetic
-# book on THIS machine, so you can decide whether the v2 efficiency work
-# (on-the-fly split 5.1, transcode 5.2) is actually warranted before building it:
+# This measures the four v2 NFR targets (PRD §5.1, tad.md §5) against a
+# synthetic book on THIS machine, so you can decide whether the v2 efficiency
+# work (on-the-fly split 5.1, transcode 5.2) is warranted before you build it:
 #
 #   NFR-P1  ingest/pre-split   <=2 min per 10h book
 #   NFR-P2  feed render p95    <200 ms
 #   NFR-P3  audio TTFB (LAN)   <300 ms
 #   NFR-P4  idle RSS           <50 MB
 #
-# It is deliberately dependency-light — bash, ffmpeg, ffprobe, curl, awk, sort —
-# and touches nothing the server ships: it builds the release binary, synthesizes
-# a chapterised .m4a with ffmpeg, boots podspine against a throwaway library +
-# data dir on the loopback, drives it with curl, then tears everything down.
+# It is deliberately dependency-light (bash, ffmpeg, ffprobe, curl, awk,
+# sort), and it touches nothing the server ships. It builds the release
+# binary, synthesizes a chapterised .m4a with ffmpeg, boots podspine against
+# a throwaway library + data dir on the loopback, drives it with curl, and
+# then tears everything down.
 #
 # Numbers reflect the host it runs on (CPU, disk, filesystem). Run it on the box
 # you actually deploy to; a CI runner or dev laptop is only a rough proxy. The
@@ -47,11 +48,12 @@ for tool in ffmpeg ffprobe curl awk sort; do
   command -v "$tool" >/dev/null 2>&1 || { echo "bench: missing required tool: $tool" >&2; exit 1; }
 done
 
-# Fractional epoch seconds, portably. `date +%s.%N` is GNU-only: BSD/macOS `date`
-# has no %N and prints it literally, which would poison the ingest timing. Prefer
-# bash 5's EPOCHREALTIME builtin (handles a comma decimal separator under some
-# locales); fall back to `date +%N` when it yields real digits; else degrade to
-# whole-second resolution (old macOS bash + BSD date) rather than lie.
+# Fractional epoch seconds, portably. `date +%s.%N` is GNU-only: BSD/macOS
+# `date` has no %N and prints it literally, and that would poison the ingest
+# timing. Prefer bash 5's EPOCHREALTIME builtin (it handles a comma decimal
+# separator under some locales). Fall back to `date +%N` when it yields real
+# digits. Otherwise degrade to whole-second resolution (old macOS bash + BSD
+# date); do not lie.
 now() {
   if [ -n "${EPOCHREALTIME:-}" ]; then
     printf '%s' "${EPOCHREALTIME/,/.}"
@@ -118,8 +120,9 @@ t_start=$(now)
   --bind "127.0.0.1:${PORT}" --base-url "$BASE" >"$WORK/server.log" 2>&1 &
 SERVER_PID=$!
 
-# Poll the home grid until the book is indexed + split (a /book/ link appears).
-# Elapsed from launch to that point is the ingest (pre-split) cost.
+# Poll the home grid until the book is indexed and split (a /book/ link
+# appears). The time from launch to that point is the ingest (pre-split)
+# cost.
 SLUG=""
 for _ in $(seq 1 600); do
   if ! kill -0 "$SERVER_PID" 2>/dev/null; then
@@ -141,7 +144,8 @@ FEED_URL="$BASE/feed/${FEED_ID}.xml"
 AUDIO_URL="$BASE/audio/${FEED_ID}/1"
 
 ingest_s="$(awk -v a="$t_start" -v b="$t_ready" 'BEGIN{printf "%.2f", b-a}')"
-# Extrapolate to a 10h (36000s) book — split time is ~linear in source duration.
+# Extrapolate to a 10h (36000s) book; split time is ~linear in source
+# duration.
 ingest_10h="$(awk -v s="$ingest_s" -v d="$DURATION_SEC" 'BEGIN{printf "%.1f", s*36000/d}')"
 
 # --- feed render latency (p95) --------------------------------------------

--- a/scripts/lint_changesets.sh
+++ b/scripts/lint_changesets.sh
@@ -4,9 +4,10 @@
 #   1. Every file needs YAML front matter (opens with `---`, closes with `---`).
 #      knope parses EVERY .md in .changeset/, so a stray README.md fails the whole
 #      release with "missing front matter".
-#   2. The body (after the front matter) must be a SINGLE non-empty line. knope
-#      renders any 2nd line / paragraph as a `#### heading` block instead of a clean
-#      changelog bullet, which corrupts the release notes.
+#   2. The body (after the front matter) must be a SINGLE non-empty line.
+#      knope renders any second line or paragraph as a `#### heading` block
+#      instead of a clean changelog bullet, and that corrupts the release
+#      notes.
 # Mirrors clauster's scripts/lint_changesets.py. POSIX sh; no runtime deps.
 set -eu
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,10 +22,10 @@ async fn main() -> Result<()> {
 
     let config = Config::load().context("resolving configuration")?;
 
-    // Install the recorder (and bind its listener) before the first reconcile,
-    // so startup ingest is measured rather than silently dropped. Both failures
-    // are fatal: metrics were explicitly asked for, so a missing endpoint should
-    // surface here, not as a gap in a dashboard.
+    // Install the recorder (and bind its listener) before the first
+    // reconcile, so that the startup ingest is measured, not silently
+    // dropped. Both failures are fatal: metrics were explicitly asked for, so
+    // a missing endpoint must surface here, not as a gap in a dashboard.
     let metrics = match config.metrics_bind {
         Some(bind) => {
             let handle = podspine_metrics::install()
@@ -61,20 +61,21 @@ async fn main() -> Result<()> {
     )
     .context("canonicalizing the data dir / library root")?;
 
-    // First-run UX (issue 159): don't hold the HTTP port down behind the initial
-    // reconcile. A large first scan takes minutes to split, and anything in front
-    // of the server (a reverse proxy, a Funnel) returns 502 the whole time. Instead
-    // mark the state "scanning" and hand the initial reconcile to the watcher's
-    // background thread, which registers the filesystem watch first, runs the
-    // reconcile, then flips the state to "ready" via the callback. Until then
-    // `GET /` shows a "Scanning…" page and the capability routes answer 503 +
-    // Retry-After rather than a 502/404. A warm restart reaches ready almost
-    // immediately — the reconcile's idempotency early-returns.
+    // First-run UX (issue 159): do not hold the HTTP port down behind the
+    // initial reconcile. A large first scan takes minutes to split, and
+    // anything in front of the server (a reverse proxy, a Funnel) returns 502
+    // the whole time. Instead, mark the state "scanning" and hand the initial
+    // reconcile to the watcher's background thread. That thread registers the
+    // filesystem watch first, runs the reconcile, and then flips the state to
+    // "ready" via the callback. Until then, `GET /` shows a "Scanning…" page,
+    // and the capability routes answer 503 + Retry-After, not a 502/404. A
+    // warm restart reaches ready almost immediately: the reconcile's
+    // idempotency early-returns.
     //
-    // Watch-before-scan (not scan-before-watch): a library change that lands during
-    // the initial scan is buffered and reconciled by the watcher rather than lost
-    // until the next event or a restart. The watcher owns the only index writer, so
-    // exactly one reconciler ever runs.
+    // Watch-before-scan (not scan-before-watch): the watcher buffers and
+    // reconciles a library change that lands during the initial scan; the
+    // change is not lost until the next event or a restart. The watcher owns
+    // the only index writer, so exactly one reconciler ever runs.
     state.set_ready(false);
     {
         let state = state.clone();

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,8 @@
+# Configuration for `typos` (the Typos CI step and local runs).
+# Add a word here only when `typos` flags a term that is correct.
+
+[default.extend-words]
+# `.opf` is the Calibre/EPUB metadata sidecar extension (never a chapter source).
+opf = "opf"
+# in-toto is the supply-chain attestation format (`podspine.intoto.jsonl`).
+intoto = "intoto"

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -42,7 +42,8 @@ function Uninstall-Podspine {
     Write-Info "Removing $dest"
     Remove-Item -LiteralPath $dest -Force
 
-    # Drop the install dir from the user PATH (only the entry we added).
+    # Drop the install dir from the user PATH (only the entry that
+    # install.ps1 added).
     $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
     if ($userPath) {
         $kept = ($userPath -split ';') | Where-Object { $_ -and $_ -ne $dir }

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -6,9 +6,9 @@ set -euo pipefail
 #
 #   curl -fsSL https://raw.githubusercontent.com/schubydoo/podspine/main/uninstall.sh | bash
 #
-# Removes the `podspine` binary installed by install.sh. It does NOT touch your
-# audiobook library or any data directory you passed to `--data-dir` — delete
-# those yourself if you want them gone.
+# This removes the `podspine` binary that install.sh installed. It does NOT
+# touch your audiobook library or any data directory you passed to
+# `--data-dir`. Delete those yourself if you want them gone.
 #
 # Environment overrides:
 #   PODSPINE_INSTALL_DIR   directory to remove from; default: ~/.local/bin
@@ -30,8 +30,9 @@ have() { command -v "$1" >/dev/null 2>&1; }
 dir="${PODSPINE_INSTALL_DIR:-${HOME}/.local/bin}"
 dest="${dir}/${TOOL_NAME}"
 
-# If it isn't where we'd install it, try to find it on PATH so we can point the
-# user at whatever they actually have (e.g. a brew/cargo copy we shouldn't touch).
+# If the binary is not at the default install path, try to find it on PATH,
+# so that the message can point the user at whatever they actually have
+# (e.g. a brew/cargo copy this script must not touch).
 if [ ! -e "$dest" ]; then
     warn "No ${TOOL_NAME} binary at ${dest}."
     if found="$(command -v "$TOOL_NAME" 2>/dev/null)"; then


### PR DESCRIPTION
Rewrites every hand-written code comment in the repository to ASD-STE100 plain English, and adds the comment-lint CI the rewrite conforms to. Comments only — no code behavior changes (two test fixtures excepted, below).

## The lint setup

- **Workspace `[lints]`** in the root `Cargo.toml`, opted into by all 12 member crates: `clippy::doc_markdown` (backtick discipline), `clippy::undocumented_unsafe_blocks` (a pure future-guard — the workspace has zero `unsafe`), `rustdoc::broken_intra_doc_links = deny`, and `rustdoc::private_intra_doc_links = allow` (deliberate: the CI doc step passes `--document-private-items` because this is a binary workspace).
- **`clippy.toml`**: `doc-valid-idents` extends the defaults with DoS, SQLite, OverDrive.
- **`typos.toml`** + a SHA-pinned `crate-ci/typos` step in `ci.yml` (allowlisted: `opf`, the Calibre sidecar extension; `intoto`, the SLSA provenance format).
- **`ci.yml`**: the lint job (now `fmt · clippy · docs · typos`) gains the Typos step and a `cargo doc -D warnings --document-private-items` step — the only place `rustdoc::` lints fire.

## The rewrite

All 22 Rust files (~2,900 comment lines) plus the workflows, scripts, manifests, and misc configs (~450 more): active voice, one statement per sentence, expanded fragments and arrow-chains, backticked identifiers. Every qualifier in the load-bearing contract comments (ffmpeg `-ss`/`-t` invariants, thumbnail/cover atomicity, the sweep-timing window) is preserved. Tool-generated `.serena/` configs were left alone.

## Doc rot fixed along the way

- Three broken intra-doc links in `crates/http` (one pointed at the pre-rename `resolve_audio_path`).
- Four glued/misplaced doc blocks: `scan_library`'s summary was stuck on `collapse_duplicate_source_rows`, `assign_slug` had a doubled summary, `book_is_transcoded` carried `AudioTarget`'s and `book_is_saver`'s summaries, `ext_lower` had a stray line.
- Stale claims that contradicted the code: `assign_slug`'s "a row whose source no longer exists is fair game" (describes the pre-Greptile behavior the guard reverted), `discover`'s "one level under" (the walk is recursive), an in-place-serving comment counting "three guards" that lists two, `knope-prepare.yml`'s Conventional-Commit-driven header (changesets model), `installer-smoke.yml`'s "ships in this PR" anchoring, the codecov baseline naming the deleted `cli` crate, and a shell-quoting artifact (`'"'"'`) in a scanner doc.
- `unparseable` → `unparsable` (5 sites, incl. one error-message string and one docs page).

## The one non-comment change

Two tests use a deliberately misspelled sidecar key (`stroage_mode`) to exercise the unknown-key error path; the spell-checker flags it. They now use `storage_modes` — still an unknown key, same test semantics, typos-clean.

## Verified

`cargo fmt --check` · `cargo clippy --workspace --all-targets --all-features -D warnings` (new lints active) · `RUSTDOCFLAGS=-D warnings cargo doc --document-private-items` · `typos` · full test suite (289 passed, exit code checked under pipefail) · YAML/TOML parse checks on every edited config · `bash -n` on the shell scripts. Rebased onto [PR 186](https://github.com/schubydoo/podspine/pull/186)'s merge.

Internal-only (comments + CI), so `no-changelog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)