### PR TITLE
feat(config): add a configurable log level

### DIFF
--- a/.changeset/configurable-log-level.md
+++ b/.changeset/configurable-log-level.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add a `--log-level` flag (`PODSPINE_LOG_LEVEL` env, `log_level` TOML key) to set log verbosity without `RUST_LOG`. Accepted values are `error`, `warn`, `info` (default), `debug`, and `trace`. When `RUST_LOG` is set, it still wins and keeps its per-module directives such as `podspine_scanner=debug`. If the level is unrecognized, Podspine uses `info` and logs a warning instead of aborting startup.

--- a/crates/config/src/book_overrides.rs
+++ b/crates/config/src/book_overrides.rs
@@ -57,6 +57,7 @@ pub struct BookOverrides {
     // Server-global: the transcode decision comes from the source codec, so a
     // per-book value would buy nothing — accept it and warn (Task 5.2).
     transcode: Option<toml::Value>,
+    log_level: Option<toml::Value>,
 }
 
 impl BookOverrides {
@@ -73,6 +74,7 @@ impl BookOverrides {
             ("cache_size", self.cache_size.is_some()),
             ("cache_ttl", self.cache_ttl.is_some()),
             ("transcode", self.transcode.is_some()),
+            ("log_level", self.log_level.is_some()),
         ]
         .into_iter()
         .filter_map(|(name, present)| present.then_some(name))
@@ -180,7 +182,7 @@ mod tests {
         std::fs::write(&audio, b"x").unwrap();
         std::fs::write(
             lib.join("Book.podspine.toml"),
-            b"storage_mode = \"saver\"\nforce_embedded_chapters = true\ntitle = \"Fixed Title\"\ndisabled = false\nbind = \"0.0.0.0:9\"\ncache_size = \"1GB\"\ntranscode = \"aac\"\n",
+            b"storage_mode = \"saver\"\nforce_embedded_chapters = true\ntitle = \"Fixed Title\"\ndisabled = false\nbind = \"0.0.0.0:9\"\ncache_size = \"1GB\"\ntranscode = \"aac\"\nlog_level = \"debug\"\n",
         )
         .unwrap();
 
@@ -194,7 +196,10 @@ mod tests {
         ignored.sort_unstable();
         // `transcode` is server-global too: a per-book value is warned about and
         // dropped, and — crucially — doesn't invalidate the whole sidecar.
-        assert_eq!(ignored, vec!["bind", "cache_size", "transcode"]);
+        assert_eq!(
+            ignored,
+            vec!["bind", "cache_size", "log_level", "transcode"]
+        );
         let _ = std::fs::remove_dir_all(&lib);
     }
 

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -21,6 +21,8 @@ const DEFAULT_BIND: &str = "0.0.0.0:8080";
 const DEFAULT_DATA_DIR: &str = "./data";
 /// Default `saver`-mode cache cap when unset: 2 GiB.
 const DEFAULT_CACHE_SIZE_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+/// Default log verbosity when neither `RUST_LOG` nor a configured level is set.
+const DEFAULT_LOG_LEVEL: &str = "info";
 
 /// How a **chaptered** book's per-chapter episodes are produced and stored.
 /// Whole-file episodes (MP3-folder tracks, chapterless single files) ignore
@@ -181,6 +183,12 @@ pub struct Cli {
     /// loopback or the LAN.
     #[arg(long, env = "PODSPINE_METRICS_BIND")]
     pub metrics_bind: Option<String>,
+    /// Log verbosity used when `RUST_LOG` is unset: `error`, `warn`, `info`,
+    /// `debug`, or `trace` (or any `RUST_LOG`-style directive such as
+    /// `podspine_scanner=debug`). `RUST_LOG` always wins when set. An
+    /// unrecognized value falls back to `info` with a warning.
+    #[arg(long, env = "PODSPINE_LOG_LEVEL")]
+    pub log_level: Option<String>,
     /// Optional TOML config file.
     #[arg(long, env = "PODSPINE_CONFIG")]
     pub config: Option<PathBuf>,
@@ -214,6 +222,8 @@ pub struct FileConfig {
     pub cache_ttl: Option<String>,
     /// Address for the separate Prometheus metrics listener (unset = disabled).
     pub metrics_bind: Option<String>,
+    /// Log verbosity used when `RUST_LOG` is unset (`info` by default).
+    pub log_level: Option<String>,
 }
 
 /// Fully resolved, validated configuration.
@@ -261,6 +271,10 @@ pub struct Config {
     /// no recorder installed). Always a second listener, never `bind`; see the
     /// `Cli::metrics_bind` note on why this surface is kept separate.
     pub metrics_bind: Option<SocketAddr>,
+    /// Log verbosity directive applied when `RUST_LOG` is unset (default
+    /// `info`). `RUST_LOG` always wins; an unrecognized value falls back to
+    /// `info` with a warning when the subscriber is built in `main`.
+    pub log_level: String,
 }
 
 /// Configuration failures: all fatal, all reported at startup.
@@ -433,6 +447,12 @@ impl Config {
             None => None,
         };
 
+        let log_level = cli
+            .log_level
+            .clone()
+            .or_else(|| file.log_level.clone())
+            .unwrap_or_else(|| DEFAULT_LOG_LEVEL.to_string());
+
         Ok(Self {
             library,
             data_dir,
@@ -446,6 +466,7 @@ impl Config {
             cache_size_bytes,
             cache_ttl,
             metrics_bind,
+            log_level,
         })
     }
 
@@ -695,6 +716,27 @@ mod tests {
     }
 
     #[test]
+    fn log_level_resolves_from_cli_over_file_and_defaults_info() {
+        // Unset everywhere gives the default.
+        let c = Config::resolve(&cli(Some("/books")), &FileConfig::default()).unwrap();
+        assert_eq!(c.log_level, "info");
+
+        // The TOML layer supplies it when the CLI does not.
+        let file = FileConfig {
+            log_level: Some("debug".to_string()),
+            ..Default::default()
+        };
+        let c = Config::resolve(&cli(Some("/books")), &file).unwrap();
+        assert_eq!(c.log_level, "debug");
+
+        // CLI wins over the TOML layer.
+        let mut cl = cli(Some("/books"));
+        cl.log_level = Some("warn".to_string());
+        let resolved = Config::resolve(&cl, &file).unwrap();
+        assert_eq!(resolved.log_level, "warn");
+    }
+
+    #[test]
     fn bad_bind_address_is_rejected() {
         let mut c = cli(Some("/books"));
         c.bind = Some("not-an-address".to_string());
@@ -878,6 +920,7 @@ mod tests {
             cache_size_bytes: Some(DEFAULT_CACHE_SIZE_BYTES),
             cache_ttl: None,
             metrics_bind: None,
+            log_level: DEFAULT_LOG_LEVEL.to_string(),
         };
         assert!(matches!(c.validate(), Err(ConfigError::LibraryNotFound(_))));
     }
@@ -899,6 +942,7 @@ mod tests {
             cache_size_bytes: Some(DEFAULT_CACHE_SIZE_BYTES),
             cache_ttl: None,
             metrics_bind: None,
+            log_level: DEFAULT_LOG_LEVEL.to_string(),
         };
         c.validate().unwrap();
         assert!(data.is_dir(), "data dir created");

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -30,6 +30,7 @@ that precedence. The library path is the only required input.
 | `--remux-non-faststart` | `PODSPINE_REMUX_NON_FASTSTART` | off | Remux a non-faststart whole-file mp4 to faststart on demand (cache-managed). See below. |
 | `--transcode` | `PODSPINE_TRANSCODE` | `off` | Re-encode sources podcatchers can't play (FLAC/Ogg/Opus/ALAC) to `aac` or `mp3`. MP3/AAC sources are never re-encoded. See below. |
 | `--metrics-bind` | `PODSPINE_METRICS_BIND` | off | Serve Prometheus metrics on this *separate* address (`127.0.0.1:9090`). See below. |
+| `--log-level` | `PODSPINE_LOG_LEVEL` | `info` | Log verbosity (`error`, `warn`, `info`, `debug`, `trace`). `RUST_LOG` overrides it and also takes per-module directives (`podspine_scanner=debug`). |
 | `--config` | `PODSPINE_CONFIG` | none | Path to a TOML config file. |
 
 > **`PODSPINE_BASE_URL` is the one that bites people.** Feed and enclosure (audio)

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -30,7 +30,7 @@ that precedence. The library path is the only required input.
 | `--remux-non-faststart` | `PODSPINE_REMUX_NON_FASTSTART` | off | Remux a non-faststart whole-file mp4 to faststart on demand (cache-managed). See below. |
 | `--transcode` | `PODSPINE_TRANSCODE` | `off` | Re-encode sources podcatchers can't play (FLAC/Ogg/Opus/ALAC) to `aac` or `mp3`. MP3/AAC sources are never re-encoded. See below. |
 | `--metrics-bind` | `PODSPINE_METRICS_BIND` | off | Serve Prometheus metrics on this *separate* address (`127.0.0.1:9090`). See below. |
-| `--log-level` | `PODSPINE_LOG_LEVEL` | `info` | Log verbosity (`error`, `warn`, `info`, `debug`, `trace`). `RUST_LOG` overrides it and also takes per-module directives (`podspine_scanner=debug`). |
+| `--log-level` | `PODSPINE_LOG_LEVEL` | `info` | Log verbosity: a level (`error`, `warn`, `info`, `debug`, `trace`) or a per-module directive (`podspine_scanner=debug`). `RUST_LOG` overrides it when set. An unrecognized value falls back to `info` with a warning. |
 | `--config` | `PODSPINE_CONFIG` | none | Path to a TOML config file. |
 
 > **`PODSPINE_BASE_URL` is the one that bites people.** Feed and enclosure (audio)

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,8 +27,13 @@ async fn main() -> Result<()> {
     let (filter, log_warnings) =
         resolve_log_filter(std::env::var("RUST_LOG").ok().as_deref(), &config.log_level);
     tracing_subscriber::fmt().with_env_filter(filter).init();
+    // Print these to stderr, not through tracing. Each one reports that a log
+    // filter was rejected, and the installed filter is the one just built from
+    // that same input. A restrictive filter (`error`, `off`, or a target-only
+    // directive) would suppress a `tracing::warn!` here and hide the diagnostic
+    // the fallback exists to give. stderr always shows it.
     for message in log_warnings {
-        tracing::warn!("{message}");
+        eprintln!("podspine: {message}");
     }
 
     // Install the recorder (and bind its listener) before the first

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,10 @@ use podspine_config::Config;
 use podspine_http::{AppState, serve};
 use podspine_index::Index;
 use podspine_scanner::{ScanOptions, spawn_library_watcher};
+use std::str::FromStr;
+
 use tracing_subscriber::EnvFilter;
+use tracing_subscriber::filter::LevelFilter;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -21,10 +24,10 @@ async fn main() -> Result<()> {
     // subscriber here rather than before the load.
     let config = Config::load().context("resolving configuration")?;
 
-    let (filter, level_warning) =
+    let (filter, log_warnings) =
         resolve_log_filter(std::env::var("RUST_LOG").ok().as_deref(), &config.log_level);
     tracing_subscriber::fmt().with_env_filter(filter).init();
-    if let Some(message) = level_warning {
+    for message in log_warnings {
         tracing::warn!("{message}");
     }
 
@@ -107,27 +110,52 @@ async fn main() -> Result<()> {
 }
 
 /// Choose the tracing filter: `RUST_LOG` when it is set and valid, otherwise
-/// the configured level, otherwise `info`.
+/// the configured level, otherwise `info`. Each fallback also returns a warning
+/// line, so a typo degrades logging instead of passing unnoticed or aborting.
 ///
 /// `RUST_LOG` stays the standard per-module escape hatch and wins whenever it
-/// parses. When it is unset (or itself invalid), the configured `log_level`
-/// applies. An unparsable configured level falls back to `info` and returns a
-/// warning message, so a typo degrades logging instead of aborting startup.
-fn resolve_log_filter(rust_log: Option<&str>, configured: &str) -> (EnvFilter, Option<String>) {
-    if let Some(directives) = rust_log
-        && let Ok(filter) = EnvFilter::try_new(directives)
-    {
-        return (filter, None);
-    }
-    match EnvFilter::try_new(configured) {
-        Ok(filter) => (filter, None),
-        Err(err) => (
-            EnvFilter::new("info"),
-            Some(format!(
-                "invalid log level {configured:?}: {err}; falling back to \"info\""
+/// parses. When it is unset the configured `log_level` applies. When it is set
+/// but unparsable, the configured level applies and a warning names the bad
+/// `RUST_LOG`. An unparsable configured level falls back to `info` with a
+/// warning of its own.
+fn resolve_log_filter(rust_log: Option<&str>, configured: &str) -> (EnvFilter, Vec<String>) {
+    let mut warnings = Vec::new();
+
+    // RUST_LOG wins whenever it parses.
+    if let Some(directives) = rust_log {
+        match EnvFilter::try_new(directives) {
+            Ok(filter) => return (filter, warnings),
+            Err(err) => warnings.push(format!(
+                "invalid RUST_LOG {directives:?}: {err}; using the configured log level"
             )),
-        ),
+        }
     }
+
+    match build_configured_filter(configured) {
+        Ok(filter) => (filter, warnings),
+        Err(err) => {
+            warnings.push(format!(
+                "invalid log level {configured:?}: {err}; falling back to \"info\""
+            ));
+            (EnvFilter::new("info"), warnings)
+        }
+    }
+}
+
+/// Build a filter from the configured `log_level`, rejecting a bare word that is
+/// not a level name.
+///
+/// A directive with no `=` must name a level (`info`, `debug`, `off`, ...).
+/// `EnvFilter` otherwise reads an unknown bare word as a *target* name at trace
+/// level, so `--log-level warning` would enable only a phantom `warning` target
+/// and silence every real log line with no error. Validate the bare form as a
+/// level first; leave the `target=level` form (and multi-directive strings) to
+/// `EnvFilter` itself, which already validates the level after each `=`.
+fn build_configured_filter(configured: &str) -> Result<EnvFilter, String> {
+    if !configured.contains('=') {
+        LevelFilter::from_str(configured).map_err(|err| err.to_string())?;
+    }
+    EnvFilter::try_new(configured).map_err(|err| err.to_string())
 }
 
 #[cfg(test)]
@@ -135,20 +163,40 @@ mod tests {
     use super::*;
 
     #[test]
-    fn configured_level_applies_when_rust_log_unset() {
-        let (_filter, warning) = resolve_log_filter(None, "debug");
-        assert!(warning.is_none());
+    fn configured_level_is_applied_when_rust_log_unset() {
+        let (filter, warnings) = resolve_log_filter(None, "debug");
+        assert!(warnings.is_empty());
+        assert_eq!(filter.to_string(), "debug");
     }
 
     #[test]
     fn rust_log_wins_over_the_configured_level() {
-        let (_filter, warning) = resolve_log_filter(Some("trace"), "info");
-        assert!(warning.is_none());
+        let (filter, warnings) = resolve_log_filter(Some("trace"), "info");
+        assert!(warnings.is_empty());
+        assert_eq!(filter.to_string(), "trace");
     }
 
     #[test]
-    fn invalid_configured_level_warns_and_falls_back() {
-        let (_filter, warning) = resolve_log_filter(None, "podspine=chatty");
-        assert!(warning.is_some());
+    fn a_bare_misspelled_level_warns_and_falls_back_to_info() {
+        // "warning" is not a level name. EnvFilter would read it as a target and
+        // go silent, so this must warn and fall back to info (finding 1).
+        let (filter, warnings) = resolve_log_filter(None, "warning");
+        assert_eq!(filter.to_string(), "info");
+        assert!(warnings.iter().any(|w| w.contains("warning")));
+    }
+
+    #[test]
+    fn an_invalid_per_module_level_warns_and_falls_back_to_info() {
+        let (filter, warnings) = resolve_log_filter(None, "podspine=chatty");
+        assert_eq!(filter.to_string(), "info");
+        assert!(!warnings.is_empty());
+    }
+
+    #[test]
+    fn an_invalid_rust_log_warns_and_uses_the_configured_level() {
+        // A bad RUST_LOG must warn, then the configured level applies (finding 2).
+        let (filter, warnings) = resolve_log_filter(Some("=bogus"), "debug");
+        assert_eq!(filter.to_string(), "debug");
+        assert!(warnings.iter().any(|w| w.contains("RUST_LOG")));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,16 +11,22 @@ use podspine_config::Config;
 use podspine_http::{AppState, serve};
 use podspine_index::Index;
 use podspine_scanner::{ScanOptions, spawn_library_watcher};
+use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
-        )
-        .init();
-
+    // Resolve configuration first, then build the log subscriber from it. The
+    // config crate emits no tracing during load, and a fatal config error
+    // prints through `anyhow` on exit, so nothing is lost by initializing the
+    // subscriber here rather than before the load.
     let config = Config::load().context("resolving configuration")?;
+
+    let (filter, level_warning) =
+        resolve_log_filter(std::env::var("RUST_LOG").ok().as_deref(), &config.log_level);
+    tracing_subscriber::fmt().with_env_filter(filter).init();
+    if let Some(message) = level_warning {
+        tracing::warn!("{message}");
+    }
 
     // Install the recorder (and bind its listener) before the first
     // reconcile, so that the startup ingest is measured, not silently
@@ -98,4 +104,51 @@ async fn main() -> Result<()> {
 
     serve(config.bind, state).await.context("serving")?;
     Ok(())
+}
+
+/// Choose the tracing filter: `RUST_LOG` when it is set and valid, otherwise
+/// the configured level, otherwise `info`.
+///
+/// `RUST_LOG` stays the standard per-module escape hatch and wins whenever it
+/// parses. When it is unset (or itself invalid), the configured `log_level`
+/// applies. An unparsable configured level falls back to `info` and returns a
+/// warning message, so a typo degrades logging instead of aborting startup.
+fn resolve_log_filter(rust_log: Option<&str>, configured: &str) -> (EnvFilter, Option<String>) {
+    if let Some(directives) = rust_log
+        && let Ok(filter) = EnvFilter::try_new(directives)
+    {
+        return (filter, None);
+    }
+    match EnvFilter::try_new(configured) {
+        Ok(filter) => (filter, None),
+        Err(err) => (
+            EnvFilter::new("info"),
+            Some(format!(
+                "invalid log level {configured:?}: {err}; falling back to \"info\""
+            )),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn configured_level_applies_when_rust_log_unset() {
+        let (_filter, warning) = resolve_log_filter(None, "debug");
+        assert!(warning.is_none());
+    }
+
+    #[test]
+    fn rust_log_wins_over_the_configured_level() {
+        let (_filter, warning) = resolve_log_filter(Some("trace"), "info");
+        assert!(warning.is_none());
+    }
+
+    #[test]
+    fn invalid_configured_level_warns_and_falls_back() {
+        let (_filter, warning) = resolve_log_filter(None, "podspine=chatty");
+        assert!(warning.is_some());
+    }
 }


### PR DESCRIPTION
## What

Add a first-class log-level option so an operator can set verbosity without `RUST_LOG`:

- CLI `--log-level`
- env `PODSPINE_LOG_LEVEL`
- TOML `log_level`

Precedence is CLI/env over TOML over the default `info`. `RUST_LOG` still wins when set and keeps its per-module directives (`podspine_scanner=debug`), so the standard escape hatch is unchanged. An unrecognized configured level falls back to `info` with a warning instead of aborting startup.

## How

- `crates/config/src/lib.rs`: new `log_level` field on `Cli`, `FileConfig`, and `Config`, resolved in `Config::resolve` with the usual precedence.
- `src/main.rs`: the tracing subscriber now builds after `Config::load()` via a pure, unit-tested `resolve_log_filter`. The config crate emits no tracing during load, and a fatal config error still prints through anyhow, so the reorder loses nothing.
- `docs/DEPLOYMENT.md`: new config-table row.

## Verify

- `cargo clippy --all-targets -- -D warnings` clean.
- `cargo test` green, including 4 new tests (precedence, `RUST_LOG` wins, invalid-level fallback).
- `cargo run -- --library ./sample-books --log-level debug` logs at debug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)