### PR TITLE
ci: let Renovate track the pinned knope version

### DIFF
--- a/.github/workflows/knope-prepare.yml
+++ b/.github/workflows/knope-prepare.yml
@@ -95,6 +95,7 @@ jobs:
         if: ${{ steps.changesets.outputs.has == 'true' }}
         uses: knope-dev/action@19617851f9f13ab2f27a05989c55efb18aca3675 # v2.1.2
         with:
+          # renovate: datasource=github-releases depName=knope-dev/knope extractVersion=^knope/v(?<version>.+)$
           version: 0.23.0
       - name: Open or refresh the release PR
         if: ${{ steps.changesets.outputs.has == 'true' }}

--- a/.github/workflows/knope-release.yml
+++ b/.github/workflows/knope-release.yml
@@ -62,6 +62,7 @@ jobs:
       - name: Install knope
         uses: knope-dev/action@19617851f9f13ab2f27a05989c55efb18aca3675 # v2.1.2
         with:
+          # renovate: datasource=github-releases depName=knope-dev/knope extractVersion=^knope/v(?<version>.+)$
           version: 0.23.0
       # knope creates the GitHub Release + tag as the App token, which
       # triggers release.yml (the signed build). This is a no-op when the


### PR DESCRIPTION
knope-dev/action's `version:` input (0.23.0) is invisible to Renovate's github-actions manager — it pins only the action's `uses:` SHA, not the `with: version:` input — so the knope version drifts silently.

This adds a `# renovate:` annotation directly above each `version:` line in `knope-release.yml` and `knope-prepare.yml`. knope's release tags are monorepo-prefixed (`knope/vX.Y.Z`), so the annotation carries `extractVersion=^knope/v(?<version>.+)$`.

Comment-only change; a no-op until the matching custom.regex manager in the shared renovate-config preset lands. The resulting bump PR is review-only (no auto-merge), consistent with claustrum, scratchsmith, and the rest of the fleet.

Part of a fleet-wide Renovate coverage audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)