### PR TITLE
fix(config): accept metrics_bind in a per-book sidecar instead of failing it

### DIFF
--- a/.changeset/metrics-bind-sidecar.md
+++ b/.changeset/metrics-bind-sidecar.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Fix a per-book `.podspine.toml` that sets `metrics_bind` failing the whole sidecar. `metrics_bind` is a server-global key. It is now accepted and ignored with a warning, like the other server-global keys, rather than rejected as an unknown field. A book with `metrics_bind` in its sidecar keeps its other overrides instead of losing all of them.

--- a/crates/config/src/book_overrides.rs
+++ b/crates/config/src/book_overrides.rs
@@ -54,6 +54,7 @@ pub struct BookOverrides {
     config: Option<toml::Value>,
     cache_size: Option<toml::Value>,
     cache_ttl: Option<toml::Value>,
+    metrics_bind: Option<toml::Value>,
     // Server-global: the transcode decision comes from the source codec, so a
     // per-book value would buy nothing — accept it and warn (Task 5.2).
     transcode: Option<toml::Value>,
@@ -73,6 +74,7 @@ impl BookOverrides {
             ("config", self.config.is_some()),
             ("cache_size", self.cache_size.is_some()),
             ("cache_ttl", self.cache_ttl.is_some()),
+            ("metrics_bind", self.metrics_bind.is_some()),
             ("transcode", self.transcode.is_some()),
             ("log_level", self.log_level.is_some()),
         ]
@@ -182,7 +184,7 @@ mod tests {
         std::fs::write(&audio, b"x").unwrap();
         std::fs::write(
             lib.join("Book.podspine.toml"),
-            b"storage_mode = \"saver\"\nforce_embedded_chapters = true\ntitle = \"Fixed Title\"\ndisabled = false\nbind = \"0.0.0.0:9\"\ncache_size = \"1GB\"\ntranscode = \"aac\"\nlog_level = \"debug\"\n",
+            b"storage_mode = \"saver\"\nforce_embedded_chapters = true\ntitle = \"Fixed Title\"\ndisabled = false\nbind = \"0.0.0.0:9\"\ncache_size = \"1GB\"\ntranscode = \"aac\"\nlog_level = \"debug\"\nmetrics_bind = \"127.0.0.1:9\"\n",
         )
         .unwrap();
 
@@ -198,7 +200,13 @@ mod tests {
         // dropped, and — crucially — doesn't invalidate the whole sidecar.
         assert_eq!(
             ignored,
-            vec!["bind", "cache_size", "log_level", "transcode"]
+            vec![
+                "bind",
+                "cache_size",
+                "log_level",
+                "metrics_bind",
+                "transcode"
+            ]
         );
         let _ = std::fs::remove_dir_all(&lib);
     }


### PR DESCRIPTION
## What

A per-book `.podspine.toml` that sets `metrics_bind` failed to parse and took every other override in that file down with it, showing an "unknown field" error.

`metrics_bind` is a server-global key (it configures one process-wide listener), but it was missing from the `BookOverrides` server-global list. With `deny_unknown_fields`, the whole sidecar was rejected.

## Fix

Add `metrics_bind` to the accepted-and-ignored server-global list, so it is warned about and dropped like `bind`, `cache_size`, `log_level`, and the rest — the book keeps its other overrides. This mirrors the `log_level` fix in PR 225.

Surfaced by the reviewers on PR 225 as a pre-existing 🟣 finding, split out here per the review's guidance.

## Verify

- `cargo clippy --all-targets -- -D warnings` clean.
- `cargo test -p podspine-config` green; `parses_overrides_and_reports_ignored_global_keys` now includes `metrics_bind` in the sidecar and the expected ignored-key list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)