### PR TITLE
chore(ci): use actions-rust-lang/setup-rust-toolchain for toolchain + cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       # False positives go in `typos.toml` at the repository root.
       - name: Typos
         uses: crate-ci/typos@d43b6c087ac471e2ea7b8af622ff15f05c0c365b # v1.50.1
-      - uses: actions-rust-lang/setup-rust-toolchain@1fbea72663f6d4c03efaab13560c8a24cfd2a7cc # v1.9.0
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           components: rustfmt, clippy
           # Built-in caching (Swatinem/rust-cache under the hood) replaces the
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions-rust-lang/setup-rust-toolchain@1fbea72663f6d4c03efaab13560c8a24cfd2a7cc # v1.9.0
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           # rustflags: "" keeps the action from forcing `-D warnings` on cargo
           # build/test; built-in caching replaces the Swatinem step.
@@ -130,7 +130,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions-rust-lang/setup-rust-toolchain@1fbea72663f6d4c03efaab13560c8a24cfd2a7cc # v1.9.0
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           # rustflags: "" keeps the action from forcing `-D warnings` on cargo
           # build/test; built-in caching replaces the Swatinem step.
@@ -170,7 +170,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions-rust-lang/setup-rust-toolchain@1fbea72663f6d4c03efaab13560c8a24cfd2a7cc # v1.9.0
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           components: llvm-tools-preview
           # Built-in caching replaces the Swatinem step; rustflags: "" keeps the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,14 @@ jobs:
       # False positives go in `typos.toml` at the repository root.
       - name: Typos
         uses: crate-ci/typos@d43b6c087ac471e2ea7b8af622ff15f05c0c365b # v1.50.1
-      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+      - uses: actions-rust-lang/setup-rust-toolchain@1fbea72663f6d4c03efaab13560c8a24cfd2a7cc # v1.9.0
         with:
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+          # Built-in caching (Swatinem/rust-cache under the hood) replaces the
+          # standalone step. Empty rustflags: the action defaults RUSTFLAGS to
+          # `-D warnings` for the whole job; clippy/rustdoc already deny warnings
+          # explicitly, and forcing it on every cargo build is not wanted here.
+          rustflags: ""
       - name: Format
         run: cargo fmt --all --check
       - name: Clippy (deny warnings)
@@ -63,8 +67,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - uses: actions-rust-lang/setup-rust-toolchain@1fbea72663f6d4c03efaab13560c8a24cfd2a7cc # v1.9.0
+        with:
+          # rustflags: "" keeps the action from forcing `-D warnings` on cargo
+          # build/test; built-in caching replaces the Swatinem step.
+          rustflags: ""
       # Real ffmpeg, from a cached static build on Linux (seconds, vs. apt
       # that pulls the whole libav* tree); see .github/actions/setup-ffmpeg
       # for the why.
@@ -123,8 +130,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - uses: actions-rust-lang/setup-rust-toolchain@1fbea72663f6d4c03efaab13560c8a24cfd2a7cc # v1.9.0
+        with:
+          # rustflags: "" keeps the action from forcing `-D warnings` on cargo
+          # build/test; built-in caching replaces the Swatinem step.
+          rustflags: ""
       - name: Set up ffmpeg
         uses: $/.github/actions/setup-ffmpeg
       - uses: taiki-e/install-action@7b8d4719ee4aaa279bdf55df38dacb9ebfe12a6c # v2.87.6
@@ -160,10 +170,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+      - uses: actions-rust-lang/setup-rust-toolchain@1fbea72663f6d4c03efaab13560c8a24cfd2a7cc # v1.9.0
         with:
           components: llvm-tools-preview
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+          # Built-in caching replaces the Swatinem step; rustflags: "" keeps the
+          # action from forcing `-D warnings` on the coverage build.
+          rustflags: ""
       - uses: taiki-e/install-action@7b8d4719ee4aaa279bdf55df38dacb9ebfe12a6c # v2.87.6
         with:
           tool: cargo-llvm-cov

--- a/.github/workflows/knope-prepare.yml
+++ b/.github/workflows/knope-prepare.yml
@@ -77,7 +77,7 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
           persist-credentials: true
-      - uses: actions-rust-lang/setup-rust-toolchain@1fbea72663f6d4c03efaab13560c8a24cfd2a7cc # v1.9.0
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         if: ${{ steps.changesets.outputs.has == 'true' }}
         with:
           # No Actions cache (matches the prior setup, which had none); rustflags:

--- a/.github/workflows/knope-prepare.yml
+++ b/.github/workflows/knope-prepare.yml
@@ -77,8 +77,13 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
           persist-credentials: true
-      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+      - uses: actions-rust-lang/setup-rust-toolchain@1fbea72663f6d4c03efaab13560c8a24cfd2a7cc # v1.9.0
         if: ${{ steps.changesets.outputs.has == 'true' }}
