### PR TITLE
chore(ci): mint app tokens with client-id instead of the deprecated app-id

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -39,7 +39,7 @@ jobs:
         continue-on-error: true
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.PODSPINE_CI_APP_ID }}
+          client-id: ${{ secrets.PODSPINE_CI_APP_CLIENT_ID }}
           private-key: ${{ secrets.PODSPINE_CI_APP_PRIVATE_KEY }}
           permission-contents: read
           permission-pull-requests: write

--- a/.github/workflows/knope-prepare.yml
+++ b/.github/workflows/knope-prepare.yml
@@ -7,7 +7,7 @@ name: Prepare Release
 # gate; the merge triggers knope-release.yml.
 #
 # Gated on the `KNOPE_ENABLED` repo variable (now 'true'). This needs the
-# `podspine-ci` GitHub App INSTALLED on the repo (PODSPINE_CI_APP_ID /
+# `podspine-ci` GitHub App INSTALLED on the repo (PODSPINE_CI_APP_CLIENT_ID /
 # PODSPINE_CI_APP_PRIVATE_KEY secrets). The App is needed only for
 # release-driving pushes; see the changeset-first ordering below.
 
@@ -59,14 +59,14 @@ jobs:
         if: ${{ steps.changesets.outputs.has == 'true' }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.PODSPINE_CI_APP_ID }}
+          client-id: ${{ secrets.PODSPINE_CI_APP_CLIENT_ID }}
           private-key: ${{ secrets.PODSPINE_CI_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
       - name: Verify App token was minted
         if: ${{ steps.changesets.outputs.has == 'true' && steps.app-token.outputs.token == '' }}
         run: |
-          echo "::error::podspine-ci App token mint produced an empty token; check the PODSPINE_CI_APP_ID / PODSPINE_CI_APP_PRIVATE_KEY secrets and the App installation."
+          echo "::error::podspine-ci App token mint produced an empty token; check the PODSPINE_CI_APP_CLIENT_ID / PODSPINE_CI_APP_PRIVATE_KEY secrets and the App installation."
           exit 1
       # Re-checkout with the App token persisted, so that knope's `git push`
       # of the release branch, and the PR it opens, run as the App identity.

--- a/.github/workflows/knope-release.yml
+++ b/.github/workflows/knope-release.yml
@@ -43,13 +43,13 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.PODSPINE_CI_APP_ID }}
+          client-id: ${{ secrets.PODSPINE_CI_APP_CLIENT_ID }}
           private-key: ${{ secrets.PODSPINE_CI_APP_PRIVATE_KEY }}
           permission-contents: write
       - name: Verify App token was minted
         if: ${{ steps.app-token.outputs.token == '' }}
         run: |
-          echo "::error::podspine-ci App token mint produced an empty token; check the PODSPINE_CI_APP_ID / PODSPINE_CI_APP_PRIVATE_KEY secrets and the App installation."
+          echo "::error::podspine-ci App token mint produced an empty token; check the PODSPINE_CI_APP_CLIENT_ID / PODSPINE_CI_APP_PRIVATE_KEY secrets and the App installation."
           exit 1
       # Tag the squash commit that landed on main (merge_commit_sha), not the
       # orphaned PR head. Full history and tags, for knope's version

--- a/.github/workflows/packaging-bump.yml
+++ b/.github/workflows/packaging-bump.yml
@@ -55,7 +55,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.PODSPINE_CI_APP_ID }}
+          client-id: ${{ secrets.PODSPINE_CI_APP_CLIENT_ID }}
           private-key: ${{ secrets.PODSPINE_CI_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
@@ -64,7 +64,7 @@ jobs:
         if: ${{ steps.app-token.outputs.token == '' }}
         run: |
           echo "::error::podspine-ci App token mint produced an empty token; refusing to \
-          proceed. Check PODSPINE_CI_APP_ID / PODSPINE_CI_APP_PRIVATE_KEY and the App install."
+          proceed. Check PODSPINE_CI_APP_CLIENT_ID / PODSPINE_CI_APP_PRIVATE_KEY and the App install."
           exit 1
 
       - name: Check out repo

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -40,7 +40,7 @@ jobs:
         continue-on-error: true
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.PODSPINE_CI_APP_ID }}
+          client-id: ${{ secrets.PODSPINE_CI_APP_CLIENT_ID }}
           private-key: ${{ secrets.PODSPINE_CI_APP_PRIVATE_KEY }}
           permission-pull-requests: read
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -52,7 +52,7 @@ jobs:
         continue-on-error: true
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.PODSPINE_CI_APP_ID }}
+          client-id: ${{ secrets.PODSPINE_CI_APP_CLIENT_ID }}
           private-key: ${{ secrets.PODSPINE_CI_APP_PRIVATE_KEY }}
           permission-administration: read
           permission-contents: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -50,7 +50,7 @@ jobs:
         continue-on-error: true
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.PODSPINE_CI_APP_ID }}
+          client-id: ${{ secrets.PODSPINE_CI_APP_CLIENT_ID }}
           private-key: ${{ secrets.PODSPINE_CI_APP_PRIVATE_KEY }}
           permission-contents: read
       - name: Gitleaks
@@ -149,7 +149,7 @@ jobs:
         continue-on-error: true
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.PODSPINE_CI_APP_ID }}
+          client-id: ${{ secrets.PODSPINE_CI_APP_CLIENT_ID }}
           private-key: ${{ secrets.PODSPINE_CI_APP_PRIVATE_KEY }}
           permission-contents: read
       - name: Set up uv

--- a/.github/workflows/tap-sync-trigger.yml
+++ b/.github/workflows/tap-sync-trigger.yml
@@ -38,7 +38,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.PODSPINE_CI_APP_ID }}
+          client-id: ${{ secrets.PODSPINE_CI_APP_CLIENT_ID }}
           private-key: ${{ secrets.PODSPINE_CI_APP_PRIVATE_KEY }}
           owner: schubydoo
           repositories: |


### PR DESCRIPTION
## What

`actions/create-github-app-token` deprecated the `app-id` input in favor of `client-id`, so every App-token mint logged a deprecation warning. This switches all 10 mints across 8 workflows to `client-id`.

Files: `changeset-check`, `knope-prepare`, `knope-release`, `packaging-bump`, `security` (×2), `scorecard`, `tap-sync-trigger`, `pr-title`. (`claude-review` already used `client-id`.)

## How

- `app-id: ${{ secrets.PODSPINE_CI_APP_ID }}` → `client-id: ${{ secrets.PODSPINE_CI_APP_CLIENT_ID }}` on every mint.
- Updated the comments and `::error::` messages that named the secret.

## Notes

- `PODSPINE_CI_APP_CLIENT_ID` already exists (added for the `claude-review` workflow) and pairs with the unchanged `PODSPINE_CI_APP_PRIVATE_KEY`.
- All mints pin `create-github-app-token@…v3.2.0`, which accepts `client-id` (the `claude-review` workflow already runs this combo on this repo).
- `PODSPINE_CI_APP_ID` is now unused; it can be removed from repo secrets at your convenience.

## Verify

- `actionlint` reports no new issues on the changed files (only pre-existing shellcheck info in the untouched `release.yml`).
- Real confirmation is a live mint: the next `pr-title` / `changeset-check` run on this PR exercises the new input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)