### PR TITLE
fix(ci): stop the release/nightly build failing on the linker_messages lint

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -62,9 +62,14 @@ jobs:
           target: ${{ matrix.target }}
           # No Actions cache: caching in an artifact-publishing workflow is a
           # cache-poisoning vector (matching the prior setup and release.yml).
-          # rustflags: "" avoids forcing `-D warnings` on the build.
+          # This is an artifact build, not the warnings gate (ci.yml is). Both
+          # knobs are needed to not fail it on a warning: rustflags: "" clears the
+          # action's default RUSTFLAGS=-D warnings, and build-warnings: warn clears
+          # its default CARGO_BUILD_WARNINGS=deny — which otherwise turns the new
+          # `linker_messages` lint (zig LLD's -O1 deprecation notice) into an error.
           cache: false
           rustflags: ""
+          build-warnings: warn
       # zig is the cross linker for the musl targets (incl. rusqlite's bundled
       # SQLite C). Installed from a pinned, checksum-verified tarball by the local
       # ./.github/actions/setup-zig composite action, not mlugg/setup-zig (which

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,9 +77,15 @@ jobs:
           target: ${{ matrix.target }}
           # No Actions cache in this signed-release build (cache-poisoning vector
           # in an artifact-publishing workflow, matching the prior setup and the
-          # setup-zig step below). rustflags: "" avoids forcing `-D warnings`.
+          # setup-zig step below). This is an artifact build, not the warnings gate
+          # (ci.yml is). Both knobs are needed to not fail it on a warning:
+          # rustflags: "" clears the action's default RUSTFLAGS=-D warnings, and
+          # build-warnings: warn clears its default CARGO_BUILD_WARNINGS=deny — which
+          # otherwise turns the new `linker_messages` lint (zig LLD's -O1 deprecation
+          # notice) into an error.
           cache: false
           rustflags: ""
+          build-warnings: warn
       # zig is the cross linker for the musl targets only (incl. rusqlite's bundled
       # SQLite C). Installed from a pinned, checksum-verified tarball by the local
       # ./.github/actions/setup-zig composite action, not mlugg/setup-zig (which


### PR DESCRIPTION
## Symptom

The nightly build has failed since **2026-09-09** (run for `be9632f`), and the signed-release build would fail the same way on the next tag. Both fail in the `Build (musl via zig)` step with:

```
warning: linker stderr: ignoring deprecated linker optimization setting '1'
note: `#[warn(linker_messages)]` on by default
error: `podspine` (bin "podspine") generated 1 warning
error: warnings are denied by `build.warnings` configuration
```

This predates and is unrelated to the Zig self-manage change (PR 232) — the same failure appears on pre-232 commits.

## Cause

A recent stable Rust enabled the `linker_messages` lint, which surfaces zig LLD's `-O1` deprecation notice as a warning. `actions-rust-lang/setup-rust-toolchain` has a `build-warnings` input that defaults to `deny` and is exported as `CARGO_BUILD_WARNINGS=deny`. The jobs set `rustflags: ""`, but that clears only `RUSTFLAGS`, not `CARGO_BUILD_WARNINGS` — so the linker warning is still denied.

## Fix

Set `build-warnings: warn` on the `setup-rust-toolchain` step in `nightly.yml` and `release.yml`, matching the existing `rustflags: ""` intent (these are artifact builds, not the warnings gate). `ci.yml` keeps the default `deny`, so code-quality warnings still fail there.

## Verify

- `actionlint` clean on the changed files (only pre-existing shellcheck notices in untouched `release.yml` run-blocks remain).
- After merge: re-run **nightly** via `workflow_dispatch` to confirm green — this also exercises the new self-managed Zig install end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)