### PR TITLE
fix(docker): upgrade base packages so openssl is patched

### DIFF
--- a/.changeset/openssl-base-upgrade.md
+++ b/.changeset/openssl-base-upgrade.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+The Docker image now runs `apk upgrade` before installing runtime dependencies, so openssl (libcrypto3/libssl3) and other base packages get the patched release from the Alpine branch instead of the older version frozen in the pinned base image

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,13 @@
 # debian's full ffmpeg).
 FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 
+# Upgrade the base packages first. openssl (libcrypto3/libssl3) ships inside the
+# base image, so `apk add` alone keeps the digest-pinned version and never picks
+# up a patched release from the branch. `apk upgrade` floats the base to the
+# current v3.24 packages, which closes base CVEs (openssl and others) on rebuild.
 # ffmpeg is the one runtime dependency; ca-certificates for outbound TLS if needed.
-RUN apk add --no-cache ffmpeg ca-certificates
+RUN apk upgrade --no-cache \
+ && apk add --no-cache ffmpeg ca-certificates
 
 # A non-root system user. Own /data before VOLUME, so that the anonymous
 # volume Docker creates at runtime inherits podspine ownership (otherwise it


### PR DESCRIPTION
## Problem

The code-scanning openssl alerts (CVE-2026-14456 et al., fixed in `3.5.8-r0`) persisted even on a freshly built nightly image.

**Root cause:** `libcrypto3`/`libssl3` ship *inside* the base Alpine image (busybox's `ssl_client` depends on them). The pinned base digest freezes them at `3.5.7-r0`:

```
$ docker run --rm alpine@sha256:28bd5fe8... apk info -v | grep -iE 'libcrypto|libssl'
libcrypto3-3.5.7-r0
libssl3-3.5.7-r0
```

`RUN apk add --no-cache ffmpeg ca-certificates` finds the openssl dependency already satisfied, so it never upgrades it. Every rebuild bakes in `3.5.7-r0` no matter what the v3.24 branch publishes. Rebuilding only helps *newly installed* packages, not base-frozen ones.

## Fix

Run `apk upgrade --no-cache` before installing runtime deps, so the base floats to the current v3.24 packages. Verified against the exact pinned digest:

```
$ docker run --rm alpine@sha256:28bd5fe8... sh -c 'apk upgrade --no-cache >/dev/null && apk info -v | grep -iE "libcrypto|libssl"'
libcrypto3-3.5.8-r0
libssl3-3.5.8-r0
```

This closes the openssl CVEs and self-heals future base CVEs (busybox, zlib, etc.) on each rebuild.

## Notes

- The `FROM` digest stays pinned, so Scorecard Pinned-Dependencies is unaffected.
- Trade-off: the image is no longer bit-reproducible from the digest alone — base packages float to build-time latest. Correct direction for a security-sensitive image on a rebuild cadence.
- Patch changeset included; fold into the next release to move `:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)