### PR TITLE
fix(ci): tolerate an unreachable fuzz corpus, adopt $/ self-repository refs

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,20 @@
+# actionlint configuration.
+#
+# The ignore below exists because actionlint (≤ v1.7.12, the latest as of
+# 2026-09-01) does not yet understand GitHub's `$/` self-repository `uses:`
+# syntax (July 2026) and reports it as an invalid action reference. The syntax
+# is deliberate — it is immune to runtime filesystem substitution and GitHub
+# treats it as pinned — so this one message shape is suppressed rather than the
+# migration reverted. zizmor's `self-repository` audit asks for it.
+#
+# ⚠️ Suppressing the format error also silences actionlint's local-action call
+# checks for the `$/` sites (input-name typos, missing required inputs) — those
+# are gated on the `./` prefix internally. `setup-ffmpeg`, the only local action
+# here, is called with no inputs at all three sites, so nothing is forfeited
+# today; give the action inputs and this loses real coverage.
+#
+# ⚠️ Remove this file once rhysd/actionlint issue 711 ships `$/` support.
+paths:
+  .github/workflows/**/*.{yaml,yml}:
+    ignore:
+      - 'specifying action "\$/.+" in invalid format because ref is missing'

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -8,9 +8,11 @@
 # fuzzes, and pushes the grown corpus back, so coverage compounds across
 # runs. This needs a `schubydoo/podspine-fuzz-corpus` repo and a
 # `FUZZ_STORAGE_TOKEN` PAT (write); see the publish checklist. The PR job
-# deliberately carries no such secret. If the secret is unset, the job still
-# runs (it fuzzes from seed); it only does not accumulate. `fuzz-seconds` is
-# PER target, so wall-clock ≈ fuzz-seconds × harness count + build.
+# deliberately carries no such secret. A probe step tests the corpus repo
+# first: if the secret is unset, or the token no longer authenticates, the job
+# fuzzes from seed and does not accumulate, but it still runs and still finds
+# crashes. `fuzz-seconds` is PER target, so wall-clock ≈ fuzz-seconds ×
+# harness count + build.
 # Docs: https://google.github.io/clusterfuzzlite/
 name: ClusterFuzzLite batch fuzzing
 
@@ -37,6 +39,34 @@ jobs:
       matrix:
         sanitizer: [address]
     steps:
+      # ClusterFuzzLite clones storage-repo BEFORE it fuzzes, and a clone that
+      # it cannot authenticate raises and reds the whole job — on 2026-09-01
+      # this lost 300s × 3 harnesses of crash detection to a corpus-only
+      # problem. Probe the repo first and give an empty storage-repo when the
+      # probe fails: CIFuzz then keeps the GitHub Actions filestore
+      # (filestore_utils.get_filestore returns early on a falsy
+      # git_store_repo) and fuzzes from seed. git's own error stays in the log
+      # for diagnosis; Actions masks the token in it.
+      - name: Probe the corpus storage repo
+        id: corpus
+        env:
+          FUZZ_STORAGE_TOKEN: ${{ secrets.FUZZ_STORAGE_TOKEN }}
+        run: |
+          set -uo pipefail
+          reachable=false
+          if [ -z "${FUZZ_STORAGE_TOKEN}" ]; then
+            cause="FUZZ_STORAGE_TOKEN is not set"
+          elif GIT_TERMINAL_PROMPT=0 git ls-remote \
+            "https://x-access-token:${FUZZ_STORAGE_TOKEN}@github.com/schubydoo/podspine-fuzz-corpus.git" \
+            HEAD >/dev/null; then
+            reachable=true
+          else
+            cause="the corpus repo refused the token (git's error is above)"
+          fi
+          if [ "${reachable}" = false ]; then
+            echo "::warning::Corpus persistence is off: ${cause}. This run fuzzes from seed and does not keep the corpus."
+          fi
+          echo "reachable=${reachable}" >> "${GITHUB_OUTPUT}"
       - name: Build fuzzers (${{ matrix.sanitizer }})
         uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
@@ -51,5 +81,9 @@ jobs:
           mode: batch
           sanitizer: ${{ matrix.sanitizer }}
           output-sarif: true
-          storage-repo: https://${{ secrets.FUZZ_STORAGE_TOKEN }}@github.com/schubydoo/podspine-fuzz-corpus.git
+          # Empty when the probe failed. The `x-access-token:` user is the
+          # supported credential shape; a bare `https://TOKEN@github.com` puts
+          # the token in the user field with no password, which git can only
+          # complete by a prompt it does not have in CI.
+          storage-repo: ${{ steps.corpus.outputs.reachable == 'true' && format('https://x-access-token:{0}@github.com/schubydoo/podspine-fuzz-corpus.git', secrets.FUZZ_STORAGE_TOKEN) || '' }}
           storage-repo-branch: main

