### PR TITLE
feat(ui): show the running version in a page footer

### DIFF
--- a/.changeset/show-version-in-ui.md
+++ b/.changeset/show-version-in-ui.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Show the running Podspine version in a footer on every web page, including the first-run scanning page. An operator can now tell which build is deployed without inspecting the container image tag. The value is the compiled workspace version, so a `:nightly` image reports the same version as the release it branches from.

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -80,7 +80,10 @@ const STYLE: &str = r#"
         --danger:#f87171; }
 }
 * { box-sizing:border-box; }
-body { margin:0; font:16px/1.5 system-ui,-apple-system,Segoe UI,Roboto,sans-serif;
+/* A column that fills the viewport so the footer sits at the bottom on a short
+   page instead of floating up under the content. `main` grows to take the slack. */
+body { margin:0; min-height:100dvh; display:flex; flex-direction:column;
+       font:16px/1.5 system-ui,-apple-system,Segoe UI,Roboto,sans-serif;
        color:var(--text); background:var(--bg); }
 a { color:var(--accent); }
 :focus-visible { outline:3px solid var(--accent); outline-offset:2px; border-radius:4px; }
@@ -99,7 +102,7 @@ footer.site { padding:1rem 1.25rem; border-top:1px solid var(--border);
         cursor:pointer; }
 .themepicker button:first-child { border-left:0; }
 .themepicker button[aria-pressed="true"] { background:var(--accent); color:var(--accent-text); }
-main { max-width:960px; margin:0 auto; padding:1.5rem 1.25rem; }
+main { flex:1 0 auto; width:100%; max-width:960px; margin:0 auto; padding:1.5rem 1.25rem; }
 .grid { list-style:none; margin:0; padding:0; display:grid; gap:1.25rem;
         grid-template-columns:repeat(auto-fill,minmax(150px,1fr)); }
 .card a { display:block; text-decoration:none; color:var(--text); }

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -88,6 +88,8 @@ header.site { padding:1rem 1.25rem; border-bottom:1px solid var(--border);
         display:flex; align-items:center; justify-content:space-between; gap:1rem; }
 header.site h1 { margin:0; font-size:1.25rem; }
 header.site a { text-decoration:none; color:var(--text); }
+footer.site { padding:1rem 1.25rem; border-top:1px solid var(--border);
+        color:var(--muted); font-size:.85rem; text-align:center; }
 /* Theme picker: a no-JS segmented control (a form of submit buttons). The active
    theme is marked with aria-pressed, which also styles it. */
 .themepicker { display:inline-flex; margin:0; border:1px solid var(--border);
@@ -243,6 +245,21 @@ fn theme_picker(current: Theme) -> Markup {
     }
 }
 
+/// The running Podspine version, resolved at compile time. `CARGO_PKG_VERSION`
+/// is the `[workspace.package]` version that every crate inherits, so this is
+/// the deployed build's version. Nightly images carry the same value as the
+/// release they branch from: distinguishing them needs a build-time git sha,
+/// which is out of scope here.
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// The site footer: the running Podspine version, shown on every page so an
+/// operator can tell what is deployed without inspecting the container tag.
+fn footer() -> Markup {
+    html! {
+        footer.site { "Podspine v" (VERSION) }
+    }
+}
+
 /// Wrap page `body` content in the full HTML document shell for the given `theme`.
 fn page(title: &str, theme: Theme, body: Markup) -> Markup {
     html! {
@@ -260,6 +277,7 @@ fn page(title: &str, theme: Theme, body: Markup) -> Markup {
                     (theme_picker(theme))
                 }
                 (body)
+                (footer())
             }
         }
     }
@@ -342,6 +360,7 @@ pub fn scanning_page(theme: Theme) -> Markup {
                         "This page refreshes on its own — your books will appear here when it's done."
                     }
                 }
+                (footer())
             }
         }
     }
@@ -647,6 +666,21 @@ mod tests {
         let html = index_page(&[], Theme::System).into_string();
         assert!(html.contains("No audiobooks found"));
         assert!(!html.contains("<ul"));
+    }
+
+    #[test]
+    fn footer_shows_the_running_version() {
+        let expected = format!("Podspine v{}", env!("CARGO_PKG_VERSION"));
+        let home = index_page(&[], Theme::System).into_string();
+        assert!(
+            home.contains(&expected),
+            "home page footer names the version"
+        );
+        let scanning = scanning_page(Theme::System).into_string();
+        assert!(
+            scanning.contains(&expected),
+            "scanning page footer names the version"
+        );
     }
 
     #[test]

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -37,6 +37,12 @@ that precedence. The library path is the only required input.
 > can't fetch anything. Set it to the LAN IP / hostname (and scheme + port, or the
 > public URL if behind a proxy) that clients actually reach.
 
+### Which version is running?
+
+The running version shows in the footer of every web page, for example `Podspine v1.7.2`.
+Read it to see which build a deployment serves. This matters most with the `:nightly`
+image, whose tag does not change between releases.
+
 ### Storage mode: `full` vs `saver`
 
 > **Disk use — only *chaptered* books materialize under `--data-dir`.** A


### PR DESCRIPTION
## What

Show the running Podspine version in a footer on every web page, so an operator can tell which build is deployed without inspecting the container image tag. The footer appears on the browse grid, book/subscribe pages (via the shared shell), and the first-run scanning page.

## How

- `crates/ui/src/lib.rs`: a `VERSION` const from `env!("CARGO_PKG_VERSION")` (the `[workspace.package]` version every crate inherits), a small `footer()` helper rendered in both `page()` and `scanning_page()`, and a `footer.site` CSS rule that reuses the theme variables.

## Notes

- A `:nightly` image reports the same version as the release it branches from. Distinguishing nightlies would need a build-time git sha, which is left out of scope.

## Verify

- `cargo clippy --all-targets -- -D warnings` clean.
- `cargo test -p podspine-ui` green, including a new test asserting both the home page and the scanning page render `Podspine v<version>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)