+        with:
+          # No Actions cache (matches the prior setup, which had none); rustflags:
+          # "" keeps the action from forcing `-D warnings`.
+          cache: false
+          rustflags: ""
       - name: Configure git identity (podspine-ci App)
         if: ${{ steps.changesets.outputs.has == 'true' }}
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -57,9 +57,14 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+      - uses: actions-rust-lang/setup-rust-toolchain@1fbea72663f6d4c03efaab13560c8a24cfd2a7cc # v1.9.0
         with:
-          targets: ${{ matrix.target }}
+          target: ${{ matrix.target }}
+          # No Actions cache: caching in an artifact-publishing workflow is a
+          # cache-poisoning vector (matching the prior setup and release.yml).
+          # rustflags: "" avoids forcing `-D warnings` on the build.
+          cache: false
+          rustflags: ""
       # zig is the cross linker for the musl targets (incl. rusqlite's bundled
       # SQLite C). No Actions cache: caching in an artifact-publishing workflow is a
       # cache-poisoning vector (zizmor cache-poisoning), matching release.yml.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions-rust-lang/setup-rust-toolchain@1fbea72663f6d4c03efaab13560c8a24cfd2a7cc # v1.9.0
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           target: ${{ matrix.target }}
           # No Actions cache: caching in an artifact-publishing workflow is a

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,9 +72,14 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+      - uses: actions-rust-lang/setup-rust-toolchain@1fbea72663f6d4c03efaab13560c8a24cfd2a7cc # v1.9.0
         with:
-          targets: ${{ matrix.target }}
+          target: ${{ matrix.target }}
+          # No Actions cache in this signed-release build (cache-poisoning vector
+          # in an artifact-publishing workflow, matching the prior setup and the
+          # setup-zig step below). rustflags: "" avoids forcing `-D warnings`.
+          cache: false
+          rustflags: ""
       # zig is the cross linker for the musl targets only (incl. rusqlite's bundled
       # SQLite C). mlugg/setup-zig is the maintained successor to the abandoned
       # goto-bus-stop/setup-zig.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions-rust-lang/setup-rust-toolchain@1fbea72663f6d4c03efaab13560c8a24cfd2a7cc # v1.9.0
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           target: ${{ matrix.target }}
           # No Actions cache in this signed-release build (cache-poisoning vector

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -78,7 +78,7 @@ jobs:
       # build the amd64 static musl binary first. This is single-arch on an
       # amd64 runner, so plain musl-gcc (it links rusqlite's bundled SQLite C)
       # is enough; no cross toolchain is needed.
-      - uses: actions-rust-lang/setup-rust-toolchain@1fbea72663f6d4c03efaab13560c8a24cfd2a7cc # v1.9.0
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           target: x86_64-unknown-linux-musl
           # No Actions cache here (matches the prior setup, which had none) and

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -78,9 +78,13 @@ jobs:
       # build the amd64 static musl binary first. This is single-arch on an
       # amd64 runner, so plain musl-gcc (it links rusqlite's bundled SQLite C)
       # is enough; no cross toolchain is needed.
-      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+      - uses: actions-rust-lang/setup-rust-toolchain@1fbea72663f6d4c03efaab13560c8a24cfd2a7cc # v1.9.0
         with:
-          targets: x86_64-unknown-linux-musl
+          target: x86_64-unknown-linux-musl
+          # No Actions cache here (matches the prior setup, which had none) and
+          # rustflags: "" keeps the action from forcing `-D warnings` on the build.
+          cache: false
+          rustflags: ""
       - name: Install musl toolchain
         run: sudo apt-get update && sudo apt-get install -y musl-tools
       - name: Build static amd64 binary


### PR DESCRIPTION
Switches every Rust toolchain step to `actions-rust-lang/setup-rust-toolchain@1fbea72` (v1.9.0), which installs the toolchain and caches in one action, and drops the two standalone `Swatinem/rust-cache` steps in `ci.yml`.

## What changed
- `ci.yml` (lint, test, test-windows, coverage), `security.yml`, `release.yml`, `nightly.yml`, `knope-prepare.yml`.
- `rustflags: ""` on every use. The new action defaults `RUSTFLAGS` to `-D warnings` for the whole job; this repo denies warnings only in clippy and rustdoc, so the empty value preserves current build/test behavior.
- `cache: false` on the release, nightly, security, and knope jobs to keep their prior no-cache behavior (cache-poisoning surface in the artifact-publishing flows; the others had no cache before). Built-in caching replaces `Swatinem/rust-cache` only in the CI lint/test/coverage jobs, where a cache already existed.
- The action reads `rust-toolchain.toml` (channel stable, rustfmt+clippy) on its own; dtolnay `targets:` renamed to the action`s `target:` input.

## Renovate
No config change needed. `default.json` in `schubydoo/renovate-config` enables the `github-actions` manager and `helpers:pinGitHubActionDigestsToSemver`, which maintains the `@<sha> # v1.9.0` pin format used here.

CI-only change, so `no-changelog` is applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)