--- a/.github/workflows/cflite_cron.yml
+++ b/.github/workflows/cflite_cron.yml
@@ -3,8 +3,11 @@
 # inputs that add no coverage). Coverage replays the whole corpus and pushes
 # an HTML line-coverage report to the corpus repo's gh-pages branch, which
 # shows exactly which parser code the fuzzers reach (0% means a harness is
-# owed). Both reuse the storage-repo + FUZZ_STORAGE_TOKEN. NOT required
-# checks. Docs: https://google.github.io/clusterfuzzlite/
+# owed). Both reuse the storage-repo + FUZZ_STORAGE_TOKEN. Neither has work
+# to do without the corpus, so a shared `probe` job tests the storage repo
+# first and both jobs skip (green, with a warning) when it does not answer —
+# see cflite_batch.yml for why the probe exists. NOT required checks.
+# Docs: https://google.github.io/clusterfuzzlite/
 name: ClusterFuzzLite cron (prune + coverage)
 
 on:
@@ -15,8 +18,45 @@ on:
 permissions: {}
 
 jobs:
+  # One probe for both jobs below. It runs as its own job so that a corpus
+  # that does not answer shows as two skipped jobs, not as a red run: an
+  # unauthenticated clone raises inside ClusterFuzzLite and reds the job.
+  # git's own error stays in the log for diagnosis; Actions masks the token.
+  probe:
+    name: probe the corpus repo
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    concurrency:
+      group: ${{ github.workflow }}-probe
+      cancel-in-progress: true
+    outputs:
+      reachable: ${{ steps.corpus.outputs.reachable }}
+    steps:
+      - name: Probe the corpus storage repo
+        id: corpus
+        env:
+          FUZZ_STORAGE_TOKEN: ${{ secrets.FUZZ_STORAGE_TOKEN }}
+        run: |
+          set -uo pipefail
+          reachable=false
+          if [ -z "${FUZZ_STORAGE_TOKEN}" ]; then
+            cause="FUZZ_STORAGE_TOKEN is not set"
+          elif GIT_TERMINAL_PROMPT=0 git ls-remote \
+            "https://x-access-token:${FUZZ_STORAGE_TOKEN}@github.com/schubydoo/podspine-fuzz-corpus.git" \
+            HEAD >/dev/null; then
+            reachable=true
+          else
+            cause="the corpus repo refused the token (git's error is above)"
+          fi
+          if [ "${reachable}" = false ]; then
+            echo "::warning::Prune and coverage are skipped: ${cause}. There is no corpus to work on."
+          fi
+          echo "reachable=${reachable}" >> "${GITHUB_OUTPUT}"
+
   prune:
     name: prune corpus
+    needs: probe
+    if: needs.probe.outputs.reachable == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 55
     permissions:
@@ -40,11 +80,13 @@ jobs:
           mode: prune
           sanitizer: address
           output-sarif: true
-          storage-repo: https://${{ secrets.FUZZ_STORAGE_TOKEN }}@github.com/schubydoo/podspine-fuzz-corpus.git
+          storage-repo: https://x-access-token:${{ secrets.FUZZ_STORAGE_TOKEN }}@github.com/schubydoo/podspine-fuzz-corpus.git
           storage-repo-branch: main
 
   coverage:
     name: coverage report
+    needs: probe
+    if: needs.probe.outputs.reachable == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -66,6 +108,6 @@ jobs:
           fuzz-seconds: 300
           mode: coverage
           sanitizer: coverage
-          storage-repo: https://${{ secrets.FUZZ_STORAGE_TOKEN }}@github.com/schubydoo/podspine-fuzz-corpus.git
+          storage-repo: https://x-access-token:${{ secrets.FUZZ_STORAGE_TOKEN }}@github.com/schubydoo/podspine-fuzz-corpus.git
           storage-repo-branch: main
           storage-repo-branch-coverage: gh-pages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       # that pulls the whole libav* tree); see .github/actions/setup-ffmpeg
       # for the why.
       - name: Set up ffmpeg
-        uses: ./.github/actions/setup-ffmpeg
+        uses: $/.github/actions/setup-ffmpeg
       # nextest instead of `cargo test`: same tests, same gate (non-zero exit
       # on failure), but a junit.xml falls out (.config/nextest.toml `ci`
       # profile): the only format Codecov's Test Analytics ingests. Prebuilt
@@ -126,7 +126,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Set up ffmpeg
-        uses: ./.github/actions/setup-ffmpeg
+        uses: $/.github/actions/setup-ffmpeg
       - uses: taiki-e/install-action@1ed6d7be6168f6c9046541087ff549b6bc581fdf # v2.87.2
         with:
           tool: cargo-nextest
