### PR TITLE
docs: split shared guidance into AGENTS.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,7 @@
 /tad.md
 /tasks.md
 
-# Agent config (normally committed; kept local while planning skills run)
-/CLAUDE.md
+# Local agent tooling + host notes (not part of the public repo)
 /.claude/
 /.worktreeinclude
 /CLAUDE.local.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,13 @@
 # Podspine
 
-Self-hosted server that turns audiobook files into per-chapter podcast RSS feeds any podcatcher can play. Rust/Axum, shells out to ffmpeg/ffprobe, AGPL-3.0. **Pre-code stage** — planning is done, no source scaffolded yet.
+Self-hosted server that turns audiobook files into per-chapter podcast RSS feeds any podcatcher can play. Rust/Axum, shells out to ffmpeg/ffprobe, AGPL-3.0. Released and feature-complete.
 
 ## Critical commands
 Rust workspace:
 - Build `cargo build` · Test `cargo test` · Lint `cargo clippy -- -D warnings` · Format `cargo fmt`
-- Run locally: `cargo run -- --library ./sample-books` → http://localhost:8080
+- Run locally: `cargo run -- --library /path/to/audiobooks` → http://localhost:8080 (point `--library` at a real audiobook directory)
 - Release binary: `cargo build --release --target x86_64-unknown-linux-musl`
-- Container: `docker run -v /books:/library -p 8080:8080 podspine`
+- Container: `docker run -v /books:/library -p 8080:8080 ghcr.io/schubydoo/podspine`
 - `ffmpeg`/`ffprobe` must be on PATH (bundled in the Docker image).
 
 ## Architecture map
@@ -22,12 +22,12 @@ Cargo workspace, one crate per pipeline stage: `scanner` (watch/classify by form
 - `guid = blake3(book.id : idx : source_mtime)` — keeps episodes stable across rescans.
 - **NEVER add DRM circumvention** (Audible AAX/AAXC/.aa, OverDrive, WMA-DRM); DRM-free input only. Keep ffmpeg out-of-process (GPL boundary).
 - FLAC: prefer a `.cue` sidecar (embedded FLAC chapters lack titles).
-- License is AGPL-3.0 — add a `LICENSE` file when scaffolding.
+- License is AGPL-3.0.
 
 ## Workflow preferences
 - Minimal diffs for small fixes; don't rewrite a file for a one-line change.
-- Milestone-based, no deadlines. Prove the hardest piece first — correct M4B split + sequential pubDates (Sprint 1) — before server work.
+- The correctness invariants above (sequential pubDates, exact enclosure length, safe ffmpeg argv) are load-bearing — never regress them.
 - Default and PR target branch is `main`.
 
 ## What NOT to include here
-Crate versions and design rationale live in the local design docs — don't duplicate. Don't restate standard Rust conventions (clippy/fmt enforce them).
+Crate/dependency versions live in `Cargo.toml` — don't duplicate them here. Don't restate standard Rust conventions (clippy/fmt enforce them).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# Podspine
+
+Self-hosted server that turns audiobook files into per-chapter podcast RSS feeds any podcatcher can play. Rust/Axum, shells out to ffmpeg/ffprobe, AGPL-3.0. **Pre-code stage** — planning is done, no source scaffolded yet.
+
+## Critical commands
+Rust workspace:
+- Build `cargo build` · Test `cargo test` · Lint `cargo clippy -- -D warnings` · Format `cargo fmt`
+- Run locally: `cargo run -- --library ./sample-books` → http://localhost:8080
+- Release binary: `cargo build --release --target x86_64-unknown-linux-musl`
+- Container: `docker run -v /books:/library -p 8080:8080 podspine`
+- `ffmpeg`/`ffprobe` must be on PATH (bundled in the Docker image).
+
+## Architecture map
+Cargo workspace, one crate per pipeline stage: `scanner` (watch/classify by format tier) → `prober` (ffprobe) / `chapters` (sidecar-vs-embedded resolution) → `splitter` (ffmpeg) → `index` (rusqlite, bundled) → `feed` (rss 2.1 + itunes/podcast ns) → `http` (axum; Range via axum-range) + `ui` (maud) + `config`. Pre-split at ingest (v1); flat filesystem for audio + SQLite index.
+
+## Hard rules
+- **YOU MUST** make feed pubDates sequential, oldest = chapter 1 (else episodes play out of order — the #1 bug). Always emit `itunes:episode`, `itunes:duration`, and `enclosure length`.
+- **enclosure `length` = real output file size** (`fs::metadata().len()`), NEVER prorated from bitrate.
+- ffmpeg split: `-ss <start>` BEFORE `-i`, `-t <duration>` (NEVER `-to` after `-i` — makes a 2× file), plus `-map 0:a:0 -map_chapters -1 -c copy -movflags +faststart`.
+- **Pass ffmpeg args as an argv vector, NEVER a shell string** — chapter titles are untrusted (command injection).
+- Treat book/chapter ids as opaque index keys; canonicalize and assert the path stays under the library root; 404 on reject. NEVER `format!("{root}/{user_input}")`.
+- `guid = blake3(book.id : idx : source_mtime)` — keeps episodes stable across rescans.
+- **NEVER add DRM circumvention** (Audible AAX/AAXC/.aa, OverDrive, WMA-DRM); DRM-free input only. Keep ffmpeg out-of-process (GPL boundary).
+- FLAC: prefer a `.cue` sidecar (embedded FLAC chapters lack titles).
+- License is AGPL-3.0 — add a `LICENSE` file when scaffolding.
+
+## Workflow preferences
+- Minimal diffs for small fixes; don't rewrite a file for a one-line change.
+- Milestone-based, no deadlines. Prove the hardest piece first — correct M4B split + sequential pubDates (Sprint 1) — before server work.
+- Default and PR target branch is `main`.
+
+## What NOT to include here
+Crate versions and design rationale live in the local design docs — don't duplicate. Don't restate standard Rust conventions (clippy/fmt enforce them).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,16 @@
+# CLAUDE.md
+
+**The shared agent instructions for this repo live in [AGENTS.md](AGENTS.md). The `@`
+line below imports it, so it loads with this file — you don't need to open it separately.**
+
+@AGENTS.md
+
+⚠️ **That `@AGENTS.md` line is load-bearing — do not "tidy" it into a plain link.**
+Claude Code reads `CLAUDE.md`, not `AGENTS.md`; a markdown link is a suggestion an agent
+may or may not follow, while `@` is an import expanded into context at launch. `@` is inert
+inside backticks or code fences, so `` `@AGENTS.md` `` in prose does NOT import.
+
+---
+
+`CLAUDE.local.md` is gitignored and loads *after* this file — host-specific paths, the
+local planning docs, and personal tooling notes belong there, not here.


### PR DESCRIPTION
Public AGENTS.md (project guide) + thin CLAUDE.md that `@`-imports it; local planning-doc refs moved to gitignored CLAUDE.local.md.