@@ -168,7 +168,7 @@ jobs:
         with:
           tool: cargo-llvm-cov
       - name: Set up ffmpeg
-        uses: ./.github/actions/setup-ffmpeg
+        uses: $/.github/actions/setup-ffmpeg
       # Enforce the line floor (the real gate; the baseline is ~94%) and emit
       # lcov. cargo-llvm-cov writes lcov.info before the threshold check, so
       # the upload below still runs on a floor failure, and a drop surfaces


### PR DESCRIPTION
Three CI changes, in two commits.

## 1. A corpus problem no longer costs a fuzzing run

ClusterFuzzLite clones `storage-repo` **before** it fuzzes, and a clone it cannot authenticate raises inside CIFuzz and reds the whole job. In [run 33492617354](https://github.com/schubydoo/podspine/actions/runs/33492617354) (2026-09-01) the fuzzers built, all three targets passed the bad-build check, and then the job died on the corpus clone — 300s × 3 harnesses of crash detection lost to a problem that has nothing to do with the code under test.

Each workflow now probes the corpus repo with `git ls-remote` first:

- **`cflite_batch`** gives `run_fuzzers` an **empty** `storage-repo` when the probe fails. `filestore_utils.get_filestore` returns the GitHub Actions filestore on a falsy `git_store_repo` ([source](https://github.com/google/oss-fuzz/blob/master/infra/cifuzz/filestore_utils.py)), so the job fuzzes from seed and still finds crashes; it only stops accumulating. This is what the workflow header always claimed happened with an unset secret, and never did.
- **`cflite_cron`** has nothing to prune and nothing to report on without the corpus, so a shared `probe` job gates both jobs and they skip green.

Both paths emit a warning annotation naming the cause, and git's own error stays in the log (Actions masks the token in it).

**Probe script verified by execution**, not inference — three cases, against the real corpus repo:

| token | git output | step exit | output |
|---|---|---|---|
| valid | — | 0 | `reachable=true` |
| invalid | `remote: Invalid username or token…` | 0 | `reachable=false` |
| empty | — | 0 | `reachable=false` |

### The credential shape also changes

`https://${TOKEN}@github.com/…` → `https://x-access-token:${TOKEN}@github.com/…` at all three sites.

The bare form puts the token in the URL's *user* field with no password. Git can only complete that with a prompt it does not have in CI, which is why the failure read `fatal: could not read Password for 'https://***@github.com'` rather than naming an auth error. With `x-access-token:`, a bad token reports `remote: Invalid username or token` instead (see the table above) — the next such failure will say what is actually wrong.

⚠️ **This is not confirmed as the root cause.** The token has no expiry and still carries Contents: read+write on the corpus repo, and the identical config succeeded on 2026-08-31 (run 33384962213) with nothing changed in between. What is proven: form A works with a valid token, so whatever CI presented was not accepted. If the corpus stays unreachable after this merges, the probe's warning will name the reason.

## 2. zizmor `self-repository` — alerts 117, 118, 119 (note)

The three step-level `./.github/actions/setup-ffmpeg` refs in `ci.yml` move to GitHub's `$/` self-repository syntax: immune to runtime filesystem substitution, treated as pinned. They are the only local action refs in this repo — there is no job-level reusable-workflow call to leave alone, as there was in [clauster PR 1360](https://github.com/schubydoo/clauster/pull/1360).

## 3. `.github/actionlint.yaml`

actionlint (v1.7.12, the latest today) does not know `$/` yet and calls it an invalid action reference, so the config suppresses exactly that one message shape and documents when to delete it (rhysd/actionlint issue 711).

⚠️ The suppression also disables actionlint's local-action input checks for those sites — clauster moved that coverage into a test. Here it costs nothing today: `setup-ffmpeg` declares no inputs and is called bare at all three sites. The config says so, and says what changes if the action ever gains inputs. Note podspine does not run actionlint in CI, so this file serves local and editor runs.

## Verification

- `zizmor 1.30.0` regular persona (what `security.yml` runs): **no findings repo-wide**, down from 3 `self-repository`.
- `zizmor --pedantic` on both cflite workflows: 2 low, unchanged from the pre-change baseline (the new `probe` job carries its own concurrency group).
- `actionlint` clean on all three workflows with the config; without it, exactly the 3 expected format errors — so the ignore is load-bearing, not decorative.
- `typos` clean; pre-commit hooks passed on both commits.
- Not run: the workflows themselves. `cflite_batch` is schedule/dispatch only, so the first real exercise is a manual dispatch after merge.

## Next step after merge

Dispatch `ClusterFuzzLite batch fuzzing` and read the corpus probe step: it either persists the corpus, or names why it cannot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)